### PR TITLE
Fix setting non-transient peer connections

### DIFF
--- a/services/user/AdminSys/ui/src/peers/peers-page.tsx
+++ b/services/user/AdminSys/ui/src/peers/peers-page.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { Button, Form } from "../components";
 import { PsinodeConfig } from "../configuration/interfaces";
-import { writeConfig } from "../configuration/utils";
 import { putJson } from "../helpers";
 import {
     AddConnectionInputs,
@@ -66,10 +65,7 @@ export const PeersPage = ({
     const setConfigPeers = async (input: PsinodeConfig) => {
         try {
             setConfigPeersError(undefined);
-            const result = await putJson(
-                "/native/admin/config",
-                writeConfig(input)
-            );
+            const result = await putJson("/native/admin/config", input);
             if (result.ok) {
                 // TODO: revisit
                 // configForm.resetField("peers", { defaultValue: input.peers });


### PR DESCRIPTION
`writeConfig` reverses the transformations applied by `resolveConfigFormDiff`. Since the peers page sees the unmodified json returned from `/native/admin/config`, it MUST NOT use `writeConfig`.