### PR TITLE
Replicates psispace in rust

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "psibase",
     "test_contract",
     "test_service_elections",
+    "test_service_psispace",
     "test_fracpack",
 ]
 

--- a/rust/psibase/src/serve_http.rs
+++ b/rust/psibase/src/serve_http.rs
@@ -1,5 +1,5 @@
 use crate::{
-    create_schema, generate_action_templates, reflect::Reflect, HttpReply, HttpRequest,
+    check, create_schema, generate_action_templates, reflect::Reflect, HttpReply, HttpRequest,
     ProcessActionStruct, WithActionStruct,
 };
 use async_graphql::{
@@ -120,11 +120,13 @@ pub fn serve_pack_action<Wrapper: WithActionStruct>(request: &HttpRequest) -> Op
         >(
             self,
         ) -> Self::Output {
+            let arg_struct_result = serde_json::from_slice::<ArgStruct>(self.0);
+            if let Err(err) = &arg_struct_result {
+                check(false, &format!("err parsing action args json {}", err));
+            }
             HttpReply {
                 contentType: "application/octet-stream".into(),
-                body: serde_json::from_slice::<ArgStruct>(self.0)
-                    .unwrap()
-                    .packed(),
+                body: arg_struct_result.unwrap().packed(),
                 headers: vec![],
             }
         }

--- a/rust/psibase_macros/src/service_macro.rs
+++ b/rust/psibase_macros/src/service_macro.rs
@@ -717,11 +717,10 @@ fn process_service_tables(
 
     let table_impl = quote! {
         impl #psibase_mod::Table<#table_record_struct_name> for #table_name {
-            const TABLE_SERVICE: #psibase_mod::AccountNumber = SERVICE;
             const TABLE_INDEX: u16 = #table_index;
             const SECONDARY_KEYS: u8 = #sks_len;
 
-            fn new(db_id: #psibase_mod::DbId, prefix: Vec<u8>) -> Self {
+            fn with_prefix(db_id: #psibase_mod::DbId, prefix: Vec<u8>) -> Self {
                 #table_name{db_id, prefix}
             }
 

--- a/rust/psibase_macros/src/service_macro.rs
+++ b/rust/psibase_macros/src/service_macro.rs
@@ -658,6 +658,7 @@ fn process_service_tables(
     secondary_keys.sort_by_key(|sk| sk.idx);
     let mut sks_fns = quote! {};
     let mut sks = quote! {};
+    let sks_len = secondary_keys.len() as u8;
     for (idx, secondary_key) in secondary_keys.iter().enumerate() {
         let sk_ident = &secondary_key.ident;
         let sk_idx = secondary_key.idx;
@@ -718,6 +719,7 @@ fn process_service_tables(
         impl #psibase_mod::Table<#table_record_struct_name> for #table_name {
             const TABLE_SERVICE: #psibase_mod::AccountNumber = SERVICE;
             const TABLE_INDEX: u16 = #table_index;
+            const SECONDARY_KEYS: u8 = #sks_len;
 
             fn new(db_id: #psibase_mod::DbId, prefix: Vec<u8>) -> Self {
                 #table_name{db_id, prefix}

--- a/rust/test_service_elections/src/lib.rs
+++ b/rust/test_service_elections/src/lib.rs
@@ -77,7 +77,7 @@ mod service {
 
     #[action]
     fn get_election(election_id: u32) -> ElectionRecord {
-        let table = ElectionsTable::open();
+        let table = ElectionsTable::new();
         let idx = table.get_index_pk();
         let election_opt = idx.get(&election_id);
         check_some(election_opt, "election does not exist")
@@ -85,7 +85,7 @@ mod service {
 
     #[action]
     fn get_candidate(election_id: u32, candidate: AccountNumber) -> CandidateRecord {
-        let table = CandidatesTable::open();
+        let table = CandidatesTable::new();
         let idx = table.get_index_pk();
         let candidate_opt = idx.get(&(election_id, candidate));
         check_some(candidate_opt, "candidate for election does not exist")
@@ -94,7 +94,7 @@ mod service {
     // Full elections paginator
     #[action]
     fn list_elections(cursor: Option<u32>, reverse: bool, page_size: u32) -> Vec<ElectionRecord> {
-        let table = ElectionsTable::open();
+        let table = ElectionsTable::new();
         let idx = table.get_index_pk();
         let page_size = page_size as usize;
 
@@ -115,7 +115,7 @@ mod service {
 
     #[action]
     fn list_active_elections() -> Vec<ElectionRecord> {
-        let table = ElectionsTable::open();
+        let table = ElectionsTable::new();
         let idx = table.get_index_by_dates_key();
 
         let current_time = get_current_time();
@@ -135,7 +135,7 @@ mod service {
         // check election exists
         get_election(election_id);
 
-        let table = CandidatesTable::open();
+        let table = CandidatesTable::new();
 
         let idx = table.get_index_pk();
 
@@ -157,7 +157,7 @@ mod service {
             "election is not finished",
         );
 
-        let table = CandidatesTable::open();
+        let table = CandidatesTable::new();
         let idx = table.get_index_by_election_votes_key();
 
         let winner = idx
@@ -189,7 +189,7 @@ mod service {
             "Election can't start in the past",
         );
 
-        let table = ElectionsTable::open();
+        let table = ElectionsTable::new();
         let idx = table.get_index_pk();
 
         let last_election = idx.into_iter().last();
@@ -226,7 +226,7 @@ mod service {
             "election is already in progress",
         );
 
-        let table = CandidatesTable::open();
+        let table = CandidatesTable::new();
         let idx = table.get_index_pk();
 
         let candidate = get_sender();
@@ -256,7 +256,7 @@ mod service {
 
         let candidate = get_sender();
 
-        let table = CandidatesTable::open();
+        let table = CandidatesTable::new();
         let candidate_record = get_candidate(election_id, candidate);
         table.remove(&candidate_record);
     }
@@ -275,7 +275,7 @@ mod service {
 
         let mut candidate_record = get_candidate(election_id, candidate);
 
-        let table = VotesTable::open();
+        let table = VotesTable::new();
         let idx = table.get_index_pk();
 
         let voter = get_sender();
@@ -293,7 +293,7 @@ mod service {
 
         // Increment candidate vote
         candidate_record.votes += 1;
-        CandidatesTable::open().put(&candidate_record).unwrap();
+        CandidatesTable::new().put(&candidate_record).unwrap();
     }
 
     // The UI allows us to test things manually

--- a/rust/test_service_elections/src/lib.rs
+++ b/rust/test_service_elections/src/lib.rs
@@ -72,7 +72,7 @@ mod service {
     }
 
     fn get_current_time() -> TimePointSec {
-        transaction_sys::Wrapper::call().headBlockTime()
+        transaction_sys::Wrapper::call().currentBlock().time
     }
 
     #[action]

--- a/rust/test_service_psispace/Cargo.toml
+++ b/rust/test_service_psispace/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "psispace-sys"
+version.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+fracpack = { version = "0.1.0", path = "../fracpack" }
+psibase = { version = "0.1.0", path = "../psibase" }
+serde = { version = "1.0.145", features = ["derive"] }

--- a/rust/test_service_psispace/README.md
+++ b/rust/test_service_psispace/README.md
@@ -1,0 +1,7 @@
+# Replica of psispace-sys
+
+This is a replica of the original CPP psispace-sys contract as an example, to demonstrate tables and http functionalities.
+
+```sh
+cargo psibase build
+```

--- a/rust/test_service_psispace/src/lib.rs
+++ b/rust/test_service_psispace/src/lib.rs
@@ -50,7 +50,7 @@ mod service {
             content_type: contentType,
             content,
         };
-        ContentTable::open().put(&new_content).unwrap();
+        ContentTable::new().put(&new_content).unwrap();
     }
 
     /// Remove an existing file
@@ -58,7 +58,7 @@ mod service {
     #[allow(non_snake_case)]
     fn removeSys(path: String) {
         let key = (get_sender(), path);
-        ContentTable::open().erase(&key);
+        ContentTable::new().erase(&key);
     }
 
     #[action]
@@ -94,7 +94,7 @@ mod service {
             target.truncate(query_params_begin_pos);
         }
 
-        let table = ContentTable::open().get_index_pk();
+        let table = ContentTable::new().get_index_pk();
         let content_key = (account, target.clone());
         let content = table.get(&content_key);
 
@@ -159,7 +159,7 @@ mod tests {
             content.clone(),
         );
 
-        let stored_content = ContentTable::open()
+        let stored_content = ContentTable::with_service(account!("psispace-sys"), 0)
             .get_index_pk()
             .get(&(bob, path.clone()));
 

--- a/rust/test_service_psispace/src/lib.rs
+++ b/rust/test_service_psispace/src/lib.rs
@@ -6,8 +6,8 @@
 #[psibase::service(name = "psispace-sys")]
 mod service {
     use psibase::{
-        check, get_sender, get_service, serve_action_templates, serve_pack_action, serve_schema,
-        AccountNumber, Fracpack, HttpReply, HttpRequest, Reflect, Table, TableIndex,
+        check, get_sender, get_service, serve_action_templates, serve_pack_action, AccountNumber,
+        Fracpack, HttpReply, HttpRequest, Reflect, Table, TableIndex,
     };
     use serde::{Deserialize, Serialize};
 
@@ -83,7 +83,7 @@ mod service {
     fn handle_contract_request(request: HttpRequest) -> Option<HttpReply> {
         None.or_else(|| serve_action_templates::<Wrapper>(&request))
             .or_else(|| serve_pack_action::<Wrapper>(&request))
-            .or_else(|| serve_schema::<Wrapper>(&request)) // TODO: Replace with GraphQL
+            // TODO: add GraphQL
             .or_else(|| handle_content_request(get_service(), request))
     }
 

--- a/rust/test_service_psispace/src/lib.rs
+++ b/rust/test_service_psispace/src/lib.rs
@@ -1,0 +1,333 @@
+/// psispace-sys replica
+///
+/// This is a replica of the original CPP psispace-sys contract as an example,
+/// to demonstrate tables and http functionalities.
+/// Please don't publish this as the real psispace-sys service.
+#[psibase::service(name = "psispace-sys")]
+mod service {
+    use psibase::{
+        check, get_sender, get_service, serve_action_templates, serve_pack_action, serve_schema,
+        AccountNumber, Fracpack, HttpReply, HttpRequest, Reflect, Table, TableIndex,
+    };
+    use serde::{Deserialize, Serialize};
+
+    type ContentKey = (AccountNumber, String);
+
+    #[table(name = "ContentTable", index = 0)]
+    #[derive(Debug, Fracpack, PartialEq, Reflect, Serialize, Deserialize)]
+    pub struct ContentRow {
+        pub account: AccountNumber,
+        pub path: String,
+        pub content_type: String,
+        pub content: Vec<u8>,
+    }
+
+    impl ContentRow {
+        #[primary_key]
+        fn get_primary_key(&self) -> ContentKey {
+            (self.account, self.path.to_owned())
+        }
+    }
+
+    impl From<ContentRow> for HttpReply {
+        fn from(content_row: ContentRow) -> Self {
+            HttpReply {
+                contentType: content_row.content_type,
+                body: content_row.content,
+                headers: Vec::new(),
+            }
+        }
+    }
+
+    /// Store a new file
+    #[action]
+    #[allow(non_snake_case)]
+    fn storeSys(path: String, contentType: String, content: Vec<u8>) {
+        check(path.starts_with('/'), "Path doesn't begin with /");
+        let new_content = ContentRow {
+            account: get_sender(),
+            path,
+            content_type: contentType,
+            content,
+        };
+        ContentTable::open().put(&new_content).unwrap();
+    }
+
+    /// Remove an existing file
+    #[action]
+    #[allow(non_snake_case)]
+    fn removeSys(path: String) {
+        let key = (get_sender(), path);
+        ContentTable::open().erase(&key);
+    }
+
+    #[action]
+    #[allow(non_snake_case)]
+    fn serveSys(request: HttpRequest) -> Option<HttpReply> {
+        check(
+            request.host.len() > request.rootHost.len(),
+            "unexpected rootHost len greater than host",
+        );
+
+        let account_name_len = request.host.len() - request.rootHost.len();
+        let account_name = &request.host[..account_name_len - 1];
+        let account = AccountNumber::from(account_name);
+
+        if account == SERVICE {
+            handle_contract_request(request)
+        } else {
+            handle_content_request(account, request)
+        }
+    }
+
+    fn handle_contract_request(request: HttpRequest) -> Option<HttpReply> {
+        None.or_else(|| serve_action_templates::<Wrapper>(&request))
+            .or_else(|| serve_pack_action::<Wrapper>(&request))
+            .or_else(|| serve_schema::<Wrapper>(&request)) // TODO: Replace with GraphQL
+            .or_else(|| handle_content_request(get_service(), request))
+    }
+
+    fn handle_content_request(account: AccountNumber, request: HttpRequest) -> Option<HttpReply> {
+        let mut target = request.target;
+
+        if let Some(query_params_begin_pos) = target.find('?') {
+            target.truncate(query_params_begin_pos);
+        }
+
+        let table = ContentTable::open().get_index_pk();
+        let content_key = (account, target.clone());
+        let content = table.get(&content_key);
+
+        content
+            .or_else(|| get_index_content(&account, &table, &target))
+            .or_else(|| get_default_profile(&table, &target))
+            .map(HttpReply::from)
+    }
+
+    fn get_index_content(
+        account: &AccountNumber,
+        table: &TableIndex<ContentKey, ContentRow>,
+        target: &str,
+    ) -> Option<ContentRow> {
+        if target.ends_with('/') {
+            let key = (account.to_owned(), format!("{}index.html", target));
+            table.get(&key)
+        } else {
+            let key = (account.to_owned(), format!("{}/index.html", target));
+            table.get(&key)
+        }
+    }
+
+    fn get_default_profile<'a>(
+        table: &'a TableIndex<ContentKey, ContentRow>,
+        target: &'a str,
+    ) -> Option<ContentRow> {
+        if target == "/" {
+            let key = (
+                get_service(),
+                "/default-profile/default-profile.html".to_owned(),
+            );
+            table.get(&key)
+        } else if target.starts_with("/default-profile/") {
+            let key = (get_service(), target.to_owned());
+            table.get(&key)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        service::{ContentRow, ContentTable},
+        Wrapper,
+    };
+    use psibase::{account, ChainResult, HttpReply, HttpRequest, Table};
+
+    #[psibase::test_case(services("psispace-sys"))]
+    fn users_can_store_content(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+
+        let path = "/abc.html".to_owned();
+        let content_type = "text/html".to_owned();
+        let content = "<h1>Hello world!</h1>".to_owned().into_bytes();
+        Wrapper::push_from(&chain, bob).storeSys(
+            path.clone(),
+            content_type.clone(),
+            content.clone(),
+        );
+
+        let stored_content = ContentTable::open()
+            .get_index_pk()
+            .get(&(bob, path.clone()));
+
+        assert!(stored_content.is_some());
+
+        assert_eq!(
+            stored_content.unwrap(),
+            ContentRow {
+                account: bob,
+                path,
+                content_type,
+                content
+            }
+        );
+
+        Ok(())
+    }
+
+    #[psibase::test_case(services("psispace-sys"))]
+    fn paths_must_begin_with_slash(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+
+        let path = "abc.html".to_owned();
+        let content_type = "text/html".to_owned();
+        let content = "<h1>Hello world!</h1>".to_owned().into_bytes();
+        let error = Wrapper::push_from(&chain, bob)
+            .storeSys(path.clone(), content_type.clone(), content.clone())
+            .trace
+            .error
+            .unwrap();
+        assert!(
+            error.contains("Path doesn't begin with /"),
+            "error = {}",
+            error
+        );
+
+        Ok(())
+    }
+
+    #[psibase::test_case(services("psispace-sys"))]
+    fn index_files_are_retrieved_for_folders(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+
+        let path = "/articles/index.html".to_owned();
+        let content_type = "text/html".to_owned();
+        let content = "<h1>Hello world!</h1>".to_owned().into_bytes();
+        Wrapper::push_from(&chain, bob).storeSys(
+            path.clone(),
+            content_type.clone(),
+            content.clone(),
+        );
+
+        // with slash
+        let response = push_servesys_request(&chain, "bob", "/articles/").get()?;
+        assert!(response.is_some());
+        assert_reply(&response.unwrap(), &content_type, &content);
+
+        // without slash
+        let response = push_servesys_request(&chain, "bob", "/articles").get()?;
+        assert!(response.is_some());
+        assert_reply(&response.unwrap(), &content_type, &content);
+
+        // without slash and query parameters
+        let response = push_servesys_request(&chain, "bob", "/articles?top=10").get()?;
+        assert!(response.is_some());
+        assert_reply(&response.unwrap(), &content_type, &content);
+
+        Ok(())
+    }
+
+    #[psibase::test_case(services("psispace-sys"))]
+    fn contract_files_are_retrieved(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let index_path = "/index.html".to_owned();
+        let index_content_type = "text/html".to_owned();
+        let index_content = "<h1>PsiSpace File Upload Manager</h1>"
+            .to_owned()
+            .into_bytes();
+        Wrapper::push(&chain).storeSys(
+            index_path.clone(),
+            index_content_type.clone(),
+            index_content.clone(),
+        );
+
+        let style_path = "/assets/styles.css".to_owned();
+        let style_content_type = "text/css".to_owned();
+        let style_content = ".container { margin: 20px; }".to_owned().into_bytes();
+        Wrapper::push(&chain).storeSys(
+            style_path.clone(),
+            style_content_type.clone(),
+            style_content.clone(),
+        );
+
+        // index path retrieves index.html file
+        let response = push_servesys_request(&chain, "psispace-sys", "/").get()?;
+        assert!(response.is_some());
+        assert_reply(&response.unwrap(), &index_content_type, &index_content);
+
+        // retrieves styles.css from default profile
+        let response = push_servesys_request(&chain, "psispace-sys", "/assets/styles.css").get()?;
+        assert!(response.is_some());
+        assert_reply(&response.unwrap(), &style_content_type, &style_content);
+
+        Ok(())
+    }
+
+    #[psibase::test_case(services("psispace-sys"))]
+    fn default_profile_files_are_retrieved(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let index_path = "/default-profile/default-profile.html".to_owned();
+        let index_content_type = "text/html".to_owned();
+        let index_content = "<h1>Default profile!</h1>".to_owned().into_bytes();
+        Wrapper::push(&chain).storeSys(
+            index_path.clone(),
+            index_content_type.clone(),
+            index_content.clone(),
+        );
+
+        let style_path = "/default-profile/styles.css".to_owned();
+        let style_content_type = "text/css".to_owned();
+        let style_content = ".container { margin: 20px; }".to_owned().into_bytes();
+        Wrapper::push(&chain).storeSys(
+            style_path.clone(),
+            style_content_type.clone(),
+            style_content.clone(),
+        );
+
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+
+        // index path retrieves default-profile.html file
+        let response = push_servesys_request(&chain, "bob", "/").get()?;
+        assert!(response.is_some());
+        assert_reply(&response.unwrap(), &index_content_type, &index_content);
+
+        // retrieves styles.css from default profile
+        let response = push_servesys_request(&chain, "bob", "/default-profile/styles.css").get()?;
+        assert!(response.is_some());
+        assert_reply(&response.unwrap(), &style_content_type, &style_content);
+
+        Ok(())
+    }
+
+    fn assert_reply(reply: &HttpReply, content_type: &str, content: &Vec<u8>) {
+        assert_eq!(
+            reply,
+            &HttpReply {
+                contentType: content_type.to_owned(),
+                body: content.clone(),
+                headers: Vec::new(),
+            },
+            "unexpected http reply {:?}",
+            reply
+        );
+    }
+
+    fn push_servesys_request(
+        chain: &psibase::Chain,
+        account: &str,
+        target: &str,
+    ) -> ChainResult<Option<HttpReply>> {
+        Wrapper::push(&chain).serveSys(HttpRequest {
+            host: format!("{}.testnet.psibase.io", account),
+            rootHost: "testnet.psibase.io".to_string(),
+            target: target.to_string(),
+            method: "GET".to_string(),
+            contentType: "".to_string(),
+            body: Vec::new(),
+        })
+    }
+}


### PR DESCRIPTION
- Replicates psispace-sys in rust
- Implements table.erase
- Adds number of secondary keys in the `Table` trait (to optimize erase operation)
- General improvements on the election service (now it supports current time and serves the simple ui)
- Improves table interface adding the methods: `new(), with_service() and with_prefix()`