### PR TITLE
Fix direct access to applet subpath

### DIFF
--- a/services/user/CommonSys/common/rpc.mjs
+++ b/services/user/CommonSys/common/rpc.mjs
@@ -363,7 +363,12 @@ export class AppletId {
     }
 
     get fullPath() {
-        const suffix = this.subPath !== "" ? "/" + this.subPath : "";
+        const suffix =
+            this.subPath && this.subPath !== ""
+                ? this.subPath.startsWith("/")
+                    ? this.subPath
+                    : "/" + this.subPath
+                : "";
         return this.name + suffix;
     }
 

--- a/services/user/CommonSys/ui/src/helpers.ts
+++ b/services/user/CommonSys/ui/src/helpers.ts
@@ -10,7 +10,13 @@ export const getIframeId = (appletId: AppletId) => {
     // Do more than one iFrame of the same appletStr/subPath ever need to be opened simultaneously?
     //    If so, this method needs to change to add a refCount to the ID or something, to ensure the IDs
     //    are unique.
-    return "applet_" + appletId.name + "_" + appletId.subPath;
+    const escapedId = (
+        "applet_" +
+        appletId.name +
+        "_" +
+        appletId.subPath
+    ).replace(/([^a-zA-Z0-9_-]+)/gi, "_");
+    return escapedId;
 };
 
 export const constructTransaction = async (actions: any) => {

--- a/services/user/CommonSys/ui/src/views/applet.tsx
+++ b/services/user/CommonSys/ui/src/views/applet.tsx
@@ -42,7 +42,7 @@ export const Applet = ({ applet, handleMessage }: Props) => {
             let url = await appletId.url();
 
             // If we're on the applet page, add the query params to the applet url
-            if (window.location.pathname === `/applet/${appletId}`) {
+            if (window.location.pathname.startsWith(`/applet/${appletId}`)) {
                 const queryParams = window.location.search;
                 url += queryParams;
             }
@@ -66,29 +66,24 @@ export const Applet = ({ applet, handleMessage }: Props) => {
         [appletId, handleMessage]
     );
 
-    useEffect(() => {
-        if (appletSrc && appletId) {
-            console.info(`Initializing applet ${appletId}: ${appletSrc}`);
-            // Configure iFrameResizer
-            const iFrame = document.getElementById(iFrameId);
-            if (iFrame) {
-                // TODO - Fix error: Failed to execute 'postMessage' on 'DOMWindow'
-                //        https://github.com/gofractally/psibase/issues/107
-                (window as any).iFrameResize(
-                    {
-                        // All options: https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/parent_page/options.md
-                        // log: true,
-                        checkOrigin: true,
-                        autoResize: false,
-                        scrolling: true,
-                        onMessage: doHandleMessage,
-                        onInit,
-                    },
-                    "#" + iFrameId
-                )[0].iFrameResizer;
-            }
+    const initializeIFrame = () => {
+        // Configure iFrameResizer
+        const iFrame = document.getElementById(iFrameId);
+        if (iFrame) {
+            (window as any).iFrameResize(
+                {
+                    // All options: https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/parent_page/options.md
+                    // log: true,
+                    checkOrigin: true,
+                    autoResize: false,
+                    scrolling: true,
+                    onMessage: doHandleMessage,
+                    onInit,
+                },
+                "#" + iFrameId
+            )[0].iFrameResizer;
         }
-    }, [appletSrc, appletId, onInit, iFrameId, doHandleMessage]);
+    };
 
     return appletId && appletSrc ? (
         <iframe
@@ -97,6 +92,7 @@ export const Applet = ({ applet, handleMessage }: Props) => {
             src={appletSrc}
             allow="camera;microphone"
             title={appletId.name}
+            onLoad={initializeIFrame}
             frameBorder="0"
         />
     ) : null;

--- a/services/user/InviteSys/ui/src/layouts/default.tsx
+++ b/services/user/InviteSys/ui/src/layouts/default.tsx
@@ -1,9 +1,14 @@
 import { Outlet } from "react-router-dom";
 
+import { useInitilize } from "store/hooks/useInitialize";
+import { psiboardApplet } from "service";
+
 export const Layout = () => {
-    return (
-        <main className="psibase max-w-screen-xs xs:mt-8 xs:h-auto mx-auto h-full space-y-4 bg-white px-2 py-4">
-            <Outlet />
-        </main>
-    );
+  useInitilize(psiboardApplet);
+
+  return (
+    <main className="psibase max-w-screen-xs xs:mt-8 xs:h-auto mx-auto h-full space-y-4 bg-white px-2 py-4">
+      <Outlet />
+    </main>
+  );
 };

--- a/services/user/InviteSys/ui/src/pages/options/options.tsx
+++ b/services/user/InviteSys/ui/src/pages/options/options.tsx
@@ -1,15 +1,11 @@
-import { psiboardApplet } from "service";
 import { Button, Heading, Icon, Text } from "components";
 import { useParam } from "store";
 import { useUsers, useUser } from "store/hooks/useUser";
 import { useInviteToken } from "store/queries/usePrivateKey";
-import { useInitilize } from "store/hooks/useInitialize";
 import { useGenerateLink } from "store/hooks/useGenerateLink";
 import { Link } from "react-router-dom";
 
 export const Options = () => {
-  useInitilize(psiboardApplet);
-
   const token = useParam("token");
   const appletName = useParam("applet");
 
@@ -56,8 +52,11 @@ export const Options = () => {
         </header>
         {isSignedIn && isInviteValid ? (
           <div className="border-y border-gray-300 overflow-y-auto h-64">
-            {users?.map((account) => (
-              <Link to={`/select-account?account=${account}&token=${token}`}>
+            {users?.map((account, idx) => (
+              <Link
+                key={`acc-${idx}`}
+                to={`/select-account?account=${account}&token=${token}`}
+              >
                 <div
                   key={account}
                   className="flex cursor-pointer items-center justify-between px-3 py-5 hover:bg-gray-100"


### PR DESCRIPTION
When we were accessing the applet subpath address directly (by copying and pasting a link / sharing a link) we were seeing the following issue:
![image](https://user-images.githubusercontent.com/79721020/223909054-9e608773-fe29-4951-a7c4-9e10ef2446b2.png)

1. This PR fixes the above issue.
2. Also fixes the #107 
3. Fixes an issue on invite-sys because the applet was being initialized only when the root path (`/`) was being called, making a directly call to `invite-sys/signup?token=....` to fail. I moved the `useInitialize`  hook call to the Layout parent component.