### PR TITLE
Fix simpleUI

### DIFF
--- a/rust/psibase/src/boot.rs
+++ b/rust/psibase/src/boot.rs
@@ -325,6 +325,13 @@ pub fn get_initial_actions(
             store_third_party!("htm.module.js", js),
             store_third_party!("iframeResizer.contentWindow.js", js),
             store_third_party!("iframeResizer.js", js),
+            store_third_party!("react-dom.development.js", js),
+            store_third_party!("react-dom.production.min.js", js),
+            store_third_party!("react-router-dom.min.js", js),
+            store_third_party!("react.development.js", js),
+            store_third_party!("react.production.min.js", js),
+            store_third_party!("semantic-ui-react.min.js", js),
+            store_third_party!("useLocalStorageState.js", js),
         ];
 
         let mut account_sys_files = vec![];


### PR DESCRIPTION
This closes #504 by restoring the third-party dependencies that were removed. We can clean up third-party dependencies as a separate effort later.

Tested simpleUI working with this change by visiting the proxy-sys service UI.