### PR TITLE
Update cargo-psibase

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "account_sys"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "fracpack",
  "psibase",
@@ -386,7 +386,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "burst-transfer"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-psibase"
-version = "0.5.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "binaryen",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "elections"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "fracpack",
  "psibase",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "fracpack"
-version = "0.5.0"
+version = "0.2.0"
 dependencies = [
  "custom_error",
  "psibase_macros",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "gen-cpp-doc"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clang",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "md2man"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "clap 3.2.25",
  "pulldown-cmark",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "psibase"
-version = "0.5.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "psibase_macros"
-version = "0.5.0"
+version = "0.2.0"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -2280,14 +2280,14 @@ dependencies = [
 
 [[package]]
 name = "psibase_names"
-version = "0.5.0"
+version = "0.2.0"
 dependencies = [
  "seahash",
 ]
 
 [[package]]
 name = "psispace-sys"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "async-graphql",
  "fracpack",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "test_contract"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "psibase",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "test_fracpack"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.1.0"
 rust-version = "1.64"
 repository = "https://github.com/gofractally/psibase"
 homepage = "https://psibase.io"

--- a/rust/account_sys/Cargo.toml
+++ b/rust/account_sys/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-fracpack = { path = "../fracpack" }
-psibase = { path = "../psibase" }
+fracpack = { version = "0.2.0", path = "../fracpack" }
+psibase = { version = "0.2.0", path = "../psibase" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/burst-transfer/Cargo.toml
+++ b/rust/burst-transfer/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 chrono = "0.4"
 clap = {version = "3.1", features = ["derive"]}
 futures = "0.3"
-psibase = { path = "../psibase" }
+psibase = { version = "0.2.0", path = "../psibase" }
 rand = "0.8.5"
 reqwest = { version = "0.11", default-features = false, features = ["json","rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/cargo-psibase/Cargo.toml
+++ b/rust/cargo-psibase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-psibase"
-version.workspace = true
+version = "0.2.0"
 rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
@@ -15,7 +15,7 @@ cargo_metadata = "0.15.0"
 clap = {version = "3.1", features = ["derive"]}
 console = "0.15.2"
 parity-wasm = "0.45"
-psibase = { path = "../psibase" }
+psibase = { version = "0.2.0", path = "../psibase" }
 regex = "1"
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/rust/fracpack/Cargo.toml
+++ b/rust/fracpack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fracpack"
-version.workspace = true
+version = "0.2.0"
 rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
@@ -13,4 +13,4 @@ path = "src/fracpack.rs"
 
 [dependencies]
 custom_error = "1.9.2"
-psibase_macros = { path = "../psibase_macros" }
+psibase_macros = { version = "0.2.0", path = "../psibase_macros" }

--- a/rust/psibase/Cargo.toml
+++ b/rust/psibase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psibase"
-version.workspace = true
+version = "0.2.0"
 rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
@@ -16,14 +16,14 @@ anyhow = "1.0"
 async-graphql = "4.0"
 chrono = "0.4"
 custom_error = "1.9"
-fracpack = { path = "../fracpack" }
+fracpack = { version = "0.2.0", path = "../fracpack" }
 futures = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 include_dir = "0.7.3"
 sha2 = "0.10"
 mime_guess = "2.0"
-psibase_macros = { path = "../psibase_macros" }
-psibase_names = { path = "../psibase_names" }
+psibase_macros = { version = "0.2.0", path = "../psibase_macros" }
+psibase_names = { version = "0.2.0", path = "../psibase_names" }
 ripemd = "0.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11.12"

--- a/rust/psibase_macros/Cargo.toml
+++ b/rust/psibase_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psibase_macros"
-version.workspace = true
+version = "0.2.0"
 rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
@@ -15,6 +15,6 @@ proc-macro = true
 darling = "0.14"
 proc-macro-error = "1.0.4"
 proc-macro2 = "1.0.36"
-psibase_names = { path = "../psibase_names" }
+psibase_names = { version = "0.2.0", path = "../psibase_names" }
 quote = "1.0.15"
 syn = {version = "1.0.86", features = ["full", "visit-mut"] }

--- a/rust/psibase_names/Cargo.toml
+++ b/rust/psibase_names/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psibase_names"
-version.workspace = true
+version = "0.2.0"
 rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/rust/test_contract/Cargo.toml
+++ b/rust/test_contract/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-psibase = { path = "../psibase" }
+psibase = { version = "0.2.0", path = "../psibase" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/test_fracpack/Cargo.toml
+++ b/rust/test_fracpack/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 
 [dependencies]
 cxx = "1.0"
-fracpack = { path = "../fracpack" }
+fracpack = { version = "0.2.0", path = "../fracpack" }
 hex = "0.3.1"
-psibase_macros = { path = "../psibase_macros" }
+psibase_macros = { version = "0.2.0", path = "../psibase_macros" }
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/rust/test_service_elections/Cargo.toml
+++ b/rust/test_service_elections/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-fracpack = { path = "../fracpack" }
-psibase = { path = "../psibase" }
+fracpack = { version = "0.2.0", path = "../fracpack" }
+psibase = { version = "0.2.0", path = "../psibase" }
 serde = { version = "1.0.145", features = ["derive"] }

--- a/rust/test_service_psispace/Cargo.toml
+++ b/rust/test_service_psispace/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 async-graphql = "4.0"
-fracpack = { path = "../fracpack" }
-psibase = { path = "../psibase" }
+fracpack = { version = "0.2.0", path = "../fracpack" }
+psibase = { version = "0.2.0", path = "../psibase" }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
This reverts commit 2550f84d0475d3cf5ea3acb8328a5ccd42a774bc which unified all rust module version numbers under the workspace. This is much nicer for version management, however it precludes being able to publish updated versions to crates.io. See [this github issue](https://github.com/rust-lang/cargo/issues/11133) for more details.