### PR TITLE
Reduce log severity when psinode can't lock db memory

### DIFF
--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -1437,7 +1437,7 @@ void run(const std::string&              db_path,
 
    if (system->sharedDatabase.isSlow())
    {
-      PSIBASE_LOG(psibase::loggers::generic::get(), error)
+      PSIBASE_LOG(psibase::loggers::generic::get(), warning)
           << "unable to lock memory for " << db_path
           << ". Try upgrading your shell's limits using \"sudo prlimit --memlock=-1 --pid "
              "$$\". "


### PR DESCRIPTION
It's not really an error, psinode can still run, albeit slower, without locking db memory. Log severity therefore has been reduced from `error` to `warning`.
