### PR TITLE
Fix wasm cache

### DIFF
--- a/libraries/psibase/native/src/ExecutionContext.cpp
+++ b/libraries/psibase/native/src/ExecutionContext.cpp
@@ -105,7 +105,7 @@ namespace psibase
 
       BackendEntry get(const Checksum256& hash, const VMOptions& vmOptions)
       {
-         BackendEntry                result;
+         BackendEntry                result{hash, vmOptions};
          std::lock_guard<std::mutex> lock{mutex};
          auto&                       ind = backends.get<ByHash>();
          auto                        it  = ind.find(std::tie(hash, vmOptions));


### PR DESCRIPTION
The key that was inserted in the cache was uninitialized which mostly prevented modules from being reused, but sometimes also used the wrong module.