### PR TITLE
Update 20.04 image

### DIFF
--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -9,7 +9,7 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled]
 
 env:
-  UBUNTU_2004_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2004-builder:3423d5e152f9f060d013866621d3541fe8340305"
+  UBUNTU_2004_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2004-builder:9455b1e6e0e2fb00aa8a94c93ef28ed07d205bc6"
 
 jobs:
   ubuntu-2004-build:

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -9,7 +9,7 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled]
 
 env:
-  UBUNTU_2004_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2004-builder:2b11e9bfdd41b3ba01a905f972444b5d76afc4ab"
+  UBUNTU_2004_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2004-builder:3423d5e152f9f060d013866621d3541fe8340305"
 
 jobs:
   ubuntu-2004-build:

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -9,7 +9,7 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled]
 
 env:
-  UBUNTU_2204_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2204-builder:333817a3ad5d99bb1e8fc5a6c1b6b845223e3451"
+  UBUNTU_2204_IMAGE: "ghcr.io/gofractally/internal-ubuntu-2204-builder:9455b1e6e0e2fb00aa8a94c93ef28ed07d205bc6"
 
 jobs:
   ubuntu-2204-build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ if(DEFINED WASI_SDK_PREFIX)
     install(DIRECTORY ${WASI_SDK_PREFIX}/ USE_SOURCE_PERMISSIONS DESTINATION . COMPONENT WASI EXCLUDE_FROM_ALL FILES_MATCHING PATTERN libc.a EXCLUDE)
 elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux")
     ExternalProject_Add(wasi-sdk
-        URL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz
-        URL_HASH SHA256=8778a476af7898a51db9b78395687cc9c8b69702850da77a763711e832614dac
+        URL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz
+        URL_HASH SHA256=d900abc826eec1955b9afd250e7cc2496338abbf6c440d86a313c06e42083fa1
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""


### PR DESCRIPTION
The new image uses wasi-sdk-~17~19.0. 14.0 appears to not work quite right with simd enabled. 17.0 doesn't support ubuntu 20.