### PR TITLE
Add 'no-notes' label for excluding from release notes

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -29,6 +29,7 @@ env:
             {
               "template": "# Release Notes\n#{{CHANGELOG}}\n\n## 📦 Uncategorized\n\n#{{UNCATEGORIZED}}\n\n# Associated docker images\n\nDocker images for this release of the psinode and psibase tools are available in GitHub container registry.\n* [psinode](https://github.com/orgs/${{ github.repository_owner }}/packages/container/package/psinode)\n* [psibase](https://github.com/orgs/${{ github.repository_owner }}/packages/container/package/psibase)\n",
               "pr_template": "- [(PR ##{{NUMBER}})](#{{URL}})  |  #{{TITLE}}",
+              "ignore_labels": ["no-notes"],
               "categories": [
                 {
                     "title": "## 💻 App development",


### PR DESCRIPTION
If this label is added to PRs and issues, the release notes generator should ignore it.