### PR TITLE
implement contract as/at proposal in contract2 class

### DIFF
--- a/contracts/user/nft_sys/include/nft_sys.hpp
+++ b/contracts/user/nft_sys/include/nft_sys.hpp
@@ -6,7 +6,7 @@
 
 namespace UserContract
 {
-   class NftSys : public psibase::contract
+   class NftSys : public psibase::contract2<NftSys>
    {
      public:
       using tables = psibase::contract_tables<NftTable_t, AdTable_t>;

--- a/contracts/user/nft_sys/src/nft_sys.cpp
+++ b/contracts/user/nft_sys/src/nft_sys.cpp
@@ -64,9 +64,7 @@ void NftSys::credit(psibase::AccountNumber receiver, NID nftId, std::string memo
    check(record->owner == get_sender(), Errors::missingRequiredAuth);
    check(receiver != record->owner, Errors::creditorIsDebitor);
    check(record->creditedTo == account_sys::null_account, Errors::alreadyCredited);
-
-   auto exists = actor<account_sys>(contract, account_sys::contract).exists(receiver);
-   check(exists, Errors::receiverDNE);
+   check(at<account_sys>().exists(receiver), Errors::receiverDNE);
 
    bool transferred = _isAutoDebit(receiver);
 

--- a/libraries/psibase/common/include/psibase/contract.hpp
+++ b/libraries/psibase/common/include/psibase/contract.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <psibase/AccountNumber.hpp>
+#include <psibase/actor.hpp>
 
 namespace psibase
 {
@@ -25,4 +26,31 @@ namespace psibase
       AccountNumber _sender;
       AccountNumber _receiver;
    };
+
+   template <typename Child>
+   class contract2 : public contract
+   {
+     protected:
+      struct UserContext
+      {
+         AccountNumber account;
+
+         template <typename Contract>
+         auto at() const
+         {
+            return actor<Contract>(account, Contract::contract);
+         }
+
+         operator AccountNumber() { return account; }
+      };
+
+      auto as(AccountNumber sender) { return UserContext{sender}; }
+
+      template <typename Contract>
+      auto at()
+      {
+         return as(Child::contract).template at<Contract>();
+      }
+   };
+
 };  // namespace psibase


### PR DESCRIPTION
@tbfleming @bytemaster 

Looking for feedback on the idea of using CRTP to give the contract base class the ability to provide smart contracts with as/at syntax. See #29 for more details.

I implemented it in contract2 for now, just to avoid needing to update all child contracts. But if you guys like it, I will update this PR and put the logic in the standard contract base class.