### PR TITLE
Move psibase and psinode into separate documentation pages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,10 +101,17 @@ if(BUILD_DOC)
         BUILD_COMMAND       cargo build -r --bin gen-cpp-doc --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/rust/Cargo.toml --target-dir ${CMAKE_CURRENT_BINARY_DIR}/rust
         INSTALL_COMMAND     ""
     )
+    ExternalProject_Add(
+        md2man
+        SOURCE_DIR          ${CMAKE_CURRENT_SOURCE_DIR}/rust
+        CONFIGURE_COMMAND   ""
+        BUILD_COMMAND       cargo build -r --bin md2man --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/rust/Cargo.toml --target-dir ${CMAKE_CURRENT_BINARY_DIR}/rust
+        INSTALL_COMMAND     ""
+    )
     configure_file(doc/psidk/book.toml.in doc/psidk/book.toml)
     configure_file(doc/psidk/mermaid.min.js doc/psidk/mermaid.min.js COPYONLY)
     configure_file(doc/psidk/mermaid-init.js doc/psidk/mermaid-init.js COPYONLY)
-    file(GLOB_RECURSE doc-src ${CMAKE_CURRENT_SOURCE_DIR}/doc/src/*.md)
+    file(GLOB_RECURSE doc-src ${CMAKE_CURRENT_SOURCE_DIR}/doc/psidk/src/*.md)
     list(APPEND doc-src ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/book.toml)
     list(APPEND doc-src ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/mermaid.min.js)
     list(APPEND doc-src ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/mermaid-init.js)
@@ -121,6 +128,20 @@ if(BUILD_DOC)
         ${DOC_DEP}
         DEPENDS doc/psidk/book/index.html
     )
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/psinode.1
+        DEPENDS md2man doc/psidk/src/psibase/psinode.md
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/rust/release/md2man < ${CMAKE_CURRENT_SOURCE_DIR}/doc/psidk/src/psibase/psinode.md > ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/psinode.1
+    )
+    add_custom_target(psinode.1 ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/psinode.1)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/psinode.1 TYPE MAN COMPONENT ServerData)
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/psibase.1
+        DEPENDS md2man doc/psidk/src/psibase/psibase.md
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/rust/release/md2man < ${CMAKE_CURRENT_SOURCE_DIR}/doc/psidk/src/psibase/psibase.md > ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/psibase.1
+    )
+    add_custom_target(psibase.1 ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/psibase.1)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/psidk/psibase.1 TYPE MAN COMPONENT Client)
 endif()
 
 set(JS_DIRS

--- a/doc/psidk/src/SUMMARY.md
+++ b/doc/psidk/src/SUMMARY.md
@@ -5,6 +5,8 @@
   - [Linux](installation/linux.md)
   - [Rust](installation/rust.md)
 - [Command-line tools](psibase/README.md)
+  - [psibase](psibase/psibase.md)
+  - [psinode](psibase/psinode.md)
   - [Serving https](psibase/https.md)
   - [Logging](psibase/logging.md)
 - [Documentation](documentation.md)

--- a/doc/psidk/src/psibase/README.md
+++ b/doc/psidk/src/psibase/README.md
@@ -2,75 +2,8 @@
 
 psidk comes with two executables for working with chains:
 
-- `psinode` runs a chain. It can optionally be a producer or a non-producer node on a chain. It also optionally hosts an http interface which provides RPC services, GraphQL services, and hosts web UIs. On-chain services define most of the http interface.
-- `psibase` is a command-line client for interacting with the chain. It connects to the http interface on a running node.
-
-## psinode
-
-`psinode` has the following command-line interface:
-
-```
-psinode [OPTIONS] <DATABASE>
-```
-
-`<DATABASE>`, which is required, is a path to the psibase database. psinode creates it if it does not already exist.
-
-If you don't give it any other options, psinode will find that it has nothing to do and immediately shut down. There are four important options for creating and running a local test chain:
-
-- `--listen` tells psinode an interface and TCP port to listen on. If this argument is not provided, the HTTP server will not run. The argument can be any of the following
-  - A port number: Listens on `0.0.0.0` with the specified port
-  - An IP address: Listen on port 80 on the given interface
-  - An IP address and port separated by a colon: `ipv4:port` or `[ipv6]:port`
-  - An `http` or `https` URL: The host component must be an IP address. All components other than the host and port must be empty. `https` requires `--tls-cert` and `--tls-key` to be provided.
-  - A filesystem path: Listens on a local socket
-- `-p` or `--producer` tells psinode to produce blocks. It will not start production on an empty chain until you boot the chain (below). Its argument is a name for the producer. psinode will only produce blocks when it is this producer's turn according to consensus. Multiple distinct nodes must not use the same producer name.
-- `-o` or `--host` tells psinode to host the http interface. Its argument is a domain name which supports virtual hosting. e.g. if it's running on your local machine, use `psibase.127.0.0.1.sslip.io`. This argument allows on-chain services to handle HTTP requests and also allows the node to accept transactions.
-- `-k` or `--key` tells psinode a private key with which to sign blocks. Any number of keys may be provided, but only the one that matches the public key corresponding to the producer name will be used. If the correct key is not provided, then `psinode` will be unable to produce blocks.
-
-Three more options are important for connecting multiple nodes together in a network:
-
-- `--p2p` tells psinode to allow external nodes to peer to it over its http interface at `/native/p2p`.
-- `--peer` tells psinode a peer to sync with. The argument should have the form `host:port`. This argument can appear any number of times.
-- `--autoconnect` limits the number of out-going peer connections. If it is less than the number of `--peer` options, the later peers will be tried after a connection to an earlier peer fails.
-
-Options controlling native content (enabled in new nodes by default):
-
-- `--service` *host*:*path*: tells psinode to host static content from *path*.
-- `--admin` `static:*'` | `'*'` | *service*: tells psinode to enable the [admin API](../http.md#node-administrator-services)
-
-Options controlling TLS:
-- `--tls-cert` *file*: A file containing the certificate chain that the server will use. The key must be specified as well using `--tls-key`. This certificate will be used both as a server certificate for incoming https connections and as a client certificate for outing p2p connections using https. The certificate should be a wildcard certificate, valid for both *host* and \*.*host*.
-- `--tls-key` *file*: The private key corresponding to `--tls-cert`
-- `--tls-trustfile` *file*: This file should contain trusted root certification authorities used to verify certificates. If it is not provided a system dependent default will be used.
-
-Options can also be specified in a configuration file loaded from `<DATABASE>/config`. If an option is specified on both the command line and the config file, the command line takes precedence. When a new database is created, it will be initialized with a default configuration file that includes the [administrator service](../system-service/admin-sys.md).
-
-The configuration file also controls [logging](logging.md).
-
-Example:
-```ini
-producer = prod
-host     = 127.0.0.1.sslip.io
-listen   = 8080
-service  = localhost:$PSIBASE_DATADIR/services/admin-sys
-admin    = static:*
-
-[logger.stderr]
-type   = console
-filter = Severity >= info
-format = [{TimeStamp}] {Message}
-```
-
-Environmental variables, double quotes, and backslash escapes can be used in the value of most options. `psinode` adds some variables to its environment:
-- `PSIBASE_DATADIR`: The directory containing data files used by `psinode`.  Usually `<install-prefix>/share/psibase`.
-
-## psibase
-
-`psibase` provides commands for booting a chain, creating accounts, deploying services, and more. Notable options and commands for service development:
-
-- `-a` or `--api` tells it which api endpoint to connect to. This defaults to `http://psibase.127.0.0.1.sslip.io:8080/`.
-- `boot` boots an empty chain; see below
-- `deploy` deploys a service; see [Basic Service](../services/cpp-service/basic/)
+- [psinode](psinode.md) runs a chain. It can optionally be a producer or a non-producer node on a chain. It also optionally hosts an http interface which provides RPC services, GraphQL services, and hosts web UIs. On-chain services define most of the http interface.
+- [psibase](psibase.md) is a command-line client for interacting with the chain. It connects to the http interface on a running node.
 
 ## Booting a chain
 

--- a/doc/psidk/src/psibase/psibase.md
+++ b/doc/psidk/src/psibase/psibase.md
@@ -1,0 +1,162 @@
+# psibase
+
+## NAME
+
+psibase - The psibase blockchain command line client
+
+## SYNOPSIS
+
+`psibase` [`-a` *url*] `boot` [`-p` *name*] [`-k` *public-key*] [`--no-doc`]  
+`psibase` [`-a` *url*] `create` [`-i` | `-k` *public-key*] [-S *sender*] *name*  
+`psibase` [`-a` *url*] `deploy` [`-p`] *account* *filename*  
+`psibase` [`-a` *url*] `modify` [`-i` | `-k` *public-key*] *account*  
+`psibase` [`-a` *url*] `upload` *service* *dest* *content-type* *source*  
+`psibase` [`-a` *url*] `upload-tree` *service* *dest* *source*  
+
+## DESCRIPTION
+
+`psibase` is the command-line tool for interacting with psibase blockchains.
+
+## OPTIONS
+
+- `-a`, `--api` *url*
+
+  `psinode` API Endpoint. The default is `http://psibase.127.0.0.1.sslip.io/`
+  
+- `-h`, `--help`
+
+  Print help information
+
+- `-s`, `--sign` *private-key*
+
+  Sign transactions with this key
+
+## COMMANDS
+
+### boot
+
+`psibase` [`-a` *url*] `boot` [`-p` *name*] [`-k` *public-key*]  
+
+The boot command deploys a set of system services and web interfaces suitable for development. The chain will have a single block producer. The chain can only be booted once.
+
+- `-k`, `--key` *public-key*
+
+  Set all accounts to authenticate using this key. The key will also be used for block production. If no key is provided, the accounts will not require authentication.
+
+- `-p`, `--producer` *name*
+
+  Set the name of the block producer. `psinode` should be configured to use the same name.
+
+- `--no-doc`
+
+  Do not upload psibase documentation
+
+### create
+
+`psibase` [`-a` *url*] `create` [`-i` | `-k` *public-key*] [-S *sender*] *name*  
+
+Create or modify an account
+
+- `-i`, `--insecure`
+
+  The account won't be secured; anyone can authorize as this account without signing. This option does nothing if the account already exists. Caution: this option should not be used on production or public chains.
+
+- `-k`, `--key` *public-key*
+
+  Set the account to authenticate using this key. Also works if the account already exists.
+
+- `-S`, `--sender` *account*
+
+  Sender to use when creating the account [default: account-sys].
+
+### deploy
+
+`psibase` [`-a` *url*] `deploy` [`-p`] *account* *filename*  
+
+Deploy a service
+
+- *account*
+
+  Account to deploy the service on
+
+- *filename*
+
+  A wasm file containing the service
+
+- `-c`, `--create-account` *public-key*
+
+  Create the account if it doesn't exist. Also set the account to authenticate using this key, even if the account already existed
+
+- `-i`, `--create-insecure-account`
+
+  Create the account if it doesn't exist. The account won't be secured; anyone can authorize as this account without signing. Caution: this option should not be used on production or public.
+
+- `-p`, `--register-proxy`
+
+  Register the service with ProxySys. This allows the service to host a website, serve RPC requests, and serve GraphQL requests.
+  
+- `-S`, `--sender` *sender*
+
+  Sender to use when creating the account [default: account-sys]
+
+### modify
+
+`psibase` [`-a` *url*] `modify` [`-i` | `-k` *public-key*] *account*  
+
+Modify an account
+
+- `-i`, `--insecure`
+
+  Make the account insecure, even if it has been previously secured. Anyone will be able to authorize as this account without signing. Caution: this option should not be used on production or public chains
+  
+- `-k`, `--key`
+
+  Set the account to authenticate using this key
+
+### upload
+
+`psibase` [`-a` *url*] `upload` *service* *dest* *content-type* *source*  
+
+Upload a file to a service. The service must provide a `storeSys` action.
+
+- *service*
+
+  Service to upload to
+  
+- *dest*
+
+  Destination path within *service*
+  
+- *content-type*
+
+  MIME Content-Type of the file
+  
+- *source*
+
+  Source filename to upload
+
+- `-S`, `--sender` *sender*
+
+  Account to use as the sender of the transaction. Defaults to the *service* account.
+
+### upload-tree
+
+`psibase` [`-a` *url*] `upload-tree` *service* *dest* *source*  
+
+Upload a directory tree to a service. The service must provide a `storeSys` action. The files may be split across multiple transactions if they are too large to fit in a single transaction.
+
+- *service*
+
+  Service to upload to
+  
+- *dest*
+
+  Destination path within *service*
+  
+- *source*
+
+  Source directory to upload
+
+- `-S`, `--sender` *sender*
+
+  Account to use as the sender of the transaction. Defaults to the *service* account.

--- a/doc/psidk/src/psibase/psinode.md
+++ b/doc/psidk/src/psibase/psinode.md
@@ -1,0 +1,104 @@
+# psinode
+
+## NAME
+
+psinode - The psibase blockchain server
+
+## SYNOPSIS
+
+`psinode` [`-l` *port*] [`-p` *name*] [`-o` *host*] [*options*]\.\.\. *database*
+
+## DESCRIPTION
+
+`psinode` runs a chain. It can optionally be a producer or a non-producer node on a chain. It also optionally hosts an http interface which provides RPC services, GraphQL services, and hosts web UIs. On-chain services define most of the http interface.
+
+*database* is a directory which will contain the chain database. `psinode` creates it if it does not already exist.
+
+## OPTIONS
+
+### General options
+
+- `-l` *interface*, `--listen` *interface*
+
+  Accept connections on *interface*. If this argument is not provided, the HTTP server will not run. The argument can be any of the following:
+
+  - A port number: Listens on `0.0.0.0` with the specified port
+  - An IP address: Listen on port 80 on the given interface
+  - An IP address and port separated by a colon: *ipv4*`:`*port* or `[`*ipv6*`]:`*port*
+  - An `http` or `https` URL: The host component must be an IP address. All components other than the host and port must be empty. `https` requires `--tls-cert` and `--tls-key` to be provided.
+  - A filesystem path: Listens on a local socket
+
+- `-p` *name*, `--producer` *name*
+
+  Produce blocks using the given producer name. It will not start production on an empty chain until you boot the chain. psinode will only produce blocks when it is this producer's turn according to consensus. Multiple distinct nodes must not use the same producer name.
+
+- `-o` *hostname*, `--host` *hostname*
+
+  Enable the service http interface. Its argument is a domain name which supports virtual hosting. e.g. if it's running on your local machine, use `psibase.127.0.0.1.sslip.io`. This argument allows on-chain services to handle HTTP requests and also allows the node to accept transactions.
+
+- `-k` *private-key*, `--key` *private-key*
+
+  Use this private key to sign blocks. Any number of keys may be provided, but only the one that matches the public key corresponding to the producer name will be used. If the correct key is not provided, then `psinode` will be unable to produce blocks.
+
+### P2P Network Options
+
+- `--p2p`
+
+  allows external nodes to peer to `psinode` it over its http interface at `/native/p2p`.
+
+- `--peer` *url*
+
+  tells psinode a peer to sync with. The argument should have the form `host:port`. This argument can appear any number of times.
+
+- `--autoconnect` *number*
+
+  limits the number of out-going peer connections. If it is less than the number of `--peer` options, the later peers will be tried after a connection to an earlier peer fails.
+
+### HTTP Server
+
+- `--service` *host*:*path*
+
+  tells psinode to host static content from *path*.
+
+- `--admin` `static:*` | `*` | *service*
+
+  tells psinode to enable the [admin API](../http.md#node-administrator-services)
+
+### TLS Options
+
+- `--tls-cert` *file*
+
+  A file containing the certificate chain that the server will use. The key must be specified as well using `--tls-key`. This certificate will be used both as a server certificate for incoming https connections and as a client certificate for outing p2p connections using https. The certificate should be a wildcard certificate, valid for both *host* and \*.*host*.
+
+- `--tls-key` *file*
+
+  The private key corresponding to `--tls-cert`
+
+- `--tls-trustfile` *file*
+
+  This file should contain trusted root certification authorities used to verify certificates. If it is not provided a system dependent default will be used.
+
+### Configuration File
+
+Options can also be specified in a configuration file loaded from *database*`/config`. If an option is specified on both the command line and the config file, the command line takes precedence. When a new database is created, it will be initialized with a default configuration file that includes the [administrator service](../system-service/admin-sys.md).
+
+The configuration file also controls [logging](logging.md).
+
+Example:
+```ini
+producer = prod
+host     = psibase.127.0.0.1.sslip.io
+listen   = 8080
+service  = localhost:$PSIBASE_DATADIR/services/admin-sys
+admin    = static:*
+
+[logger.stderr]
+type   = console
+filter = Severity >= info
+format = [{TimeStamp}] {Message}
+```
+
+Environmental variables, double quotes, and backslash escapes can be used in the value of most options. `psinode` adds some variables to its environment:
+- `PSIBASE_DATADIR`
+
+  The directory containing data files used by `psinode`.  Usually `<install-prefix>/share/psibase`.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1376,6 +1376,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "md2man"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "pulldown-cmark",
+]
+
+[[package]]
 name = "mdbook"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "cargo-psibase",
     "fracpack",
     "gen-cpp-doc",
+    "md2man",
     "psibase_macros",
     "psibase",
     "test_contract",

--- a/rust/md2man/Cargo.toml
+++ b/rust/md2man/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "md2man"
+version.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition = "2021"
+publish = false
+description = "Generate man page from markdown"
+
+[dependencies]
+pulldown-cmark = "0.9"
+clap = {version = "3.1", features = ["derive"]}

--- a/rust/md2man/src/main.rs
+++ b/rust/md2man/src/main.rs
@@ -1,0 +1,175 @@
+use clap::Parser;
+use pulldown_cmark::{Event, HeadingLevel, Options, Tag};
+use std::io;
+use std::io::Write;
+use std::iter::Iterator;
+
+enum State {
+    Default,
+    Item,
+}
+
+fn md2man<'a, S: Write, I: Iterator<Item = Event<'a>>>(
+    out: &mut S,
+    iter: &mut I,
+    date: &str,
+) -> io::Result<()> {
+    let mut stack: Vec<&str> = vec![];
+    let mut current = "\\fR";
+    stack.push(current);
+    let mut state = State::Default;
+    let mut indent = 0;
+    let mut par_num = 0;
+    for item in iter {
+        match item {
+            Event::Start(t) => match t {
+                Tag::Paragraph => {
+                    current = &"\\fR";
+                    match state {
+                        State::Item => {
+                            if par_num == 1 {
+                                write!(out, "\n")?;
+                            }
+                            if par_num > 1 {
+                                write!(out, "\n.IP\n")?;
+                            }
+                            par_num += 1;
+                        }
+                        _ => {
+                            write!(out, "\n.PP\n")?;
+                        }
+                    }
+                }
+                Tag::Heading(level, _fragment, _classes) => {
+                    current = "\\fR";
+                    match level {
+                        HeadingLevel::H1 => {
+                            write!(out, ".TH ")?;
+                        }
+                        HeadingLevel::H2 => {
+                            write!(out, "\n.SH ")?;
+                        }
+                        HeadingLevel::H3 => {
+                            write!(out, "\n.SS ")?;
+                        }
+                        _ => {
+                            write!(out, "\n.PP\n")?;
+                        }
+                    }
+                }
+                Tag::CodeBlock(_kind) => {
+                    write!(out, "\n.PP\n.in +4n\n.EX\n")?;
+                }
+                Tag::List(_n) => match state {
+                    State::Item => {
+                        write!(out, "\n.RS")?;
+                    }
+                    _ => {}
+                },
+                Tag::Item => {
+                    if &current != &"\\fR" {
+                        write!(out, "\\fR")?;
+                        current = &"\\fR";
+                    }
+                    indent += 1;
+                    match state {
+                        State::Item => {
+                            write!(out, "\n.IP \\(bu 2\n")?;
+                        }
+                        _ => {
+                            state = State::Item;
+                            par_num = 0;
+                            write!(out, "\n.TP\n")?;
+                        }
+                    }
+                }
+                Tag::Emphasis => {
+                    stack.push(&"\\fI");
+                }
+                Tag::Strong => {
+                    stack.push(&"\\fB");
+                }
+                _ => {}
+            },
+            Event::End(t) => match t {
+                Tag::Heading(level, _fragment, _classes) => match level {
+                    HeadingLevel::H1 => {
+                        write!(out, " 1 \"{date}\" psibase \"Psibase User's Manual\"\n")?;
+                    }
+                    HeadingLevel::H2 | HeadingLevel::H3 => {
+                        write!(out, "\n")?;
+                    }
+                    _ => {
+                        write!(out, ":\n")?;
+                    }
+                },
+                Tag::CodeBlock(_kind) => {
+                    write!(out, "\n.EE\n.in\n")?;
+                }
+                Tag::List(_n) => match state {
+                    State::Item => {
+                        write!(out, "\n.RE\n")?;
+                    }
+                    _ => {}
+                },
+                Tag::Item => {
+                    indent -= 1;
+                    if indent == 0 {
+                        state = State::Default;
+                    }
+                }
+                Tag::Emphasis => {
+                    stack.pop();
+                }
+                Tag::Strong => {
+                    stack.pop();
+                }
+                _ => {}
+            },
+            Event::Text(s) => {
+                let format = stack[stack.len() - 1].clone();
+                if format != current {
+                    write!(out, "{}", format)?;
+                    current = format;
+                }
+                write!(out, "{s}")?;
+            }
+            Event::Code(s) => {
+                if &current != &"\\fB" {
+                    write!(out, "\\fB")?;
+                    current = &"\\fB";
+                }
+                write!(out, "{s}")?;
+            }
+            Event::SoftBreak => {
+                write!(out, "\n")?;
+            }
+            Event::HardBreak => {
+                write!(out, "\n.br\n")?;
+            }
+            _ => {}
+        }
+    }
+
+    write!(out, "\n")?;
+
+    Ok(())
+}
+
+#[derive(clap::Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(short = 'd', long, value_name = "DATE", default_value = "")]
+    date: String,
+}
+
+fn main() -> io::Result<()> {
+    let args = Args::parse();
+    let input = io::read_to_string(io::stdin())?;
+    md2man(
+        &mut io::stdout(),
+        &mut pulldown_cmark::Parser::new_ext(&input, Options::all()),
+        &args.date,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
- Add docs for `psibase` commands other than boot
- Allow generation of man pages for psibase and psinode