### PR TITLE
Deploy with updated CommonSys UI. Auto-format Rust files.

### DIFF
--- a/rust/psibase/src/boot.rs
+++ b/rust/psibase/src/boot.rs
@@ -1,13 +1,13 @@
 use crate::{
-    new_account_action, reg_server, set_auth_contract_action, set_key_action, set_producers_action, store_sys,
-    to_claim, without_tapos, Args, Error,
+    new_account_action, reg_server, set_auth_contract_action, set_key_action, set_producers_action,
+    store_sys, to_claim, without_tapos, Args, Error,
 };
 use anyhow::Context;
 use fracpack::Packable;
 use include_dir::{include_dir, Dir};
 use libpsibase::{
-    account, method, AccountNumber, Action, Claim, ExactAccountNumber, Fracpack, PublicKey, SharedGenesisActionData,
-    SharedGenesisContract, SignedTransaction,
+    account, method, AccountNumber, Action, Claim, ExactAccountNumber, Fracpack, PublicKey,
+    SharedGenesisActionData, SharedGenesisContract, SignedTransaction,
 };
 use serde_json::Value;
 
@@ -46,7 +46,8 @@ pub(super) async fn boot(
     key: &Option<PublicKey>,
     producer: &Option<ExactAccountNumber>,
 ) -> Result<(), anyhow::Error> {
-    let new_signed_transactions: Vec<SignedTransaction> = vec![boot_trx(), common_startup_trx(key, producer)];
+    let new_signed_transactions: Vec<SignedTransaction> =
+        vec![boot_trx(), common_startup_trx(key, producer)];
     push_boot(args, client, new_signed_transactions.packed_bytes()).await?;
     println!("Ok");
     Ok(())
@@ -200,7 +201,10 @@ fn fill_dir(dir: &Dir, actions: &mut Vec<Action>) {
     }
 }
 
