### PR TITLE
Reassures queries/ops exceptions are not swallowed

### DIFF
--- a/services/user/TokenSys/ui/src/App.tsx
+++ b/services/user/TokenSys/ui/src/App.tsx
@@ -42,7 +42,6 @@ function App() {
             try {
                 const userName = await getLoggedInUser();
                 if (!userName) {
-                    // TODO: This never fires because query() swallows failures and never returns.
                     throw new Error("Unable to fetch logged-in user.");
                 }
                 setUserName(userName);
@@ -90,7 +89,7 @@ function App() {
     const transfer = async ({ amount, to, token: symbol }: TransferInputs) => {
         if (!symbol) throw new Error("No token selected.");
         // TODO: Errors getting swallowed by CommonSys::executeTransaction(). Fix.
-        executeCredit({
+        await executeCredit({
             symbol,
             receiver: to,
             amount,

--- a/services/user/TokenSys/ui/src/operations.ts
+++ b/services/user/TokenSys/ui/src/operations.ts
@@ -53,5 +53,5 @@ export const operations = [CREDIT];
 
 export const executeCredit = async (payload: CreditOperationPayload) => {
     const appletId = await tokenContract.getAppletId();
-    operation(appletId, "credit", payload);
+    return operation(appletId, "credit", payload);
 };


### PR DESCRIPTION
Fixes the following item of #140:
- getLoggedInUser() swallows errors when it fails.