### PR TITLE
Add transaction logging

### DIFF
--- a/doc/psidk/src/psibase/logging.md
+++ b/doc/psidk/src/psibase/logging.md
@@ -165,29 +165,30 @@ Examples:
 
 ## Attributes
 
-| Attribute        | Availability                      | Filter Predicates               | Notes                                                                            |
-|------------------|-----------------------------------|---------------------------------|----------------------------------------------------------------------------------|
-| `BlockHeader`    | blocks                            | None                            |                                                                                  |
-| `BlockId`        | blocks                            | `=`, `!=`                       |                                                                                  |
-| `Channel`        | All records                       | `=`, `!=`                       | Possible values are `http`, `p2p`, `chain`, `block`, and `consensus`             |
-| `Escape`         | Formatters                        | N/A                             | Escapes a list of characters in a subformat.                                     |
-| `FrameDec`       | Formatters                        | N/A                             | Prefixes a nested format with a decimal octet count                              |
-| `Host`           | All records                       | `=`, `!=`                       | The system's FQDN (not the HTTP server's virtual hostname)                       |
-| `Json`           | Formatters                        | N/A                             | Formats the entire log record as JSON                                            |
-| `Message`        | Formatters                        | N/A                             | The log message                                                                  |
-| `PeerId`         | p2p connections                   | `=`, `!=`, `<`, `>`, `<=`, `>=` |                                                                                  |
-| `Process`        | All records                       | `=`, `!=`                       | The program name (usually `psinode`)                                             |
-| `ProcessId`      | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | The server's pid                                                                 |
-| `RemoteEndpoint` | HTTP requests and p2p connections | `=`, `!=`                       |                                                                                  |
-| `RequestHost`    | HTTP requests                     | `=`, `!=`                       | The value of the `Host` header                                                   |
-| `RequestMethod`  | HTTP requests                     | `=`, `!=`                       | The HTTP method of the request: `GET`, `POST`, etc.                              |
-| `RequestTarget`  | HTTP requests                     | `=`, `!=`                       |                                                                                  |
-| `ResponseBytes`  | HTTP requests                     | `=`, `!=`, `<`, `>`, `<=`, `>=` | The size of the response payload                                                 |
-| `ResponseStatus` | HTTP requests                     | `=`, `!=`, `<`, `>`, `<=`, `>=` | The numeric status code of the response                                          |
-| `ResponseTime`   | HTTP requests                     | `=`, `!=`, `<`, `>`, `<=`, `>=` | The elapsed time in microseconds spent handling the request                      |
-| `Severity`       | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | The value is one of `debug`, `info`, `notice`, `warning`, `error`, or `critical` |
-| `Syslog`         | Formatters                        | N/A                             | Formats a [syslog](#syslog) header.                                              |
-| `TimeStamp`      | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | ISO 8601 extended format                                                         |
+| Attribute        | Availability                      | Filter Predicates               | Notes                                                                               |
+|------------------|-----------------------------------|---------------------------------|-------------------------------------------------------------------------------------|
+| `BlockHeader`    | blocks                            | None                            |                                                                                     |
+| `BlockId`        | blocks                            | `=`, `!=`                       |                                                                                     |
+| `Channel`        | All records                       | `=`, `!=`                       | Possible values are `http`, `p2p`, `chain`, `block`, `transaction`, and `consensus` |
+| `Escape`         | Formatters                        | N/A                             | Escapes a list of characters in a subformat.                                        |
+| `FrameDec`       | Formatters                        | N/A                             | Prefixes a nested format with a decimal octet count                                 |
+| `Host`           | All records                       | `=`, `!=`                       | The system's FQDN (not the HTTP server's virtual hostname)                          |
+| `Json`           | Formatters                        | N/A                             | Formats the entire log record as JSON                                               |
+| `Message`        | Formatters                        | N/A                             | The log message                                                                     |
+| `PeerId`         | p2p connections                   | `=`, `!=`, `<`, `>`, `<=`, `>=` |                                                                                     |
+| `Process`        | All records                       | `=`, `!=`                       | The program name (usually `psinode`)                                                |
+| `ProcessId`      | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | The server's pid                                                                    |
+| `RemoteEndpoint` | HTTP requests and p2p connections | `=`, `!=`                       |                                                                                     |
+| `RequestHost`    | HTTP requests                     | `=`, `!=`                       | The value of the `Host` header                                                      |
+| `RequestMethod`  | HTTP requests                     | `=`, `!=`                       | The HTTP method of the request: `GET`, `POST`, etc.                                 |
+| `RequestTarget`  | HTTP requests                     | `=`, `!=`                       |                                                                                     |
+| `ResponseBytes`  | HTTP requests                     | `=`, `!=`, `<`, `>`, `<=`, `>=` | The size of the response payload                                                    |
+| `ResponseStatus` | HTTP requests                     | `=`, `!=`, `<`, `>`, `<=`, `>=` | The numeric status code of the response                                             |
+| `ResponseTime`   | HTTP requests                     | `=`, `!=`, `<`, `>`, `<=`, `>=` | The elapsed time in microseconds spent handling the request                         |
+| `Severity`       | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | The value is one of `debug`, `info`, `notice`, `warning`, `error`, or `critical`    |
+| `Syslog`         | Formatters                        | N/A                             | Formats a [syslog](#syslog) header.                                                 |
+| `TimeStamp`      | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | ISO 8601 extended format                                                            |
+| `TransactionId`  | transactions                      | `=`, `!=`                       |                                                                                     |
 
 ### Severity
 

--- a/libraries/net/include/psibase/blocknet.hpp
+++ b/libraries/net/include/psibase/blocknet.hpp
@@ -560,7 +560,7 @@ namespace psibase::net
              [this](const BlockInfo& head)
              {
                 {
-                   PSIBASE_LOG_CONTEXT_BLOCK(head.header, head.blockId);
+                   PSIBASE_LOG_CONTEXT_BLOCK(logger, head.header, head.blockId);
                    PSIBASE_LOG(logger, debug) << "New head block";
                 }
                 // TODO: only run set_producers when the producers actually changed

--- a/libraries/net/test/fuzz.hpp
+++ b/libraries/net/test/fuzz.hpp
@@ -339,9 +339,10 @@ struct NetworkBase
       auto expected = nodes[0]->node.chain().get_head_state()->blockId();
       for (const auto& node : nodes)
       {
-         auto state = node->node.chain().get_head_state();
-         PSIBASE_LOG_CONTEXT_BLOCK(state->info.header, state->blockId());
-         PSIBASE_LOG(node->node.chain().getLogger(), debug) << "final head block";
+         auto  state  = node->node.chain().get_head_state();
+         auto& logger = node->node.chain().getLogger();
+         PSIBASE_LOG_CONTEXT_BLOCK(logger, state->info.header, state->blockId());
+         PSIBASE_LOG(logger, debug) << "final head block";
          assert(node->node.chain().get_head_state()->blockId() == expected);
       }
    }

--- a/libraries/psibase/native/include/psibase/BlockContext.hpp
+++ b/libraries/psibase/native/include/psibase/BlockContext.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <psibase/Prover.hpp>
 #include <psibase/SystemContext.hpp>
+#include <psibase/log.hpp>
 #include <psibase/trace.hpp>
 
 namespace psibase
@@ -23,6 +24,8 @@ namespace psibase
       bool              active            = false;
       //
       std::map<AccountNumber, bool> modifiedAuthAccounts;
+
+      loggers::common_logger trxLogger;
 
       BlockContext(SystemContext&                  systemContext,
                    std::shared_ptr<const Revision> revision,

--- a/libraries/psibase/native/include/psibase/ForkDb.hpp
+++ b/libraries/psibase/native/include/psibase/ForkDb.hpp
@@ -425,7 +425,7 @@ namespace psibase
       const BlockHeaderState* insert(const psio::shared_view_ptr<SignedBlock>& b)
       {
          BlockInfo info(b->block());
-         PSIBASE_LOG_CONTEXT_BLOCK(info.header, info.blockId);
+         PSIBASE_LOG_CONTEXT_BLOCK(blockLogger, info.header, info.blockId);
          if (info.header.blockNum <= commitIndex)
          {
             PSIBASE_LOG(blockLogger, debug) << "Block ignored because it is before commitIndex";
@@ -578,7 +578,7 @@ namespace psibase
          assert(root->info.header.term <= currentTerm);
          if (root->invalid)
          {
-            PSIBASE_LOG_CONTEXT_BLOCK(root->info.header, root->blockId());
+            PSIBASE_LOG_CONTEXT_BLOCK(logger, root->info.header, root->blockId());
             PSIBASE_LOG(logger, critical) << "Consensus failure: invalid block " << reason;
             throw consensus_failure{};
          }
@@ -693,7 +693,7 @@ namespace psibase
          {
             if (new_head->blockNum() < commitIndex)
             {
-               PSIBASE_LOG_CONTEXT_BLOCK(new_head->info.header, new_head->blockId());
+               PSIBASE_LOG_CONTEXT_BLOCK(logger, new_head->info.header, new_head->blockId());
                PSIBASE_LOG(logger, critical)
                    << "Consensus failure: multiple conflicting forks confirmed";
                throw consensus_failure{};
@@ -729,7 +729,7 @@ namespace psibase
             }
             if (iter->first <= commitIndex)
             {
-               PSIBASE_LOG_CONTEXT_BLOCK(new_head->info.header, new_head->blockId());
+               PSIBASE_LOG_CONTEXT_BLOCK(logger, new_head->info.header, new_head->blockId());
                PSIBASE_LOG(logger, critical)
                    << "Consensus failure: multiple conflicting forks confirmed";
                throw consensus_failure{};
@@ -776,7 +776,7 @@ namespace psibase
          {
             BlockContext ctx(*systemContext, prev->revision, writer, false);
             auto         blockPtr = get(state->blockId());
-            PSIBASE_LOG_CONTEXT_BLOCK(state->info.header, state->blockId());
+            PSIBASE_LOG_CONTEXT_BLOCK(blockLogger, state->info.header, state->blockId());
             try
             {
                auto claim = validateBlockSignature(prev, state->info, blockPtr->signature());
@@ -1040,7 +1040,7 @@ namespace psibase
             byBlocknumIndex.insert({head->blockNum(), head->blockId()});
             auto proof = getBlockProof(revision, blockContext->current.header.blockNum);
             blocks.try_emplace(id, SignedBlock{blockContext->current, proof, makeData(head)});
-            PSIBASE_LOG_CONTEXT_BLOCK(blockContext->current.header, id);
+            PSIBASE_LOG_CONTEXT_BLOCK(blockLogger, blockContext->current.header, id);
             PSIBASE_LOG(blockLogger, info) << "Produced block";
             blockContext.reset();
             return head;
@@ -1134,12 +1134,12 @@ namespace psibase
                {
                   head = &state_iter->second;
                   assert(!!head->revision);
-                  PSIBASE_LOG_CONTEXT_BLOCK(info.header, info.blockId);
+                  PSIBASE_LOG_CONTEXT_BLOCK(logger, info.header, info.blockId);
                   PSIBASE_LOG(logger, debug) << "Read head block";
                }
             } while (blockNum--);
             const auto& info = states.begin()->second.info;
-            PSIBASE_LOG_CONTEXT_BLOCK(info.header, info.blockId);
+            PSIBASE_LOG_CONTEXT_BLOCK(logger, info.header, info.blockId);
             PSIBASE_LOG(logger, debug) << "Read last committed block";
          }
          // Initialize AuthState. This is a separate step because it needs

--- a/libraries/psibase/native/include/psibase/log.hpp
+++ b/libraries/psibase/native/include/psibase/log.hpp
@@ -85,22 +85,22 @@ namespace psibase
          std::shared_ptr<Impl> impl;
       };
 
-      inline auto scopedBlockHeader(const BlockHeader& header, const Checksum256& id)
+      inline auto scopedBlockHeader(auto& logger, const BlockHeader& header, const Checksum256& id)
       {
          BlockHeader result{header};
          result.authCode.reset();
          return std::tuple{
-             ::boost::log::add_scoped_thread_attribute(
-                 "BlockHeader", boost::log::attributes::constant<BlockHeader>(result)),
-             ::boost::log::add_scoped_thread_attribute(
-                 "BlockId", boost::log::attributes::constant< ::psibase::Checksum256>(id))};
+             ::boost::log::add_scoped_logger_attribute(
+                 logger, "BlockHeader", boost::log::attributes::constant<BlockHeader>(result)),
+             ::boost::log::add_scoped_logger_attribute(
+                 logger, "BlockId", boost::log::attributes::constant< ::psibase::Checksum256>(id))};
       }
 
    }  // namespace loggers
 
 #define PSIBASE_LOG(logger, log_level) BOOST_LOG_SEV(logger, psibase::loggers::level::log_level)
 
-#define PSIBASE_LOG_CONTEXT_BLOCK(header, id) \
-   auto _psibase_log_ctx = ::psibase::loggers::scopedBlockHeader(header, id)
+#define PSIBASE_LOG_CONTEXT_BLOCK(logger, header, id) \
+   auto _psibase_log_ctx = ::psibase::loggers::scopedBlockHeader(logger, header, id)
 
 }  // namespace psibase

--- a/libraries/psibase/native/src/log.cpp
+++ b/libraries/psibase/native/src/log.cpp
@@ -196,6 +196,11 @@ namespace psibase::loggers
             os << ",\"_block_header\":" << psio::convert_to_json(*attr);
          }
 
+         if (auto attr = boost::log::extract<Checksum256>("TransactionId", rec))
+         {
+            os << ",\"_transaction_id\":" << psio::convert_to_json(*attr);
+         }
+
          os << '}';
       };
 
