### PR TITLE
PKCS #11 support for psibase

### DIFF
--- a/doc/psidk/src/run-infrastructure/cli/psibase.md
+++ b/doc/psidk/src/run-infrastructure/cli/psibase.md
@@ -30,7 +30,10 @@ psibase - The psibase blockchain command line client
 
 - `-s`, `--sign` *private-key*
 
-  Sign transactions with this key
+  Sign transactions with this key. The key can be in any of the following forms:
+  - A file containing a PEM or DER encoded private key
+  - A PKCS #11 URI
+  - An EOS style base58-encoded private key beginning `PVT_K1_`
 
 ## COMMANDS
 
@@ -42,7 +45,10 @@ The boot command deploys a set of system services and web interfaces suitable fo
 
 - `-k`, `--key` *public-key*
 
-  Set all accounts to authenticate using this key. The key will also be used for block production. If no key is provided, the accounts will not require authentication.
+  Set all accounts to authenticate using this key. The key will also be used for block production. If no key is provided, the accounts will not require authentication. The public key can be any of the following:
+  - A file containing a PEM or DER encoded public key
+  - A PKCS #11 URI
+  - An EOS style base58-encoded public key beginning `PUB_K1_`
 
 - `-p`, `--producer` *name*
 
@@ -60,7 +66,10 @@ Create or modify an account
 
 - `-k`, `--key` *public-key*
 
-  Set the account to authenticate using this key. Also works if the account already exists.
+  Set the account to authenticate using this key. Also works if the account already exists.The public key can be any of the following:
+  - A file containing a PEM or DER encoded public key
+  - A PKCS #11 URI
+  - An EOS style base58-encoded public key beginning `PUB_K1_`
 
 - `-S`, `--sender` *account*
 
@@ -108,7 +117,10 @@ Modify an account
   
 - `-k`, `--key`
 
-  Set the account to authenticate using this key
+  Set the account to authenticate using this key. The public key can be any of the following:
+  - A file containing a PEM or DER encoded public key
+  - A PKCS #11 URI
+  - An EOS style base58-encoded public key beginning `PUB_K1_`
 
 ### upload
 

--- a/doc/psidk/src/run-infrastructure/cli/psibase.md
+++ b/doc/psidk/src/run-infrastructure/cli/psibase.md
@@ -66,7 +66,7 @@ Create or modify an account
 
 - `-k`, `--key` *public-key*
 
