### PR TITLE
Add Contract Queries Macros

### DIFF
--- a/rust/psibase/src/serve_http.rs
+++ b/rust/psibase/src/serve_http.rs
@@ -178,13 +178,21 @@ pub fn serve_graphql<Query: async_graphql::ObjectType + 'static>(
                 headers: vec![],
             })
         } else {
-            let request = receive_body(
+            println!("receiving graphql post...");
+            let request_result = receive_body(
                 Some(&request.contentType),
                 request.body.as_ref(),
                 Default::default(),
             )
-            .await
-            .unwrap();
+            .await;
+
+            if let Err(err) = &request_result {
+                check(false, &format!("err parsing graphql query {}", err));
+            }
+
+            let request = request_result.unwrap();
+            println!("received gql post!!! {:?}", request);
+
             let res = schema.execute(request).await;
             Some(HttpReply {
                 contentType: "application/json".into(),

--- a/rust/psibase/src/serve_http.rs
+++ b/rust/psibase/src/serve_http.rs
@@ -178,7 +178,6 @@ pub fn serve_graphql<Query: async_graphql::ObjectType + 'static>(
                 headers: vec![],
             })
         } else {
-            println!("receiving graphql post...");
             let request_result = receive_body(
                 Some(&request.contentType),
                 request.body.as_ref(),
@@ -190,10 +189,7 @@ pub fn serve_graphql<Query: async_graphql::ObjectType + 'static>(
                 check(false, &format!("err parsing graphql query {}", err));
             }
 
-            let request = request_result.unwrap();
-            println!("received gql post!!! {:?}", request);
-
-            let res = schema.execute(request).await;
+            let res = schema.execute(request_result.unwrap()).await;
             Some(HttpReply {
                 contentType: "application/json".into(),
                 body: serde_json::to_vec(&res).unwrap().into(),

--- a/rust/psibase_macros/src/graphql_macro.rs
+++ b/rust/psibase_macros/src/graphql_macro.rs
@@ -1,0 +1,164 @@
+use darling::ToTokens;
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use proc_macro_error::abort;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
+    AttrStyle, ImplItem, Item, Result, Token,
+};
+
+struct Args {
+    query_name: Ident,
+    table: Ident,
+    key_fn: Ident,
+    sub_index_params: Vec<(Ident, Ident)>,
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut vars = Punctuated::<Ident, Token![,]>::parse_terminated(input)?.into_iter();
+
+        let query_name = vars.next().expect("Query name not present");
+        let table = vars.next().expect("Table name not present");
+        let key_fn = vars.next().expect("Table key function not present");
+
+        let mut sub_index_params = Vec::new();
+        while let Some(param) = vars.next() {
+            let param_type = vars
+                .next()
+                .unwrap_or_else(|| panic!("Type not detected for param {}", param));
+            sub_index_params.push((param, param_type));
+        }
+
+        Ok(Args {
+            query_name,
+            table,
+            key_fn,
+            sub_index_params,
+        })
+    }
+}
+
+pub fn queries_macro_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as Item);
+
+    let mut queries = quote! {};
+
+    match item {
+        Item::Impl(mut query_impl) => {
+            for impl_item in query_impl.items.iter_mut() {
+                if let ImplItem::Macro(macro_item) = impl_item {
+                    if macro_item.mac.path.to_token_stream().to_string() != "table_query" {
+                        abort!(impl_item, "queries only accepts table_query macros");
+                    }
+
+                    let query_doc = macro_item
+                        .attrs
+                        .iter()
+                        .filter(|attr| {
+                            matches!(attr.style, AttrStyle::Outer) && attr.path.is_ident("doc")
+                        })
+                        .fold(quote! {}, |a, b| quote! {#a #b});
+
+                    let macro_args = macro_item.mac.tokens.clone();
+
+                    let query_fn: proc_macro2::TokenStream =
+                        table_query_macro_impl(macro_args.into()).into();
+
+                    queries = quote! {
+                        #queries
+
+                        #query_doc
+                        #query_fn
+                    };
+                }
+            }
+        }
+        _ => {
+            abort!(item, "queries attribute may only be used on an Impl")
+        }
+    }
+
+    let impl_query = quote! {
+        struct Query;
+
+        #[async_graphql::Object]
+        impl Query {
+            #queries
+        }
+    };
+
+    impl_query.into()
+}
+
+pub fn table_query_macro_impl(item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(item as Args);
+
+    let query_name = args.query_name;
+    let table = args.table;
+    let record = Ident::new(format!("{}Record", table).as_str(), table.span());
+    let key_fn = args.key_fn;
+    let sub_index_params = args.sub_index_params;
+
+    let query = if sub_index_params.is_empty() {
+        quote! {
+            async fn #query_name(
+                &self,
+                first: Option<i32>,
+                last: Option<i32>,
+                before: Option<String>,
+                after: Option<String>,
+            ) -> async_graphql::Result<async_graphql::connection::Connection<psibase::RawKey, #record>> {
+                let table_idx = #table::new().#key_fn ();
+                psibase::TableQuery::new(table_idx)
+                    .first(first)
+                    .last(last)
+                    .before(before)
+                    .after(after)
+                    .query()
+                    .await
+            }
+        }
+    } else {
+        let mut params = quote! {};
+        let mut subindex_args = quote! {};
+
+        for (param_name, param_type) in sub_index_params {
+            params = quote! {
+                #params
+                #param_name: #param_type,
+            };
+
+            subindex_args = quote! {
+                #subindex_args
+                &#param_name,
+            };
+        }
+
+        quote! {
+            async fn #query_name(
+                &self,
+                #params
+                first: Option<i32>,
+                last: Option<i32>,
+                before: Option<String>,
+                after: Option<String>,
+            ) -> async_graphql::Result<async_graphql::connection::Connection<psibase::RawKey, #record>> {
+                let table_idx = #table::new().#key_fn ();
+                let sidx = psibase::TableQuery::subindex::<String>(table_idx, #subindex_args);
+                sidx
+                    .first(first)
+                    .last(last)
+                    .before(before)
+                    .after(after)
+                    .query()
+                    .await
+            }
+        }
+    };
+
+    TokenStream::from(query)
+}

