### PR TITLE
Fix bug in test case

### DIFF
--- a/libraries/net/test/test_bft_consensus.cpp
+++ b/libraries/net/test/test_bft_consensus.cpp
@@ -27,6 +27,7 @@ TEST_CASE("bft crash", "[bft]")
    TEST_START(logger);
 
    boost::asio::io_context ctx;
+   auto                    work = boost::asio::make_work_guard(ctx);
    NodeSet<node_type>      nodes(ctx);
 
    setup<BftConsensus>(nodes, {"a", "b", "c", "d"});


### PR DESCRIPTION
The `io_context` can stop if all the nodes are disconnected, which causes subsequent connect to not work. This is only a problem in the test. In psinode itself, there's always something to keep the io_context alive.