### PR TITLE
Init secondary keys

### DIFF
--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -180,6 +180,15 @@ pub fn kv_put<'a, K: ToKey, V: Packable<'a>>(db: DbId, key: &K, value: &V) {
     kv_put_bytes(db, &key.to_key(), &value.packed())
 }
 
+/// Set a key-value pair if the key is unique
+///
+/// If key already exists, throws an error
+pub fn kv_insert_unique<'a, K: ToKey, V: Packable<'a>>(db: DbId, key: &K, value: &V) {
+    let key_bytes = key.to_key();
+    check_none(kv_get_bytes(db, &key_bytes), "key already exists");
+    kv_put_bytes(db, &key_bytes, &value.packed())
+}
+
 /// Add a sequentially-numbered record
 ///
 /// Returns the id.

--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -183,10 +183,10 @@ pub fn kv_put<'a, K: ToKey, V: Packable<'a>>(db: DbId, key: &K, value: &V) {
 /// Set a key-value pair if the key is unique
 ///
 /// If key already exists, throws an error
-pub fn kv_insert_unique<'a, K: ToKey, V: Packable<'a>>(db: DbId, key: &K, value: &V) {
+pub fn kv_insert_unique_bytes<K: ToKey>(db: DbId, key: &K, bytes: &[u8]) {
     let key_bytes = key.to_key();
     check_none(kv_get_bytes(db, &key_bytes), "key already exists");
-    kv_put_bytes(db, &key_bytes, &value.packed())
+    kv_put_bytes(db, &key_bytes, bytes)
 }
 
 /// Add a sequentially-numbered record

--- a/rust/psibase/src/to_key.rs
+++ b/rust/psibase/src/to_key.rs
@@ -65,6 +65,26 @@ impl ToKey for RawKey {
     }
 }
 
+/// A serialized key (not owning)
+///
+/// The serialized data has the same sort order as the non-serialized form
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct KeyView<'a> {
+    pub data: &'a [u8],
+}
+
+impl<'a> KeyView<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        KeyView { data }
+    }
+}
+
+impl<'a> ToKey for KeyView<'a> {
+    fn append_key(&self, key: &mut Vec<u8>) {
+        key.extend_from_slice(self.data);
+    }
+}
+
 impl<T: ToKey + ?Sized> ToKey for &T {
     fn append_key(&self, key: &mut Vec<u8>) {
         T::append_key(self, key)

--- a/rust/test_service_elections/src/lib.rs
+++ b/rust/test_service_elections/src/lib.rs
@@ -242,15 +242,11 @@ mod service {
             "election is already in progress",
         );
 
-        let table = CandidatesTable::open();
-        let idx = table.get_index_pk();
-
         let candidate = get_sender();
-        let key = (election_id, candidate);
-        let candidate_record = idx.get(key);
-        check_some(candidate_record, "candidate is not registered");
 
-        table.remove(&key);
+        let table = CandidatesTable::open();
+        let candidate_record = get_candidate(election_id, candidate);
+        table.remove(&candidate_record);
     }
 
     /// Vote for a candidate in an active election
@@ -450,7 +446,7 @@ mod tests {
             .error
             .unwrap();
         assert!(
-            error.contains("candidate is not registered"),
+            error.contains("candidate for election does not exist"),
             "error = {}",
             error
         );
@@ -467,22 +463,21 @@ mod tests {
             error
         );
 
-        // TODO:fix secondary key removal
-        // // Check candidate was added back
-        // chain.start_block();
-        // Wrapper::push_from(&chain, account!("charles")).register(1);
+        // Check candidate was added back
+        chain.start_block();
+        Wrapper::push_from(&chain, account!("charles")).register(1);
 
-        // let candidates = Wrapper::push(&chain).list_candidates(1).get()?;
-        // assert_eq!(candidates.len(), 3);
+        let candidates = Wrapper::push(&chain).list_candidates(1).get()?;
+        assert_eq!(candidates.len(), 3);
 
-        // let expected_candidates = vec![
-        //     candidate_alice.clone(),
-        //     candidate_bob.clone(),
-        //     candidate_charles.clone(),
-        // ];
-        // assert!(candidates
-        //     .iter()
-        //     .all(|item| expected_candidates.contains(item)));
+        let expected_candidates = vec![
+            candidate_alice.clone(),
+            candidate_bob.clone(),
+            candidate_charles.clone(),
+        ];
+        assert!(candidates
+            .iter()
+            .all(|item| expected_candidates.contains(item)));
 
         Ok(())
     }

--- a/rust/test_service_elections/src/lib.rs
+++ b/rust/test_service_elections/src/lib.rs
@@ -5,8 +5,8 @@
 mod service {
     use fracpack::Fracpack;
     use psibase::{
-        check, check_none, check_some, AccountNumber, Table, TableHandler, TableRecord,
-        TimePointSec,
+        check, check_none, check_some, AccountNumber, RawKey, Table, TableHandler, TableRecord,
+        TimePointSec, ToKey,
     };
 
     // #[table]
@@ -46,6 +46,13 @@ mod service {
 
         fn get_primary_key(&self) -> Self::PrimaryKey {
             (self.election_id, self.candidate)
+        }
+
+        fn get_secondary_keys(&self) -> Vec<RawKey> {
+            let by_election_votes_key =
+                RawKey::new((self.election_id, self.votes, self.candidate).to_key());
+
+            vec![by_election_votes_key]
         }
     }
 
@@ -453,21 +460,22 @@ mod tests {
             error
         );
 
-        // Check candidate was added back
-        chain.start_block();
-        Wrapper::push(&chain).register(AccountNumber::from("charles"), 1);
+        // TODO:fix secondary key removal
+        // // Check candidate was added back
+        // chain.start_block();
+        // Wrapper::push(&chain).register(AccountNumber::from("charles"), 1);
 
-        let candidates = Wrapper::push(&chain).list_candidates(1).get()?;
-        assert_eq!(candidates.len(), 3);
+        // let candidates = Wrapper::push(&chain).list_candidates(1).get()?;
+        // assert_eq!(candidates.len(), 3);
 
-        let expected_candidates = vec![
-            candidate_alice.clone(),
-            candidate_bob.clone(),
-            candidate_charles.clone(),
-        ];
-        assert!(candidates
-            .iter()
-            .all(|item| expected_candidates.contains(item)));
+        // let expected_candidates = vec![
+        //     candidate_alice.clone(),
+        //     candidate_bob.clone(),
+        //     candidate_charles.clone(),
+        // ];
+        // assert!(candidates
+        //     .iter()
+        //     .all(|item| expected_candidates.contains(item)));
 
         Ok(())
     }


### PR DESCRIPTION
Initialize secondary keys.

Currently working functionalities:
- inserting new keys
- updating keys when record is updated and change is relevant
- removing keys when record is removed

Next steps:
- Explore better type handling for secondary keys, heterogeneous lists, macros etc.
- Implement the macros itself for the tables