### PR TITLE
add build bash script, use from workflow

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -29,7 +29,7 @@ echo max_size = 600M >${WORKSPACE_ROOT}/ccache.conf
 echo log_file = ${WORKSPACE_ROOT}/ccache.log >>${WORKSPACE_ROOT}/ccache.conf
 export SCCACHE_CACHE_SIZE=200M
 export RUSTC_WRAPPER=sccache
-export DOCKER="docker run --rm \
+DOCKER="docker run --rm \
   -v ${WORKSPACE_ROOT}:${WORKSPACE_ROOT} \
   -w ${WORKSPACE_ROOT} \
   -e CCACHE_DIR \
@@ -40,16 +40,6 @@ export DOCKER="docker run --rm \
   -e WASM_PACK_CACHE=.wasm-pack-cache \
   --user $(id -u):$(id -g) \
   ${BUILDER_IMAGE}"
-export DOCKER_ROOT="docker run --rm \
-  -v ${WORKSPACE_ROOT}:${WORKSPACE_ROOT} \
-  -w ${WORKSPACE_ROOT} \
-  -e CCACHE_DIR \
-  -e CCACHE_CONFIGPATH \
-  -e SCCACHE_DIR \
-  -e SCCACHE_CACHE_SIZE \
-  -e RUSTC_WRAPPER \
-  -e WASM_PACK_CACHE=.wasm-pack-cache \
-  ${BUILDER_IMAGE}"
 
 docker pull ${BUILDER_IMAGE}
 echo =====
@@ -57,7 +47,7 @@ ${DOCKER} ccache -s
 echo =====
 ${DOCKER} sccache -s
 echo =====
