### PR TITLE
Table improvements

### DIFF
--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -180,15 +180,6 @@ pub fn kv_put<'a, K: ToKey, V: Packable<'a>>(db: DbId, key: &K, value: &V) {
     kv_put_bytes(db, &key.to_key(), &value.packed())
 }
 
-/// Set a key-value pair if the key is unique
-///
-/// If key already exists, throws an error
-pub fn kv_insert_unique_bytes<K: ToKey>(db: DbId, key: &K, bytes: &[u8]) {
-    let key_bytes = key.to_key();
-    check_none(kv_get_bytes(db, &key_bytes), "key already exists");
-    kv_put_bytes(db, &key_bytes, bytes)
-}
-
 /// Add a sequentially-numbered record
 ///
 /// Returns the id.

--- a/rust/test_service_elections/src/lib.rs
+++ b/rust/test_service_elections/src/lib.rs
@@ -205,7 +205,7 @@ mod service {
 
         println!(">>> inserting new election record");
 
-        table.put(&new_election);
+        table.put(&new_election).unwrap();
 
         new_key
     }
@@ -236,7 +236,7 @@ mod service {
             votes: 0,
         };
 
-        table.put(&new_candidate_record);
+        table.put(&new_candidate_record).unwrap();
     }
 
     /// Unregister a candidate from the election
@@ -288,11 +288,11 @@ mod service {
             voted_at: current_time,
         };
 
-        table.put(&new_voting_record);
+        table.put(&new_voting_record).unwrap();
 
         // Increment candidate vote
         candidate_record.votes += 1;
-        CandidatesTable::open().put(&candidate_record);
+        CandidatesTable::open().put(&candidate_record).unwrap();
     }
 }
 


### PR DESCRIPTION
Addresses few past review suggestions from PR https://github.com/gofractally/psibase/pull/209

- Split TbIndex from Iter
- Add idiomatic Range
- Improves secondary keys checks when replacing or writing new ones passing the abort control to the user
