### PR TITLE
rpc.mjs const should be let.

### DIFF
--- a/services/user/CommonSys/common/rpc.mjs
+++ b/services/user/CommonSys/common/rpc.mjs
@@ -641,7 +641,7 @@ export async function initializeApplet(initializer = () => {}) {
 }
 
 function set({ targetArray, newElements }, caller) {
-    const valid = newElements.every((e) => {
+    let valid = newElements.every((e) => {
         if (!verifyFields(e, ["id", "exec"])) {
             return false;
         }


### PR DESCRIPTION
`valid` may get reassigned several lines later. Should be a `let`, not a `const`.