### PR TITLE
Add query params to main applet

### DIFF
--- a/services/user/CommonSys/ui/src/views/applet.tsx
+++ b/services/user/CommonSys/ui/src/views/applet.tsx
@@ -39,7 +39,15 @@ export const Applet = ({ applet, handleMessage }: Props) => {
 
     useEffect(() => {
         const doSetAppletSrc = async () => {
-            setAppletSrc(await appletId.url());
+            let url = await appletId.url();
+
+            // If we're on the applet page, add the query params to the applet url
+            if (window.location.pathname === `/applet/${appletId}`) {
+                const queryParams = window.location.search;
+                url += queryParams;
+            }
+
+            setAppletSrc(url);
         };
         doSetAppletSrc();
     }, [appletId]);


### PR DESCRIPTION
Addresses #283 

- The query string params are only being passed if it's the current page main applet.
- As an example, the psispace applet makes use of the account applet. Imagine it's accessed through this URL: `http://psibase.127.0.0.1.sslip.io:8081/applet/psispace-sys?folder_path=/foo/bar`. The query param `?folder=/foo/bar` is not relevant for the account applet. Thus this param will be passed to the psispace applet only, because we know the main applet is derived from `/applet/psispace-sys`.
- If the query param is relevant to other sister applets it should be responsibility of the invoker to communicate to the invoked applet, through the traditional messaging infrastructure (via queries or actions).