### PR TITLE
VSCode service debugging - add launch.json.sample

### DIFF
--- a/.vscode/launch.json.sample
+++ b/.vscode/launch.json.sample
@@ -1,0 +1,93 @@
+{
+    // Make sure you build with -DCMAKE_BUILD_TYPE=Debug if you plan to debug.
+    // Always build psitest itself in Release or else it will be extra slow.
+
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Debug unit test",
+            "type": "cppdbg",
+            "MIMode": "gdb",
+            "request": "launch",
+
+            "program": "${workspaceFolder}/build/psidk/bin/psitest",
+            "cwd": "${workspaceFolder}/build",
+            "args": [
+                "${input:serviceName}-test-debug.wasm",
+                "-s",
+                "-r",
+                "compact"
+            ],
+            "stopAtEntry": false,
+            "miDebuggerPath": "/usr/bin/gdb",
+            "environment": [],
+            "externalConsole": false,
+
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                }
+            ]
+        },
+        {
+            "name": "(gdb) Debug unit test (w/Native debugging)",
+            "type": "cppdbg",
+            "MIMode": "gdb",
+            "request": "launch",
+
+            "program": "${workspaceFolder}/build/psidk/bin/psitest",
+            "cwd": "${workspaceFolder}/build",
+            "args": [
+                "${input:serviceName}-test-debug.wasm",
+                "-s",
+                "-r",
+                "compact"
+            ],
+            "stopAtEntry": false,
+            "miDebuggerPath": "/usr/bin/gdb",
+            "environment": [],
+            "externalConsole": false,
+
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Debug native",
+                    "text": "set hide-native off",
+                },
+            ]
+        }
+    ],
+    "inputs": [
+        {
+          "id": "serviceName",
+          "type":"promptString",
+          "description": "Name of the service to test",
+          "default": "TokenSys"
+        },
+      ]
+}
+
+// May want to add some path substitutions to gdb for better debugging:
+/*
+{
+    "description": "Map sources",
+    "text": "set substitute-path psidk-wasi-sdk: ${workspaceFolder}/build/wasi-sdk-prefix/src/wasi-sdk",
+    "ignoreFailures": false
+},
+{
+    "description": "Map sources",
+    "text": "set substitute-path psidk: ${workspaceFolder}/build/psidk",
+    "ignoreFailures": false
+}
+*/
+/*
+Q:  Why don't we use "sourceFileMap" above?
+A:  It appears to work at first, but then things fall apart when
+        you set breakpoints in some of the mapped files.
+        "set substitute-path" works better.
+*/

--- a/.vscode/tasks.json.sample
+++ b/.vscode/tasks.json.sample
@@ -18,7 +18,7 @@
         {
             "label": "Build Services",
             "type": "shell",
-            "command": "mkdir -p build && cd build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_DEBUG_WASM=ON -DBUILD_RUST=yes -DBUILD_DOC=no -DBUILD_JS=no -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=\"psidk\" .. && make install",
+            "command": "mkdir -p build && cd build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_DEBUG_WASM=ON -DBUILD_RUST=yes -DBUILD_DOC=no -DBUILD_JS=no -DBUILD_NATIVE=no -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=\"psidk\" .. && make install",
             "group": {
                 "kind": "build"
             },

--- a/services/user/CMakeLists.txt
+++ b/services/user/CMakeLists.txt
@@ -39,7 +39,7 @@ function(add_user_test_impl suffix name)
       ../../../system/TransactionSys/include
       ../../../system/VerifyEcSys/include
      ${CMAKE_CURRENT_LIST_DIR})
-    target_link_libraries(${TARGET} services_system${suffix} psitestlib)
+    target_link_libraries(${TARGET} services_system${suffix} psitestlib${suffix})
     set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
 endfunction()
 


### PR DESCRIPTION
Sample file that can be used to give vscode debug launch configurations using psitest