-mkdir build
+mkdir -p build
 ${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_WASM=yes -DBUILD_DEBUG_WASM=yes -DBUILD_DOC=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
 echo =====
 ${DOCKER} bash -c "cd build && make -j $(nproc)"

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+WORKSPACE_ROOT=$1
+BUILDER_IMAGE=$2
+UBUNTU_BUILD_VER=$3
+
+set -e
+
+if [ -z "$WORKSPACE_ROOT" ]; then
+  echo "Error: WORKSPACE_ROOT is not set."
+  exit 1
+fi
+
+if [ -z "$BUILDER_IMAGE" ]; then
+  echo "Error: BUILDER_IMAGE is not set."
+  exit 1
+fi
+
+if [ -z "$UBUNTU_BUILD_VER" ]; then
+  echo "Error: UBUNTU_BUILD_VER is not set."
+  exit 1
+fi
+
+cd ${WORKSPACE_ROOT}
+git submodule update --init --recursive
+export CCACHE_DIR=${WORKSPACE_ROOT}/.caches/ccache
+export SCCACHE_DIR=${WORKSPACE_ROOT}/.caches/sccache
+export CCACHE_CONFIGPATH=${WORKSPACE_ROOT}/ccache.conf
+echo max_size = 600M >${WORKSPACE_ROOT}/ccache.conf
+echo log_file = ${WORKSPACE_ROOT}/ccache.log >>${WORKSPACE_ROOT}/ccache.conf
+export SCCACHE_CACHE_SIZE=200M
+export RUSTC_WRAPPER=sccache
+export DOCKER="docker run --rm \
+  -v ${WORKSPACE_ROOT}:${WORKSPACE_ROOT} \
+  -w ${WORKSPACE_ROOT} \
+  -e CCACHE_DIR \
+  -e CCACHE_CONFIGPATH \
+  -e SCCACHE_DIR \
+  -e SCCACHE_CACHE_SIZE \
+  -e RUSTC_WRAPPER \
+  -e WASM_PACK_CACHE=.wasm-pack-cache \
+  --user $(id -u):$(id -g) \
+  ${BUILDER_IMAGE}"
+export DOCKER_ROOT="docker run --rm \
+  -v ${WORKSPACE_ROOT}:${WORKSPACE_ROOT} \
+  -w ${WORKSPACE_ROOT} \
+  -e CCACHE_DIR \
+  -e CCACHE_CONFIGPATH \
+  -e SCCACHE_DIR \
+  -e SCCACHE_CACHE_SIZE \
+  -e RUSTC_WRAPPER \
+  -e WASM_PACK_CACHE=.wasm-pack-cache \
+  ${BUILDER_IMAGE}"
+
+docker pull ${BUILDER_IMAGE}
+echo =====
+${DOCKER} ccache -s
+echo =====
+${DOCKER} sccache -s
+echo =====
+mkdir build
+${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_WASM=yes -DBUILD_DEBUG_WASM=yes -DBUILD_DOC=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
+echo =====
+${DOCKER} bash -c "cd build && make -j $(nproc)"
+echo =====
+${DOCKER} bash -c "cd build && ctest --output-on-failure -j $(nproc)"
+echo =====
+ls -la ${WORKSPACE_ROOT}
+ls -la ${WORKSPACE_ROOT}/build/doc/psidk
+echo =====
+${DOCKER} ccache -s
+echo =====
+${DOCKER} sccache -s
+echo =====
+${DOCKER} bash -c "cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME=psidk-ubuntu-${UBUNTU_BUILD_VER}"
+echo =====
+${DOCKER} bash -c "cd build && mv book psidk-book && tar czf ../psidk-book.tar.gz psidk-book"

--- a/.github/workflows/ubuntu-builder.yml
+++ b/.github/workflows/ubuntu-builder.yml
@@ -32,46 +32,7 @@ jobs:
           restore-keys: |
             $ubuntu-${{ matrix.ubuntu-version }}-caches-
       - name: Build
-        run: |
-          set -e
-          echo =====
-          mkdir -p $HOME/.ssh
-          chmod 700 $HOME/.ssh
-          git submodule update --init --recursive
-          echo =====
-          export CCACHE_DIR=${GITHUB_WORKSPACE}/.caches/ccache
-          export SCCACHE_DIR=${GITHUB_WORKSPACE}/.caches/sccache
-          export CCACHE_CONFIGPATH=${GITHUB_WORKSPACE}/ccache.conf
-          echo max_size = 600M >${GITHUB_WORKSPACE}/ccache.conf
-          echo log_file = ${GITHUB_WORKSPACE}/ccache.log >>${GITHUB_WORKSPACE}/ccache.conf
-          export SCCACHE_CACHE_SIZE=200M
-          export RUSTC_WRAPPER=sccache
-          export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} -e CCACHE_DIR -e CCACHE_CONFIGPATH -e SCCACHE_DIR -e SCCACHE_CACHE_SIZE -e RUSTC_WRAPPER -e WASM_PACK_CACHE=.wasm-pack-cache --user $(id -u):$(id -g) ${{ matrix.builder-image }}"
-          export DOCKER_ROOT="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} -e CCACHE_DIR -e CCACHE_CONFIGPATH -e SCCACHE_DIR -e SCCACHE_CACHE_SIZE -e RUSTC_WRAPPER -e WASM_PACK_CACHE=.wasm-pack-cache ${{ matrix.builder-image }}"
-
-          docker pull ${{ matrix.builder-image }}
-          echo =====
-          ${DOCKER} ccache -s
-          echo =====
-          ${DOCKER} sccache -s
-          echo =====
-          mkdir build
-          ${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_WASM=yes -DBUILD_DEBUG_WASM=yes -DBUILD_DOC=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
-          echo =====
-          ${DOCKER} bash -c "cd build && make -j $(nproc)"
-          echo =====
-          ${DOCKER} bash -c "cd build && ctest --output-on-failure -j $(nproc)"
-          echo =====
-          ls -la ${GITHUB_WORKSPACE}
-          ls -la ${GITHUB_WORKSPACE}/build/doc/psidk
-          echo =====
-          ${DOCKER} ccache -s
-          echo =====
-          ${DOCKER} sccache -s
-          echo =====
-          ${DOCKER} bash -c "cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME=psidk-ubuntu-${{ matrix.ubuntu-version }}"
-          echo =====
-          ${DOCKER} bash -c "cd build && mv book psidk-book && tar czf ../psidk-book.tar.gz psidk-book"
+        run: bash ${GITHUB_WORKSPACE}/.github/scripts/build.sh ${GITHUB_WORKSPACE} ${{ matrix.builder-image }} ${{ matrix.ubuntu-version }}
       - name: Upload psidk-ubuntu-${{ matrix.ubuntu-version }}
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Extracts into a bash script the functionality from the github workflow that mounts the source into a docker container for building. Github workflow calls the new script.

Script can also be reused outside CI/CD context to more easily reproduce the ci/cd build locally.