--- a/rust/psibase_macros/src/graphql_macro.rs
+++ b/rust/psibase_macros/src/graphql_macro.rs
@@ -34,15 +34,17 @@ impl Parse for Args {
             loop {
                 if input.is_empty() {
                     break;
-                } else if input.peek(Token![,]) {
-                    input.parse::<Token![,]>().expect("expected ,");
 
-                // Every param has a colon to define it's type
+                // Every param has a colon to define its type
                 } else if input.peek2(Token![:]) {
                     let param = input
                         .parse::<TypeParam>()
                         .expect("unable to parse subindex param type");
                     subindex_params.push(param);
+                    if input.is_empty() {
+                        break;
+                    }
+                    input.parse::<Token![,]>().expect("expected ,");
 
                 // This is the last param, it should always be the remaining key TypeParamBound
                 } else {
@@ -53,11 +55,6 @@ impl Parse for Args {
                 }
             }
         }
-
-        eprintln!(
-            "subindex_params: {:?}\n\n subindex_remaining_key_ty: {:?}",
-            subindex_params, subindex_remaining_key_ty
-        );
 
         Ok(Args {
             query_name,

--- a/rust/psibase_macros/src/lib.rs
+++ b/rust/psibase_macros/src/lib.rs
@@ -2,7 +2,7 @@
 //! [psibase crate](https://docs.rs/psibase). See the documentation for those crates.
 
 use fracpack_macro::fracpack_macro_impl;
-use graphql_macro::{queries_macro_impl, table_query_macro_impl};
+use graphql_macro::{queries_macro_impl, table_query_macro_impl, table_query_subindex_macro_impl};
 use number_macro::{account_macro_impl, method_macro_impl};
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
@@ -422,4 +422,10 @@ pub fn queries(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn table_query(item: TokenStream) -> TokenStream {
     table_query_macro_impl(item)
+}
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn table_query_subindex(item: TokenStream) -> TokenStream {
+    table_query_subindex_macro_impl(item)
 }

--- a/rust/psibase_macros/src/lib.rs
+++ b/rust/psibase_macros/src/lib.rs
@@ -2,6 +2,7 @@
 //! [psibase crate](https://docs.rs/psibase). See the documentation for those crates.
 
 use fracpack_macro::fracpack_macro_impl;
+use graphql_macro::{queries_macro_impl, table_query_macro_impl};
 use number_macro::{account_macro_impl, method_macro_impl};
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
@@ -11,6 +12,7 @@ use test_case_macro::test_case_macro_impl;
 use to_key_macro::to_key_macro_impl;
 
 mod fracpack_macro;
+mod graphql_macro;
 mod number_macro;
 mod reflect_macro;
 mod service_macro;
@@ -408,4 +410,16 @@ pub fn method(item: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn method_raw(item: TokenStream) -> TokenStream {
     method_macro_impl(false, item)
+}
+
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn queries(attr: TokenStream, item: TokenStream) -> TokenStream {
+    queries_macro_impl(attr, item)
+}
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn table_query(item: TokenStream) -> TokenStream {
+    table_query_macro_impl(item)
 }

--- a/rust/psibase_macros/src/service_macro.rs
+++ b/rust/psibase_macros/src/service_macro.rs
@@ -750,10 +750,12 @@ fn process_service_tables(
         (table_name, table_record_struct_name.clone())
     };
 
+    // TODO: This specific naming convention is a bit of a hack. Figure out a way of using an associated type
     let table_record_type_id = Ident::new(
         format!("{}Record", table_name_id).as_str(),
         table_record_struct_name.span(),
     );
+
     let table_record_type_impl = quote! {
         type #table_record_type_id = #record_name_id;
     };

--- a/rust/psibase_macros/src/service_macro.rs
+++ b/rust/psibase_macros/src/service_macro.rs
@@ -750,6 +750,15 @@ fn process_service_tables(
         (table_name, table_record_struct_name.clone())
     };
 
+    let table_record_type_id = Ident::new(
+        format!("{}Record", table_name_id).as_str(),
+        table_record_struct_name.span(),
+    );
+    let table_record_type_impl = quote! {
+        type #table_record_type_id = #record_name_id;
+    };
+    items.push(parse_quote! {#table_record_type_impl});
+
     let table_impl = quote! {
         impl #psibase_mod::Table<#record_name_id> for #table_name_id {
             const TABLE_INDEX: u16 = #table_index;

--- a/rust/test_service_psispace/Cargo.toml
+++ b/rust/test_service_psispace/Cargo.toml
@@ -15,3 +15,4 @@ async-graphql = "4.0"
 fracpack = { version = "0.1.0", path = "../fracpack" }
 psibase = { version = "0.1.0", path = "../psibase" }
 serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0"

--- a/rust/test_service_psispace/Cargo.toml
+++ b/rust/test_service_psispace/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+async-graphql = "4.0"
 fracpack = { version = "0.1.0", path = "../fracpack" }
 psibase = { version = "0.1.0", path = "../psibase" }
 serde = { version = "1.0.145", features = ["derive"] }

--- a/rust/test_service_psispace/src/lib.rs
+++ b/rust/test_service_psispace/src/lib.rs
@@ -71,7 +71,7 @@ mod service {
             content_by_account,
             ContentTable,
             get_index_pk,
-            account: AccountNumber
+            account: AccountNumber,
         );
     }
 

--- a/rust/test_service_psispace/src/lib.rs
+++ b/rust/test_service_psispace/src/lib.rs
@@ -42,7 +42,7 @@ mod service {
     }
 
     // TODO: create a macro for unnamed field keys (eg as seen in tuples keys),
-    // so that we can support these type of tables GQL queries.
+    // so that we can support these types of tables in GQL queries.
     #[derive(ToKey, InputObject)]
     pub struct ContentKeyNamed {
         pub account: AccountNumber,


### PR DESCRIPTION
Queries can be implemented by using the following macros:

```
    #[queries]
    impl Queries {
        /// List all the existing files
        table_query!(content, ContentTable, get_index_pk: ContentKeyNamed);

        /// List files content by account subindex
        table_query_subindex!(
            content_by_account,
            ContentTable,
            get_index_pk,
            account: AccountNumber
        );
    }
```

- `table_query!` is used to wrap an index function and its named keys type with the `first, last, before, after, gt, ge, lt, le` query functions
- `table_query_subindex!` is used to wrap a subindex for a given index function and the defined subindex partial fields.  
  - the last parameter of this query can set the subindex RemainingKey type if it's a single ident parameter such as `Vec<u8>`, `String`, `MyStruct`