### PR TITLE
Fix cpp docs in github actions

### DIFF
--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -60,7 +60,7 @@ jobs:
           ${DOCKER} sccache -s
           echo =====
           mkdir build
-          ${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_WASM=yes -DBUILD_DEBUG_WASM=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
+          ${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_WASM=yes -DBUILD_DEBUG_WASM=yes -DBUILD_DOC=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
           echo =====
           ${DOCKER} bash -c "cd build && make -j $(nproc)"
           echo =====
@@ -74,7 +74,7 @@ jobs:
           echo =====
           ${DOCKER} bash -c "cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME=psidk-ubuntu-2004"
           echo =====
-          ${DOCKER} bash -c "cd doc/psidk && mdbook build && mv book psidk-book && tar czf ../../psidk-book.tar.gz psidk-book"
+          ${DOCKER} bash -c "cd build/doc/psidk && mv book psidk-book && tar czf ../../../psidk-book.tar.gz psidk-book"
       - name: Upload psidk-ubuntu-2004
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -67,7 +67,6 @@ jobs:
           ${DOCKER} bash -c "cd build && ctest --output-on-failure -j $(nproc)"
           echo =====
           ls -la ${GITHUB_WORKSPACE}
-          ls -la ${GITHUB_WORKSPACE}/build/doc/psidk
           echo =====
           ${DOCKER} ccache -s
           echo =====
@@ -75,7 +74,7 @@ jobs:
           echo =====
           ${DOCKER} bash -c "cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME=psidk-ubuntu-2004"
           echo =====
-          ${DOCKER} bash -c "cd build/doc/psidk && mv book psidk-book && tar czf ../../../psidk-book.tar.gz psidk-book"
+          ${DOCKER} bash -c "cd build && mv book psidk-book && tar czf ../psidk-book.tar.gz psidk-book"
       - name: Upload psidk-ubuntu-2004
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -67,6 +67,7 @@ jobs:
           ${DOCKER} bash -c "cd build && ctest --output-on-failure -j $(nproc)"
           echo =====
           ls -la ${GITHUB_WORKSPACE}
+          ls -la ${GITHUB_WORKSPACE}/build/doc/psidk
           echo =====
           ${DOCKER} ccache -s
           echo =====

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -73,7 +73,7 @@ jobs:
           echo =====
           ${DOCKER} bash -c "cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME=psidk-ubuntu-2204"
           echo =====
-          ${DOCKER} bash -c "cd build/doc/psidk && mv book psidk-book && tar czf ../../../psidk-book.tar.gz psidk-book"
+          ${DOCKER} bash -c "cd build && mv book psidk-book && tar czf ../psidk-book.tar.gz psidk-book"
       - name: Upload psidk-ubuntu-2204
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -9,7 +9,7 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled]
 
 env:
-  UBUNTU_2204_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2204-builder:69f0e6ba3d4cfc889625c111c8d546f6d8b50d83"
+  UBUNTU_2204_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2204-builder:333817a3ad5d99bb1e8fc5a6c1b6b845223e3451"
 
 jobs:
   ubuntu-2204-build:

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -9,7 +9,7 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled]
 
 env:
-  UBUNTU_2204_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2204-builder:863f6e091ac215d170e1a6419cf9dee55d9ac427"
+  UBUNTU_2204_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2204-builder:69f0e6ba3d4cfc889625c111c8d546f6d8b50d83"
 
 jobs:
   ubuntu-2204-build:
@@ -65,6 +65,7 @@ jobs:
           ${DOCKER} bash -c "cd build && ctest --output-on-failure -j $(nproc)"
           echo =====
           ls -la ${GITHUB_WORKSPACE}
+          ls -la ${GITHUB_WORKSPACE}/build/doc/psidk
           echo =====
           ${DOCKER} ccache -s
           echo =====

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -58,7 +58,7 @@ jobs:
           ${DOCKER} sccache -s
           echo =====
           mkdir build
-          ${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_WASM=yes -DBUILD_DEBUG_WASM=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
+          ${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_WASM=yes -DBUILD_DEBUG_WASM=yes -DBUILD_DOC=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
           echo =====
           ${DOCKER} bash -c "cd build && make -j $(nproc)"
           echo =====
@@ -72,7 +72,7 @@ jobs:
           echo =====
           ${DOCKER} bash -c "cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME=psidk-ubuntu-2204"
           echo =====
-          ${DOCKER} bash -c "cd doc/psidk && mdbook build && mv book psidk-book && tar czf ../../psidk-book.tar.gz psidk-book"
+          ${DOCKER} bash -c "cd build/doc/psidk && mv book psidk-book && tar czf ../../../psidk-book.tar.gz psidk-book"
       - name: Upload psidk-ubuntu-2204
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Doc build needs to run gen-cpp-doc, which means it needs to run under CMake instead of a direct call to mdbook.