### PR TITLE
add new subdirectory to boot image to avoid glob expansion issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 
 option(BUILD_RUST "Build rust" ON)
 if(BUILD_RUST)
-    set(BOOT_IMAGE ${CMAKE_CURRENT_SOURCE_DIR}/rust/psibase/boot-image)
+    set(BOOT_IMAGE ${CMAKE_CURRENT_SOURCE_DIR}/rust/psibase/boot-image/contents/)
     set(COMMON_SYS ${CMAKE_CURRENT_SOURCE_DIR}/services/user/CommonSys)
     set(THIRD_SRC ${COMMON_SYS}/common/thirdParty/src)
     set(THIRD_DEST ${BOOT_IMAGE}/CommonSys/common/thirdParty)
@@ -140,7 +140,7 @@ if(BUILD_RUST)
         DEPENDS wasm ${DOC_DEP} ${JS_DEPS}
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/rust
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND   rm -rf ${BOOT_IMAGE}/*
+        BUILD_COMMAND   rm -rf ${BOOT_IMAGE}
         COMMAND         mkdir -p ${BOOT_IMAGE}/CommonSys/common ${BOOT_IMAGE}/CommonSys/common/fonts ${BOOT_IMAGE}/CommonSys/ui/vanilla
         COMMAND         mkdir -p ${BOOT_IMAGE}/AccountSys/ui ${BOOT_IMAGE}/ExploreSys/ui
         COMMAND         mkdir -p ${BOOT_IMAGE}/AuthEcSys ${BOOT_IMAGE}/TokenSys/ui ${BOOT_IMAGE}/PsiSpaceSys/ui

--- a/rust/psibase/src/boot.rs
+++ b/rust/psibase/src/boot.rs
@@ -55,7 +55,7 @@ macro_rules! sgc {
             flags: $flags,
             vmType: 0,
             vmVersion: 0,
-            code: include_bytes!(concat!("../boot-image/", $wasm)).into(),
+            code: include_bytes!(concat!("../boot-image/contents/", $wasm)).into(),
         }
     };
 }
@@ -67,7 +67,7 @@ macro_rules! store {
             account!($acc),
             $dest,
             $ty,
-            include_bytes!(concat!("../boot-image/", $src)),
+            include_bytes!(concat!("../boot-image/contents/", $src)),
         )
     };
 }
@@ -309,7 +309,7 @@ pub fn create_boot_transactions(
         ];
 
         fill_dir(
-            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/CommonSys/ui/dist"),
+            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/contents/CommonSys/ui/dist"),
             &mut common_sys_files,
             common_sys::SERVICE,
             common_sys::SERVICE,
@@ -343,7 +343,7 @@ pub fn create_boot_transactions(
             // ),
         ];
         fill_dir(
-            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/AccountSys/ui/dist"),
+            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/contents/AccountSys/ui/dist"),
             &mut account_sys_files,
             account!("r-account-sys"),
             account!("r-account-sys"),
@@ -363,7 +363,7 @@ pub fn create_boot_transactions(
             // ),
         ];
         fill_dir(
-            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/ExploreSys/ui/dist"),
+            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/contents/ExploreSys/ui/dist"),
             &mut explore_sys_files,
             account!("explore-sys"),
             account!("explore-sys"),
@@ -384,7 +384,7 @@ pub fn create_boot_transactions(
             // ),
         ];
         fill_dir(
-            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/TokenSys/ui/dist"),
+            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/contents/TokenSys/ui/dist"),
             &mut token_sys_files,
             account!("r-tok-sys"),
             account!("r-tok-sys"),
@@ -392,7 +392,7 @@ pub fn create_boot_transactions(
 
         let mut psispace_sys_files = vec![];
         fill_dir(
-            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/PsiSpaceSys/ui/dist"),
+            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/contents/PsiSpaceSys/ui/dist"),
             &mut psispace_sys_files,
             psispace_sys::SERVICE,
             psispace_sys::SERVICE,
@@ -413,7 +413,7 @@ pub fn create_boot_transactions(
             new_account_action(account_sys::SERVICE, account!("doc-sys")), //
         ];
         fill_dir(
-            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/doc"),
+            &include_dir!("$CARGO_MANIFEST_DIR/boot-image/contents/doc"),
             &mut doc_actions,
             account!("doc-sys"),
             psispace_sys::SERVICE,


### PR DESCRIPTION
Adds a new directory inside boot-image that can be entirely deleted & recreated by cmake. This avoids [this glob expansion issue](https://github.com/gofractally/psibase/issues/239#issuecomment-1343528947) and still allows `boot-image/` to be bind-mounted outside of a docker container.

After this update, devs should run `rm -rf /root/psibase/rust/psibase/boot-image/*` inside their environments to manually clear out the boot-image.