-  Set the account to authenticate using this key. Also works if the account already exists.The public key can be any of the following:
+  Set the account to authenticate using this key. Also works if the account already exists. The public key can be any of the following:
   - A file containing a PEM or DER encoded public key
   - A PKCS #11 URI
   - An EOS style base58-encoded public key beginning `PUB_K1_`

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -692,6 +692,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptoki"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3aed61f60e4bd9d2adb4903090bdd46a672830cad37246100ab1f2ffbe5f95"
+dependencies = [
+ "bitflags 1.3.2",
+ "cryptoki-sys",
+ "libloading",
+ "log",
+ "paste",
+ "secrecy",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a978e5e226446ac68eded4f92796947130f0d21de1e21bf80298f9f50d917d5"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "custom_error"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1606,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2271,8 @@ dependencies = [
  "async-graphql",
  "chrono",
  "clap 3.2.25",
+ "cryptoki",
+ "cryptoki-sys",
  "custom_error",
  "der",
  "fracpack",
@@ -2248,6 +2283,7 @@ dependencies = [
  "indicatif",
  "jwt",
  "mime_guess",
+ "percent-encoding",
  "pkcs8",
  "psibase_macros",
  "psibase_names",
@@ -2262,7 +2298,9 @@ dependencies = [
  "serde_json",
  "sha2",
  "spki",
+ "subprocess",
  "tokio",
+ "url",
  "wasm-bindgen",
 ]
 
@@ -2673,6 +2711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +2941,16 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subprocess"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "subtle"

--- a/rust/psibase/Cargo.toml
+++ b/rust/psibase/Cargo.toml
@@ -22,6 +22,7 @@ getrandom = { version = "0.2", features = ["js"] }
 include_dir = "0.7.3"
 sha2 = "0.10"
 mime_guess = "2.0"
+percent-encoding = "2.3"
 psibase_macros = { path = "../psibase_macros" }
 psibase_names = { path = "../psibase_names" }
 ripemd = "0.1"
@@ -33,6 +34,7 @@ wasm-bindgen = "0.2"
 sec1 = "0.7"
 spki = "0.7"
 der = { version = "0.7", features = ["alloc", "pem", "std"] }
+url = "2.4"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 clap = {version = "3.1", features = ["derive", "env"]}
@@ -45,3 +47,6 @@ secp256k1 = { version="0.27", features = ["global-context", "bitcoin_hashes"] }
 sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 pkcs8 = { version = "0.10", features = ["pem"] }
+subprocess = "0.2"
+cryptoki = "0.6"
+cryptoki-sys = "0.1"

--- a/rust/psibase/src/boot.rs
+++ b/rust/psibase/src/boot.rs
@@ -458,7 +458,7 @@ pub fn get_initial_actions(
     if let Some(k) = initial_key {
         for account in ACCOUNTS {
             actions.push(set_key_action(account, k));
-            actions.push(set_auth_service_action(account, auth_ec_sys::SERVICE));
+            actions.push(set_auth_service_action(account, k.auth_service()));
         }
     }
 

--- a/rust/psibase/src/crypto.rs
+++ b/rust/psibase/src/crypto.rs
@@ -5,9 +5,42 @@ use std::{fmt, str::FromStr};
 
 use der::asn1::{AnyRef, BitStringRef};
 #[cfg(not(target_family = "wasm"))]
-use der::{asn1::ObjectIdentifier, Decode, Encode};
+use der::{
+    asn1::{ObjectIdentifier, OctetStringRef},
+    Decode, Encode,
+};
 #[cfg(not(target_family = "wasm"))]
 use spki::SubjectPublicKeyInfo;
+
+#[cfg(not(target_family = "wasm"))]
+use sha2::Sha256;
+
+#[cfg(not(target_family = "wasm"))]
+use subprocess::{Exec, Redirection};
+
+#[cfg(not(target_family = "wasm"))]
+use cryptoki::{
+    context::{CInitializeArgs, Pkcs11},
+    mechanism::Mechanism,
+    object::{Attribute, AttributeType, KeyType, ObjectClass, ObjectHandle},
+    session::{Session, SessionState, UserType},
+    slot::{Slot, SlotInfo, TokenInfo},
+    types::{AuthPin, RawAuthPin, Version},
+};
+#[cfg(not(target_family = "wasm"))]
+use cryptoki_sys::CK_VERSION;
+
+#[cfg(not(target_family = "wasm"))]
+use std::{
+    collections::{hash_map, HashMap},
+    mem::MaybeUninit,
+    sync::{Arc, Mutex, Once},
+};
+
+#[cfg(not(target_family = "wasm"))]
+use percent_encoding::percent_decode_str;
+#[cfg(not(target_family = "wasm"))]
+use url::Url;
 
 use crate::{account_raw, AccountNumber};
 
@@ -17,6 +50,11 @@ custom_error! {
     InvalidKey          = "Invalid key",
     ExpectedPublicKey   = "Expected public key",
     ExpectedPrivateKey  = "Expected private key",
+    InvalidPKCS11URI    = "Invalid PKCS #11 URI",
+    NoMatchingKey       = "Key not found",
+    PublicKeyNotFound   = "Public key not found",
+    KeyTypeNotSupported = "Key type not supported",
+    BadPinSource        = "Cannot interpret pin-source",
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -357,6 +395,283 @@ impl Signer for PKCS8PrivateKeyK1 {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
+#[derive(Debug)]
+struct PKCS11PrivateKey {
+    session: Arc<Mutex<Session>>,
+    key: ObjectHandle,
+    pubkey: Vec<u8>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn extract_first<T>(mut v: Vec<T>) -> Result<T, Error> {
+    v.truncate(1);
+    if let Some(result) = v.pop() {
+        Ok(result)
+    } else {
+        Err(Error::PublicKeyNotFound)
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn get_ec_public_key_der(session: &Session, key: ObjectHandle) -> Result<Vec<u8>, anyhow::Error> {
+    let attrs = session.get_attributes(key, &[AttributeType::EcParams, AttributeType::EcPoint])?;
+    let [Attribute::EcParams(params), Attribute::EcPoint(point)] = &attrs[..] else {
+        return Err(Error::PublicKeyNotFound)?;
+    };
+
+    let algid = spki::AlgorithmIdentifier {
+        oid: OID_ECDSA,
+        parameters: Some(ObjectIdentifier::from_der(&params)?),
+    };
+    Ok(Encode::to_der(&SubjectPublicKeyInfo {
+        algorithm: algid,
+        subject_public_key: BitStringRef::from_bytes(OctetStringRef::from_der(&point)?.as_bytes())?,
+    })?)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn get_public_key_der(session: &Session, key: ObjectHandle) -> Result<Vec<u8>, anyhow::Error> {
+    match session.get_attributes(key, &[AttributeType::Class, AttributeType::KeyType])?[..] {
+        [Attribute::Class(ObjectClass::PUBLIC_KEY), Attribute::KeyType(KeyType::EC)] => {
+            get_ec_public_key_der(session, key)
+        }
+        _ => Err(Error::KeyTypeNotSupported)?,
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn lookup_public_key(session: &Session, key: ObjectHandle) -> Result<ObjectHandle, anyhow::Error> {
+    let id = extract_first(session.get_attributes(key, &[AttributeType::Id])?)?;
+    Ok(extract_first(session.find_objects(&[
+        id,
+        Attribute::Class(ObjectClass::PUBLIC_KEY),
+    ])?)?)
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl Signer for PKCS11PrivateKey {
+    fn get_claim(&self) -> crate::Claim {
+        crate::Claim {
+            service: AccountNumber::new(account_raw!("verify-sys")),
+            rawData: crate::Hex::from(self.pubkey.clone()),
+        }
+    }
+    fn sign(&self, data: &[u8]) -> Vec<u8> {
+        let digest = Sha256::digest(data);
+        let session = self.session.lock().unwrap();
+        session.sign(&Mechanism::Ecdsa, self.key, &digest).unwrap()
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+struct PKCS11URI {
+    // query
+    pin_value: Option<String>,
+    pin_source: Option<String>,
+    module_path: Option<String>,
+    module_name: Option<String>,
+    // library
+    library_description: Option<String>,
+    library_manufacturer: Option<String>,
+    library_version: Option<Version>,
+    // slot
+    slot_description: Option<String>,
+    slot_id: Option<Slot>,
+    slot_manufacturer: Option<String>,
+    // token
+    manufacturer: Option<String>,
+    model: Option<String>,
+    serial: Option<String>,
+    token: Option<String>,
+    // object
+    id: Option<Vec<u8>>,
+    object: Option<Vec<u8>>,
+    type_: Option<ObjectClass>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn parse_version(v: &str) -> Result<Version, anyhow::Error> {
+    if let Some((major, minor)) = v.split_once('.') {
+        return Ok(Version::from(CK_VERSION {
+            major: major.parse()?,
+            minor: minor.parse()?,
+        }));
+    } else {
+        return Err(Error::InvalidPKCS11URI)?;
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl FromStr for PKCS11URI {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<PKCS11URI, anyhow::Error> {
+        let url = Url::parse(s)?;
+        let mut result = PKCS11URI {
+            pin_value: None,
+            pin_source: None,
+            module_path: None,
+            module_name: None,
+            library_description: None,
+            library_manufacturer: None,
+            library_version: None,
+            slot_description: None,
+            slot_id: None,
+            slot_manufacturer: None,
+            manufacturer: None,
+            model: None,
+            serial: None,
+            token: None,
+            id: None,
+            object: None,
+            type_: None,
+        };
+        for (k, v) in url.query_pairs() {
+            match &k as &str {
+                "pin-value" => {
+                    result.pin_value = Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                }
+                "pin-source" => {
+                    result.pin_source = Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                }
+                "module-path" => {
+                    result.module_path = Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                }
+                "module-name" => {
+                    result.module_name = Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                }
+                _ => return Err(Error::InvalidPKCS11URI.into()),
+            }
+        }
+        for attr in url.path().split(';') {
+            if let Some((k, v)) = attr.split_once('=') {
+                match k {
+                    "library-description" => {
+                        result.library_description =
+                            Some(String::from_utf8(percent_decode_str(v).collect())?)
+                    }
+                    "library-manufacturer" => {
+                        result.library_manufacturer =
+                            Some(String::from_utf8(percent_decode_str(v).collect())?)
+                    }
+                    "library-version" => result.library_version = Some(parse_version(v)?),
+                    "slot-description" => {
+                        result.slot_description =
+                            Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                    }
+                    "slot-id" => {
+                        result.slot_id = Some(Slot::try_from(u64::from_str(&String::from_utf8(
+                            percent_decode_str(&v).collect(),
+                        )?)?)?)
+                    }
+                    "slot-manufacturer" => {
+                        result.slot_manufacturer =
+                            Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                    }
+                    "manufacturer" => {
+                        result.manufacturer =
+                            Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                    }
+                    "model" => {
+                        result.model = Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                    }
+                    "serial" => {
+                        result.serial = Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                    }
+                    "token" => {
+                        result.token = Some(String::from_utf8(percent_decode_str(&v).collect())?)
+                    }
+                    "id" => result.id = Some(percent_decode_str(v).collect()),
+                    "object" => result.object = Some(percent_decode_str(v).collect()),
+                    "type" => {
+                        result.type_ = Some(
+                            match String::from_utf8(percent_decode_str(&v).collect())?.as_str() {
+                                "cert" => ObjectClass::CERTIFICATE,
+                                "data" => ObjectClass::DATA,
+                                "private" => ObjectClass::PRIVATE_KEY,
+                                "public" => ObjectClass::PUBLIC_KEY,
+                                "secret-key" => ObjectClass::SECRET_KEY,
+                                _ => Err(Error::InvalidPKCS11URI)?,
+                            },
+                        )
+                    }
+                    _ => return Err(Error::InvalidPKCS11URI.into()),
+                }
+            } else {
+                return Err(Error::InvalidPKCS11URI.into());
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl PKCS11URI {
+    fn matches_slot(&self, slot: Slot, sinfo: &SlotInfo) -> bool {
+        if let Some(desc) = &self.slot_description {
+            if desc != sinfo.slot_description() {
+                return false;
+            }
+        }
+        if let Some(id) = self.slot_id {
+            if id != slot {
+                return false;
+            }
+        }
+        if let Some(manuf) = &self.slot_manufacturer {
+            if manuf != sinfo.manufacturer_id() {
+                return false;
+            }
+        }
+        true
+    }
+    fn matches_token(&self, tinfo: &TokenInfo) -> bool {
+        if let Some(manuf) = &self.manufacturer {
+            if manuf != tinfo.manufacturer_id() {
+                return false;
+            }
+        }
+        if let Some(model) = &self.model {
+            if model != tinfo.model() {
+                return false;
+            }
+        }
+        if let Some(serial) = &self.serial {
+            if serial != tinfo.serial_number() {
+                return false;
+            }
+        }
+        if let Some(token) = &self.token {
+            if token != tinfo.label() {
+                return false;
+            }
+        }
+        true
+    }
+    fn attrs(&self) -> Vec<Attribute> {
+        let mut result = vec![];
+        if let Some(id) = &self.id {
+            result.push(Attribute::Id(id.clone()))
+        }
+        if let Some(object) = &self.object {
+            result.push(Attribute::Label(object.clone()))
+        }
+        if let Some(type_) = self.type_ {
+            result.push(Attribute::Class(type_))
+        }
+        result
+    }
+    fn get_module(&self) -> Result<String, anyhow::Error> {
+        if let Some(path) = &self.module_path {
+            Ok(path.to_string())
+        } else if let Some(name) = &self.module_name {
+            Ok(name.to_string() + ".so")
+        } else {
+            Ok("p11-kit-proxy.so".to_string())
+        }
+    }
+}
+
 fn read_key_file(
     key: &str,
     expected_label: &str,
@@ -381,7 +696,160 @@ fn read_key_file(
 }
 
 #[cfg(not(target_family = "wasm"))]
+struct PKCS11ModuleSet {
+    modules: HashMap<String, (Pkcs11, HashMap<Slot, Arc<Mutex<Session>>>)>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl PKCS11ModuleSet {
+    fn get_or_create(
+        &mut self,
+        filename: String,
+    ) -> Result<&mut (Pkcs11, HashMap<Slot, Arc<Mutex<Session>>>), anyhow::Error> {
+        match self.modules.entry(filename) {
+            hash_map::Entry::Vacant(entry) => {
+                let context = Pkcs11::new(entry.key())?;
+                context.initialize(CInitializeArgs::OsThreads)?;
+                Ok(entry.insert((context, HashMap::new())))
+            }
+            hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
+        }
+    }
+    fn instance() -> &'static Mutex<PKCS11ModuleSet> {
+        static mut RESULT: MaybeUninit<Mutex<PKCS11ModuleSet>> = MaybeUninit::uninit();
+        static ONCE: Once = Once::new();
+        unsafe {
+            ONCE.call_once(|| {
+                RESULT.write(Mutex::new(PKCS11ModuleSet {
+                    modules: HashMap::new(),
+                }));
+            });
+            RESULT.assume_init_ref()
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn get_session<'a>(
+    context: &Pkcs11,
+    sessions: &'a mut HashMap<Slot, Arc<Mutex<Session>>>,
+    slot: Slot,
+) -> Result<&'a Arc<Mutex<Session>>, anyhow::Error> {
+    match sessions.entry(slot) {
+        hash_map::Entry::Vacant(entry) => {
+            Ok(entry.insert(Arc::new(Mutex::new(context.open_ro_session(slot)?))))
+        }
+        hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn login(
+    context: &Pkcs11,
+    session: &Session,
+    uri: &PKCS11URI,
+    slot: Slot,
+    prompt: bool,
+) -> Result<(), anyhow::Error> {
+    if session.get_session_info()?.session_state() == SessionState::RoUser {
+        // Already logged in
+    } else if let Some(pin) = &uri.pin_value {
+        session.login(UserType::User, Some(&AuthPin::from_str(pin)?))?;
+    } else if let Some(pin_source) = &uri.pin_source {
+        if let Ok(pin_url) = Url::parse(pin_source) {
+            if pin_url.scheme() == "file" {
+                let pin = std::fs::read(pin_url.path())?;
+                session.login_with_raw(UserType::User, &RawAuthPin::from(pin))?;
+            } else {
+                Err(Error::BadPinSource)?;
+            }
+        } else if pin_source.starts_with('|') {
+            let pin = Exec::shell(&pin_source[1..])
+                .stdout(Redirection::Pipe)
+                .capture()?
+                .stdout;
+            session.login_with_raw(UserType::User, &RawAuthPin::from(pin))?;
+        } else {
+            Err(Error::BadPinSource)?;
+        }
+    } else if prompt {
+        if context
+            .get_token_info(slot)?
+            .protected_authentication_path()
+        {
+            session.login(UserType::User, None)?;
+        } else {
+            // TODO: identify token
+            let pin = rpassword::prompt_password("Enter pin: ")?;
+            session.login(UserType::User, Some(&AuthPin::from_str(&pin)?))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn load_pkcs11_private_key(key: &str) -> Result<Box<dyn Signer>, anyhow::Error> {
+    let mut uri = PKCS11URI::from_str(key)?;
+    if let Some(class) = uri.type_ {
+        if class != ObjectClass::PRIVATE_KEY {
+            Err(Error::ExpectedPrivateKey)?
+        }
+    } else {
+        uri.type_ = Some(ObjectClass::PRIVATE_KEY)
+    }
+    let mut modules = PKCS11ModuleSet::instance().lock().unwrap();
+    let (context, sessions) = modules.get_or_create(uri.get_module()?)?;
+    let attrs = uri.attrs();
+    for slot in context.get_slots_with_initialized_token()? {
+        if uri.matches_slot(slot, &context.get_slot_info(slot)?)
+            && uri.matches_token(&context.get_token_info(slot)?)
+        {
+            let session_mutex = get_session(context, sessions, slot)?;
+            let session = session_mutex.lock().unwrap();
+            login(context, &session, &uri, slot, true)?;
+            /*
+            if let Some(pin) = &uri.pin_value {
+                session.login(UserType::User, Some(&AuthPin::from_str(pin)?))?;
+            } else if let Some(pin_source) = &uri.pin_source {
+                if let Ok(pin_url) = Url::parse(pin_source) {
+                    if pin_url.scheme() == "file" {
+                        let pin = std::fs::read(pin_url.path())?;
+                        session.login_with_raw(UserType::User, &RawAuthPin::from(pin))?;
+                    } else {
+                        Err(Error::BadPinSource)?;
+                    }
+                } else if pin_source.starts_with('|') {
+                    let pin = Exec::shell(&pin_source[1..]).stdout(Redirection::Pipe).capture()?.stdout;
+                    session.login_with_raw(UserType::User, &RawAuthPin::from(pin))?;
+                } else {
+                    Err(Error::BadPinSource)?;
+                }
+            } else if context.get_token_info(slot)?.protected_authentication_path() {
+                session.login(UserType::User, None)?;
+            } else {
+                // TODO: identify token
+                let pin = rpassword::prompt_password("Enter pin: ")?;
+                session.login(UserType::User, Some(&AuthPin::from_str(&pin)?))?;
+            }*/
+
+            for obj in session.find_objects(&attrs)? {
+                let result = PKCS11PrivateKey {
+                    session: session_mutex.clone(),
+                    key: obj,
+                    pubkey: get_public_key_der(&session, lookup_public_key(&session, obj)?)?,
+                };
+                return Ok(Box::new(result));
+            }
+        }
+    }
+    return Err(Error::NoMatchingKey.into());
+}
+
+#[cfg(not(target_family = "wasm"))]
 pub fn load_private_key(key: &str) -> Result<Box<dyn Signer>, anyhow::Error> {
+    if key.starts_with("pkcs11:") {
+        return load_pkcs11_private_key(key);
+    }
     if let Ok(pkey) = PrivateKey::from_str(key) {
         return Ok(Box::new(pkey));
     }
@@ -396,6 +864,34 @@ pub fn load_private_key(key: &str) -> Result<Box<dyn Signer>, anyhow::Error> {
         })),
         _ => Err(Error::ExpectedPrivateKey.into()),
     }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn load_pkcs11_public_key(key: &str) -> Result<Vec<u8>, anyhow::Error> {
+    let mut uri = PKCS11URI::from_str(key)?;
+    if let Some(class) = uri.type_ {
+        if class != ObjectClass::PUBLIC_KEY {
+            Err(Error::ExpectedPublicKey)?
+        }
+    } else {
+        uri.type_ = Some(ObjectClass::PUBLIC_KEY)
+    }
+    let mut modules = PKCS11ModuleSet::instance().lock().unwrap();
+    let (context, sessions) = modules.get_or_create(uri.get_module()?)?;
+    let attrs = uri.attrs();
+    for slot in context.get_slots_with_initialized_token()? {
+        if uri.matches_slot(slot, &context.get_slot_info(slot)?)
+            && uri.matches_token(&context.get_token_info(slot)?)
+        {
+            let session = get_session(context, sessions, slot)?.lock().unwrap();
+            login(context, &session, &uri, slot, false)?;
+
+            for obj in session.find_objects(&attrs)? {
+                return get_public_key_der(&session, obj);
+            }
+        }
+    }
+    return Err(Error::NoMatchingKey.into());
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -432,6 +928,16 @@ impl AnyPublicKey {
 impl FromStr for AnyPublicKey {
     type Err = anyhow::Error;
     fn from_str(key: &str) -> Result<Self, Self::Err> {
+        #[cfg(not(target_family = "wasm"))]
+        if key.starts_with("pkcs11:") {
+            return Ok(Self {
+                key: crate::Claim {
+                    service: AccountNumber::new(account_raw!("verify-sys")),
+                    rawData: load_pkcs11_public_key(key)?.into(),
+                },
+            });
+        }
+
         if let Ok(pkey) = PublicKey::from_str(key) {
             return Ok(Self {
                 key: crate::Claim {

--- a/rust/psibase/src/crypto.rs
+++ b/rust/psibase/src/crypto.rs
@@ -807,30 +807,6 @@ fn load_pkcs11_private_key(key: &str) -> Result<Box<dyn Signer>, anyhow::Error> 
             let session_mutex = get_session(context, sessions, slot)?;
             let session = session_mutex.lock().unwrap();
             login(context, &session, &uri, slot, true)?;
-            /*
-            if let Some(pin) = &uri.pin_value {
-                session.login(UserType::User, Some(&AuthPin::from_str(pin)?))?;
-            } else if let Some(pin_source) = &uri.pin_source {
-                if let Ok(pin_url) = Url::parse(pin_source) {
-                    if pin_url.scheme() == "file" {
-                        let pin = std::fs::read(pin_url.path())?;
-                        session.login_with_raw(UserType::User, &RawAuthPin::from(pin))?;
-                    } else {
-                        Err(Error::BadPinSource)?;
-                    }
-                } else if pin_source.starts_with('|') {
-                    let pin = Exec::shell(&pin_source[1..]).stdout(Redirection::Pipe).capture()?.stdout;
-                    session.login_with_raw(UserType::User, &RawAuthPin::from(pin))?;
-                } else {
-                    Err(Error::BadPinSource)?;
-                }
-            } else if context.get_token_info(slot)?.protected_authentication_path() {
-                session.login(UserType::User, None)?;
-            } else {
-                // TODO: identify token
-                let pin = rpassword::prompt_password("Enter pin: ")?;
-                session.login(UserType::User, Some(&AuthPin::from_str(&pin)?))?;
-            }*/
 
             for obj in session.find_objects(&attrs)? {
                 let result = PKCS11PrivateKey {


### PR DESCRIPTION
This allows all key arguments to take a PKCS #<!---->11 URI. Such arguments will be interpreted as using `verify-sys`.

The module can be specified in the URI (e.g. `?module-name=libsofthsm2`). If a module name is not specified, the default is `p11-kit-proxy.so`, which loads a system-specific set of modules.

`psibase` assumes by default that public key objects are public on the token and private key objects are private. It will prompt for a pin only for private keys. If a pin is provided in the URI (`pin-value` or `pin-source`), then it will login with that pin to access both public and private keys.