-fn common_startup_trx(key: &Option<PublicKey>, producer: &Option<ExactAccountNumber>) -> SignedTransaction {
+fn common_startup_trx(
+    key: &Option<PublicKey>,
+    producer: &Option<ExactAccountNumber>,
+) -> SignedTransaction {
     let mut init_actions = vec![
         Action {
             sender: account!("account-sys"),
@@ -236,8 +240,8 @@ fn common_startup_trx(key: &Option<PublicKey>, producer: &Option<ExactAccountNum
 
     let html = "text/html";
     let js = "text/javascript";
-    // let css = "text/css";
-    // let svg = "image/svg+xml";
+    let css = "text/css";
+    let svg = "image/svg+xml";
 
     let mut reg_actions = vec![
         reg_server(account!("account-sys"), account!("r-account-sys")),
@@ -249,14 +253,73 @@ fn common_startup_trx(key: &Option<PublicKey>, producer: &Option<ExactAccountNum
     ];
 
     let mut common_sys_files = vec![
-        store!("common-sys", "/index.html", html, "CommonSys/ui/vanilla/index.html"),
+        store!(
+            "common-sys",
+            "/index.html",
+            html,
+            "CommonSys/ui/dist/index.html"
+        ),
+        store!("common-sys", "/index.js", js, "CommonSys/ui/dist/index.js"),
+        store!(
+            "common-sys",
+            "/style.css",
+            css,
+            "CommonSys/ui/dist/style.css"
+        ),
+        store!(
+            "common-sys",
+            "/ninebox.svg",
+            svg,
+            "CommonSys/ui/dist/ninebox.svg"
+        ),
+        store!(
+            "common-sys",
+            "/psibase.svg",
+            svg,
+            "CommonSys/ui/dist/psibase.svg"
+        ),
+        store!(
+            "common-sys",
+            "/app-account-desktop.svg",
+            svg,
+            "CommonSys/ui/dist/app-account-desktop.svg"
+        ),
+        store!(
+            "common-sys",
+            "/app-account-mobile.svg",
+            svg,
+            "CommonSys/ui/dist/app-account-mobile.svg"
+        ),
+        store!(
+            "common-sys",
+            "/app-explore-desktop.svg",
+            svg,
+            "CommonSys/ui/dist/app-explore-desktop.svg"
+        ),
+        store!(
+            "common-sys",
+            "/app-explore-mobile.svg",
+            svg,
+            "CommonSys/ui/dist/app-explore-mobile.svg"
+        ),
+        store!(
+            "common-sys",
+            "/app-wallet-desktop.svg",
+            svg,
+            "CommonSys/ui/dist/app-wallet-desktop.svg"
+        ),
+        store!(
+            "common-sys",
+            "/app-wallet-mobile.svg",
+            svg,
+            "CommonSys/ui/dist/app-wallet-mobile.svg"
+        ),
         store!(
             "common-sys",
             "/ui/common.index.html",
             html,
             "CommonSys/ui/vanilla/common.index.html"
         ),
-        store!("common-sys", "/ui/index.js", js, "CommonSys/ui/vanilla/index.js"),
         store_common!("keyConversions.mjs", js),
         store_common!("rpc.mjs", js),
         store_common!("SimpleUI.mjs", js),
@@ -305,8 +368,18 @@ fn common_startup_trx(key: &Option<PublicKey>, producer: &Option<ExactAccountNum
     )];
 
     let mut token_sys_files = vec![
-        store!("r-tok-sys", "/index.html", html, "CommonSys/ui/vanilla/common.index.html"),
-        store!("r-tok-sys", "/ui/index.js", js, "TokenSys/ui/vanilla/index.js"),
+        store!(
+            "r-tok-sys",
+            "/index.html",
+            html,
+            "CommonSys/ui/vanilla/common.index.html"
+        ),
+        store!(
+            "r-tok-sys",
+            "/ui/index.js",
+            js,
+            "TokenSys/ui/vanilla/index.js"
+        ),
         // store!("r-tok-sys", "/index.html", html, "TokenSys/ui/dist/index.html"),
         // store!("r-tok-sys", "/index.js", js, "TokenSys/ui/dist/index.js"),
         // store!("r-tok-sys", "/style.css", css, "TokenSys/ui/dist/style.css"),
@@ -367,15 +440,15 @@ fn common_startup_trx(key: &Option<PublicKey>, producer: &Option<ExactAccountNum
     actions.push(set_producers_action(
         match producer {
             Some(p) => AccountNumber::from(*p),
-            None => account!("psibase")
+            None => account!("psibase"),
         },
         match key {
             Some(k) => to_claim(k),
             None => Claim {
                 contract: AccountNumber::new(0),
-                raw_data: vec![]
-            }
-        }
+                raw_data: vec![],
+            },
+        },
     ));
 
     if let Some(k) = key {

--- a/rust/psibase/src/main.rs
+++ b/rust/psibase/src/main.rs
@@ -7,8 +7,8 @@ use futures::future::join_all;
 use indicatif::{ProgressBar, ProgressStyle};
 use libpsibase::{
     account, get_tapos_for_head, method, push_transaction, sign_transaction, AccountNumber, Action,
-    Claim, ExactAccountNumber, Fracpack, PrivateKey, PublicKey, SignedTransaction, Tapos, TaposRefBlock,
-    TimePointSec, Transaction,
+    Claim, ExactAccountNumber, Fracpack, PrivateKey, PublicKey, SignedTransaction, Tapos,
+    TaposRefBlock, TimePointSec, Transaction,
 };
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -53,7 +53,7 @@ enum Commands {
 
         /// Sets the name of the block producer
         #[clap(short = 'p', long, value_name = "PRODUCER")]
-        producer: Option<ExactAccountNumber>
+        producer: Option<ExactAccountNumber>,
     },
 
     /// Create or modify an account
@@ -252,8 +252,8 @@ pub struct ProducerConfigRow {
 fn to_claim(key: &PublicKey) -> Claim {
     return Claim {
         contract: account!("verifyec-sys"),
-        raw_data: key.packed_bytes()
-    }
+        raw_data: key.packed_bytes(),
+    };
 }
 
 fn set_producers_action(name: AccountNumber, key: Claim) -> Action {


### PR DESCRIPTION
- Updates `boot.rs` to point to updated Common-Sys UI instead of vanilla JS UI.
- Ran `cargo fmt` and `cargo clippy` from `rust` dir.