### PR TITLE
update labels and key dropping logic

### DIFF
--- a/services/system/AccountSys/ui/src/App.tsx
+++ b/services/system/AccountSys/ui/src/App.tsx
@@ -40,12 +40,14 @@ export interface AccountWithKey extends AccountWithAuth {
 function App() {
     const [accountsWithKeys, dropAccount, addAccounts] = useAccountsWithKeys();
     const [allAccounts, refreshAccounts] = useAccounts();
-    const [currentUser, setCurrentUser] = useCurrentUser();
+    const [currentUser, setCurrentUser, isAuthenticated] = useCurrentUser();
 
     const onLogout = (account: string) => {
         const isLoggingOutOfCurrentUser = currentUser === account;
         if (isLoggingOutOfCurrentUser) {
-            setCurrentUser(accountsWithKeys[0].accountNum);
+            const nextAccount = accountsWithKeys.find(acc => acc.accountNum !== account && acc.authService !== 'auth-any-sys');
+            const newUser = typeof nextAccount === 'undefined' ? '' : nextAccount.accountNum
+            setCurrentUser(newUser);
         }
         dropAccount(account)
     }
@@ -89,7 +91,7 @@ function App() {
                 />
             </div>
             <div className="bg-slate-50 mt-4 flex justify-between">
-                <CreateAccountForm errorMessage={accountError} isLoading={isAccountLoading} onCreateAccount={onCreateAccount} ref={createAccountFormRef} />
+                {isAuthenticated && <CreateAccountForm errorMessage={accountError} isLoading={isAccountLoading} onCreateAccount={onCreateAccount} ref={createAccountFormRef} />}
                 <ImportAccountForm errorMessage={importError} isLoading={isImportLoading} onImport={searchKeyPair} />
             </div>
             {/* <SetAuth /> */}

--- a/services/system/AccountSys/ui/src/components/AccountList.tsx
+++ b/services/system/AccountSys/ui/src/components/AccountList.tsx
@@ -14,8 +14,8 @@ export const AccountList = ({
 
     return (
         <div>
-            <h2 className="pt-6">Available accounts</h2>
-            <div>{isAccountsAvailable ? `Choose an account below to make it active.` : 'No accounts available.'}</div>
+            <h2 className="pt-6">My accounts</h2>
+            <div>{isAccountsAvailable ? `Select an account below to make it active.` : 'Not logged in.'}</div>
 
             {isAccountsAvailable && <table className="min-w-full table-fixed">
                 <thead className="text-slate-900">

--- a/services/system/AccountSys/ui/src/components/CreateAccountForm.tsx
+++ b/services/system/AccountSys/ui/src/components/CreateAccountForm.tsx
@@ -35,9 +35,6 @@ const getPublicKey = (key: string): { error: string, publicKey: string } => {
 
 export const CreateAccountForm = forwardRef(({ onCreateAccount, isLoading, errorMessage }: Props, ref) => {
 
-
-
-
     const [name, setName] = useState("");
     const [pubKey, setPubKey] = useState("");
     const [privKey, setPrivKey] = useState("");
@@ -71,8 +68,7 @@ export const CreateAccountForm = forwardRef(({ onCreateAccount, isLoading, error
 
     return (
         <div>
-            <h2>Add an account</h2>
-            <div>Input your own private key, or generate a new one.</div>
+            <h2>Create an account</h2>
             <div>
                 <div>Name</div>
                 <input

--- a/services/system/AccountSys/ui/src/hooks/useAccountsWithKeys.ts
+++ b/services/system/AccountSys/ui/src/hooks/useAccountsWithKeys.ts
@@ -55,8 +55,10 @@ export const useAccountsWithKeys = (): [AccountWithAuth[], (key: string) => void
         if (foundAccount) {
             const key = foundAccount.publicKey;
             setAccounts(accounts => accounts.filter(account => account.publicKey !== key));
-            console.log({ key, keyPairs })
-            setKeyPairs(keyPairs.filter(keyPair => keyPair.publicKey !== key))
+            setKeyPairs(keyPairs.filter(keyPair => {
+                if ('knownAccounts' in keyPair && keyPair.knownAccounts!.includes(accountNum)) return false
+                return keyPair.publicKey !== key
+            }))
         } else {
             console.warn(`Failed to find account ${accountNum} to drop`)
         }

--- a/services/system/AccountSys/ui/src/hooks/useCurrentUser.ts
+++ b/services/system/AccountSys/ui/src/hooks/useCurrentUser.ts
@@ -1,6 +1,7 @@
 import { useLocalStorage } from "common/useLocalStorage.mjs";
 
-export const useCurrentUser = (): [string, (newUser: string) => void] => {
+export const useCurrentUser = (): [string, (newUser: string) => void, boolean] => {
     const [currentUser, setCurrentUser] = useLocalStorage("currentUser", "");
-    return [currentUser, setCurrentUser]
+    const isAuthenticated = currentUser !== '';
+    return [currentUser, setCurrentUser, isAuthenticated]
 }


### PR DESCRIPTION
- [x] Renamed `Available Accounts` -> `My accounts` 
- [x] Renamed `No accounts available` -> `Not logged in`
- [x] Renamed `Add an account` -> `Create an account`

Ensuring more reliable error messages is not quite delivered in this one, always in an awkward position till the promises are all connected and we receive proper errors from the `operation` calls. 

The **Create an account** section only now renders when `currentUser !== ''` 

One example of wonkiness was that the private key seemed to remain in the local storage after deletion. This behaviour could have been due to multiple instances of the chain accumulating more and more records causing some stale records to remain. I've made the drop account logic more generous in dropping keys in attempt to tackle this. 
