### PR TITLE
add gdbinit commands relative to workspace

### DIFF
--- a/.vscode/launch.json.sample
+++ b/.vscode/launch.json.sample
@@ -30,11 +30,11 @@
                 },
                 {
                     "description": "Add directory from which to load auto-loaded gdb scripts",
-                    "text": "add-auto-load-scripts-directory ${workspaceFolder}/build/psidk/lib/debug/",
+                    "text": "add-auto-load-scripts-directory ${workspaceFolder}/build/psidk/share/gdb/auto-load/",
                 },
                 {
                     "description": "Add a directory from which it is safe to auto-load a file",
-                    "text": "add-auto-load-safe-path ${workspaceFolder}/build/psidk/lib/debug/",
+                    "text": "add-auto-load-safe-path ${workspaceFolder}/build/psidk/share/gdb/auto-load/",
                 }
             ]
         },

--- a/.vscode/launch.json.sample
+++ b/.vscode/launch.json.sample
@@ -27,6 +27,14 @@
                 {
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
+                },
+                {
+                    "description": "Add directory from which to load auto-loaded gdb scripts",
+                    "text": "add-auto-load-scripts-directory ${workspaceFolder}/build/psidk/lib/debug/",
+                },
+                {
+                    "description": "Add a directory from which it is safe to auto-load a file",
+                    "text": "add-auto-load-safe-path ${workspaceFolder}/build/psidk/lib/debug/",
                 }
             ]
         },
@@ -59,6 +67,14 @@
                     "description": "Debug native",
                     "text": "set hide-native off",
                 },
+                {
+                    "description": "Add directory from which to load auto-loaded gdb scripts",
+                    "text": "add-auto-load-scripts-directory ${workspaceFolder}/build/psidk/lib/debug/",
+                },
+                {
+                    "description": "Add a directory from which it is safe to auto-load a file",
+                    "text": "add-auto-load-safe-path ${workspaceFolder}/build/psidk/lib/debug/",
+                }
             ]
         }
     ],


### PR DESCRIPTION
In .gdbinit I had `add-auto-load-safe-path /root/psibase/build/psidk/lib/debug/psitest-gdb.py`
But here I changed it to `add-auto-load-safe-path /root/psibase/build/psidk/lib/debug/`, because it's supposed to add a safe dir. 
