### PR TITLE
Split boot across multiple blocks. Fixes #239.

### DIFF
--- a/libraries/net/test/test_util.cpp
+++ b/libraries/net/test/test_util.cpp
@@ -115,17 +115,22 @@ void boot(BlockContext* ctx, const Consensus& producers, bool ec)
 
    pushTransaction(
        ctx,
-       Transaction{.tapos   = {.expiration = {ctx->current.header.time.seconds + 1}},
-                   .actions = {Action{.sender  = AccountSys::service,
-                                      .service = AccountSys::service,
-                                      .method  = MethodNumber{"init"},
-                                      .rawData = psio::to_frac(std::tuple())},
-                               Action{.sender  = TransactionSys::service,
-                                      .service = TransactionSys::service,
-                                      .method  = MethodNumber{"init"},
-                                      .rawData = psio::to_frac(std::tuple())},
-                               transactor<ProducerSys>(ProducerSys::service, ProducerSys::service)
-                                   .setConsensus(producers)}});
+       Transaction{
+           .tapos   = {.expiration = {ctx->current.header.time.seconds + 1}},
+           .actions = {Action{.sender  = TransactionSys::service,
+                              .service = TransactionSys::service,
+                              .method  = MethodNumber{"startBoot"},
+                              .rawData = psio::to_frac(std::tuple(std::vector<Checksum256>()))},
+                       Action{.sender  = AccountSys::service,
+                              .service = AccountSys::service,
+                              .method  = MethodNumber{"init"},
+                              .rawData = psio::to_frac(std::tuple())},
+                       transactor<ProducerSys>(ProducerSys::service, ProducerSys::service)
+                           .setConsensus(producers),
+                       Action{.sender  = TransactionSys::service,
+                              .service = TransactionSys::service,
+                              .method  = MethodNumber{"finishBoot"},
+                              .rawData = psio::to_frac(std::tuple())}}});
 }
 
 static Tapos getTapos(const BlockInfo& info)

--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -333,6 +333,9 @@ namespace psibase
       }
       catch (const std::exception& e)
       {
+         BOOST_LOG_SCOPED_THREAD_TAG("TransactionId",
+                                     sha256(trx.transaction.data(), trx.transaction.size()));
+         PSIBASE_LOG(trxLogger, info) << "Transaction check first auth failed";
          trace.error = e.what();
          throw;
       }

--- a/libraries/psibase/tester/src/DefaultTestChain.cpp
+++ b/libraries/psibase/tester/src/DefaultTestChain.cpp
@@ -225,7 +225,7 @@ void DefaultTestChain::createSysServiceAccounts(bool show /* = false */)
 {
    transactor<AccountSys>     asys{TransactionSys::service, AccountSys::service};
    transactor<TransactionSys> tsys{TransactionSys::service, TransactionSys::service};
-   auto trace = pushTransaction(makeTransaction({asys.init(), tsys.init()}), {});
+   auto trace = pushTransaction(makeTransaction({asys.init(), tsys.finishBoot()}), {});
 
    check(psibase::show(show, trace) == "", "Failed to create system service accounts");
 }
@@ -333,7 +333,7 @@ void DefaultTestChain::registerSysRpc()
    transactor<ExploreSys>  rpcExplore(ExploreSys::service, ExploreSys::service);
    transactor<RAuthEcSys>  rpcAuthEc(RAuthEcSys::service, RAuthEcSys::service);
    transactor<PsiSpaceSys> rpcPsiSpace(PsiSpaceSys::service, PsiSpaceSys::service);
-   transactor<RTokenSys>    rpcToken(RTokenSys::service, RTokenSys::service);
+   transactor<RTokenSys>   rpcToken(RTokenSys::service, RTokenSys::service);
 
    // Store UI files
    std::string cdir      = "../services";
@@ -471,8 +471,10 @@ void DefaultTestChain::registerSysRpc()
        rpcToken.storeSys("/index.js", js, readWholeFile(tokDir + "/ui/dist/index.js")),
        rpcToken.storeSys("/style.css", css, readWholeFile(tokDir + "/ui/dist/style.css")),
        rpcToken.storeSys("/loader.svg", svg, readWholeFile(tokDir + "/ui/dist/loader.svg")),
-       rpcToken.storeSys("/app-wallet-icon.svg", svg, readWholeFile(tokDir + "/ui/dist/app-wallet-icon.svg")),
-       rpcToken.storeSys("/arrow-up-solid.svg", svg, readWholeFile(tokDir + "/ui/dist/arrow-up-solid.svg")),
+       rpcToken.storeSys("/app-wallet-icon.svg", svg,
+                         readWholeFile(tokDir + "/ui/dist/app-wallet-icon.svg")),
+       rpcToken.storeSys("/arrow-up-solid.svg", svg,
+                         readWholeFile(tokDir + "/ui/dist/arrow-up-solid.svg")),
    };
 
    trace = pushTransaction(makeTransaction(std::move(b)));