@@ -275,6 +280,11 @@ namespace psibase::loggers
          if (auto attr = boost::log::extract<BlockHeader>("BlockHeader", rec))
          {
             os << ",\"BlockHeader\":" << psio::convert_to_json(*attr);
+         }
+
+         if (auto attr = boost::log::extract<Checksum256>("TransactionId", rec))
+         {
+            os << ",\"TransactionId\":" << psio::convert_to_json(*attr);
          }
 
          if (auto attr = boost::log::extract<std::string>("RequestMethod", rec))
@@ -2545,6 +2555,7 @@ namespace psibase::loggers
          add_attribute<std::chrono::system_clock::time_point>("TimeStamp");
          add_attribute<std::string>("RemoteEndpoint");
          add_attribute<Checksum256>("BlockId");
+         add_attribute<Checksum256>("TransactionId");
          add_attribute<std::string>("Process");
          add_attribute<std::string>("Channel");
          add_attribute<std::string>("Host");

--- a/programs/psinode/config.in
+++ b/programs/psinode/config.in
@@ -15,4 +15,4 @@ admin    = static:*
 [logger.stderr]
 type   = console
 filter = Severity >= info
-format = [{TimeStamp}] [{Severity}]{?: [{RemoteEndpoint}]}: {Message}{?: {BlockId}}{?RequestMethod:: {RequestMethod} {RequestHost}{RequestTarget}{?: {ResponseStatus}{?: {ResponseBytes}}}}{?: {ResponseTime} µs}
+format = [{TimeStamp}] [{Severity}]{?: [{RemoteEndpoint}]}: {Message}{?: {TransactionId}}{?: {BlockId}}{?RequestMethod:: {RequestMethod} {RequestHost}{RequestTarget}{?: {ResponseStatus}{?: {ResponseBytes}}}}{?: {ResponseTime} µs}


### PR DESCRIPTION
Block logging is modified to use a scoped logger attribute instead of a scoped thread attribute, so that the block header and block id are not inherited by the transaction logger.  When I originally wrote the block logging, I thought that including the BlockId and header in the transaction log would be useful, but after actually trying it, it just makes the logs more verbose.