--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -1873,13 +1873,13 @@ void run(const std::string&              db_path,
    // TODO: post the transactions to chainContext rather than batching them at fixed intervals.
    auto process_transactions = [&](const std::error_code& ec)
    {
-      std::vector<transaction_queue::entry> entries;
-      {
-         std::scoped_lock lock{queue->mutex};
-         std::swap(entries, queue->entries);
-      }
       auto fail_all = [&](const std::string& message)
       {
+         std::vector<transaction_queue::entry> entries;
+         {
+            std::scoped_lock lock{queue->mutex};
+            std::swap(entries, queue->entries);
+         }
          {
             std::lock_guard lock{transactionStatsMutex};
             transactionStats.unprocessed -= entries.size();
@@ -1904,6 +1904,29 @@ void run(const std::string&              db_path,
       }
       else if (auto bc = node.chain().getBlockContext())
       {
+         std::vector<transaction_queue::entry> entries;
+         if (bc->needGenesisAction)
+         {
+            // Only process up to the genesis transaction
+            std::scoped_lock lock{queue->mutex};
+            auto             pos = std::ranges::find_if(queue->entries,
+                                                        [](const auto& entry) { return entry.is_boot; });
+            if (pos != queue->entries.end())
+               ++pos;
+            std::ranges::move(queue->entries.begin(), pos, std::back_inserter(entries));
+            queue->entries.erase(queue->entries.begin(), pos);
+         }
+         else if (bc->current.header.previous != Checksum256{})
+         {
+            std::scoped_lock lock{queue->mutex};
+            std::swap(entries, queue->entries);
+         }
+         else
+         {
+            // The genesis transaction has already been executed, but we're still
+            // building the genesis block. Wait for the next block before pushing
+            // any transactions.
+         }
          auto revisionAtBlockStart = node.chain().getHeadRevision();
          for (auto& entry : entries)
          {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -229,10 +229,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.10.0"
+name = "bitcoin-private"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
 
 [[package]]
 name = "bitflags"
@@ -2276,9 +2285,9 @@ checksum = "6361289ce24413f5d608ca31c66fb1c9ce78df14e1f86488f7f8d6f14398e8ea"
 
 [[package]]
 name = "secp256k1"
-version = "0.22.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes",
  "secp256k1-sys",
@@ -2286,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.5.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]

--- a/rust/psibase/Cargo.toml
+++ b/rust/psibase/Cargo.toml
@@ -27,5 +27,5 @@ serde_json = "1.0"
 clap = {version = "3.1", features = ["derive", "env"]}
 indicatif = "0.17"
 reqwest = { version = "0.11", default-features = false, features = ["json","rustls-tls"] }
-secp256k1 = { version="0.22", features = ["global-context", "bitcoin_hashes"] }
+secp256k1 = { version="0.27", features = ["global-context", "bitcoin_hashes"] }
 tokio = { version = "1", features = ["full"] }

--- a/rust/psibase/src/services/transaction_sys.rs
+++ b/rust/psibase/src/services/transaction_sys.rs
@@ -173,6 +173,15 @@ pub mod auth_interface {
 mod service {
     use crate::Hex;
 
+    /// Only called once, immediately after the boot transaction.
+    ///
+    /// The subsequent transactions listed must be pushed in order, and no
+    /// other transactions will be accepted until finishBoot is run.
+    #[action]
+    fn startBoot(bootTransactions: Vec<crate::Checksum256>) {
+        unimplemented!();
+    }
+
     /// Only called once during chain initialization
     ///
     /// This enables the auth checking system. Before this point, `transaction_sys`
@@ -181,7 +190,7 @@ mod service {
     /// [checkAuthSys](crate::services::transaction_sys::AuthActions::checkAuthSys)
     /// to authenticate top-level actions and uses of [runAs](Self::runAs).
     #[action]
-    fn init() {
+    fn finishBoot() {
         unimplemented!()
     }
 


### PR DESCRIPTION
- push_boot gets two transactions, the genesis transaction, and a transaction that initializes TransactionSys with a list of the remaining boot transactions ids.  The rest of the boot transactions are pushed with push_transaction.
- TransactionSys enforces that the extra boot transactions are pushed in order.
- psinode defers handling non-push_boot transactions until after the genesis block.
