### PR TITLE
rework psibase upload

### DIFF
--- a/doc/https.md
+++ b/doc/https.md
@@ -57,7 +57,7 @@ If you're running `psinode` within a container, commands sent to psinode via the
 - Firefox uses its own certificate store and may not pick up the mkcert certificates automatically.
 - If you update apps, you will need to take additional action for the changes to be served by psinode. You have a couple options:
   1. After making your changes and rebuilding, delete the `db` file and `data` directory within the `psinode_db_secure` directory, restart psinode and boot the chain again. This will, of course, wipe the chain.
-  2. Use the `psibase -a http://psibase.127.0.0.1.sslip.io:8079 upload-tree` command to upload updated app build artifacts.
+  2. Use the `psibase -a http://psibase.127.0.0.1.sslip.io:8079 upload` command to upload updated app build artifacts.
 
 ## Running an app server in dev mode for faster iteration
 

--- a/doc/psidk/src/run-infrastructure/cli/psibase.md
+++ b/doc/psidk/src/run-infrastructure/cli/psibase.md
@@ -10,8 +10,7 @@ psibase - The psibase blockchain command line client
 `psibase` [`-a` *url*] `create` [`-i` | `-k` *public-key*] [-S *sender*] *name*  
 `psibase` [`-a` *url*] `deploy` [`-p`] *account* *filename*  
 `psibase` [`-a` *url*] `modify` [`-i` | `-k` *public-key*] *account*  
-`psibase` [`-a` *url*] `upload` *service* *dest* *content-type* *source*  
-`psibase` [`-a` *url*] `upload-tree` *service* *dest* *source*  
+`psibase` [`-a` *url*] `upload` [`-r`] [`-t` *content-type*] *service* *source* *dest*  
 `psibase` `create-token` [`-e` *expiration*] [`-m` *mode*]  
 
 ## DESCRIPTION
@@ -124,47 +123,29 @@ Modify an account
 
 ### upload
 
-`psibase` [`-a` *url*] `upload` *service* *dest* *content-type* *source*  
+`psibase` [`-a` *url*] `upload` [`-r`] [`-t` *content-type*] *service* *source* *dest*  
 
 Upload a file to a service. The service must provide a `storeSys` action.
+
+- `-r`, `--recursive`
+
+  If *source* is a directory, upload its contents recursively. The files may be split across multiple transactions if they are too large to fit in a single transaction.
+
+- `-t`, `--content-type` *content-type*
+
+  MIME Content-Type of the file. If not specified, it will be guessed from the file name. Cannot be used with `-r`.
 
 - *service*
 
   Service to upload to
-  
-- *dest*
 
-  Destination path within *service*
-  
-- *content-type*
-
-  MIME Content-Type of the file
-  
 - *source*
 
   Source filename to upload
 
-- `-S`, `--sender` *sender*
-
-  Account to use as the sender of the transaction. Defaults to the *service* account.
-
-### upload-tree
-
-`psibase` [`-a` *url*] `upload-tree` *service* *dest* *source*  
-
-Upload a directory tree to a service. The service must provide a `storeSys` action. The files may be split across multiple transactions if they are too large to fit in a single transaction.
-
-- *service*
-
-  Service to upload to
-  
 - *dest*
 
   Destination path within *service*
-  
-- *source*
-
-  Source directory to upload
 
 - `-S`, `--sender` *sender*
 

--- a/doc/psidk/src/run-infrastructure/cli/psibase.md
+++ b/doc/psidk/src/run-infrastructure/cli/psibase.md
@@ -10,7 +10,7 @@ psibase - The psibase blockchain command line client
 `psibase` [`-a` *url*] `create` [`-i` | `-k` *public-key*] [-S *sender*] *name*  
 `psibase` [`-a` *url*] `deploy` [`-p`] *account* *filename*  
 `psibase` [`-a` *url*] `modify` [`-i` | `-k` *public-key*] *account*  
-`psibase` [`-a` *url*] `upload` [`-r`] [`-t` *content-type*] *service* *source* *dest*  
+`psibase` [`-a` *url*] `upload` [`-r`] [`-t` *content-type*] *service* *source* [*dest*]  
 `psibase` `create-token` [`-e` *expiration*] [`-m` *mode*]  
 
 ## DESCRIPTION
@@ -123,7 +123,7 @@ Modify an account
 
 ### upload
 
-`psibase` [`-a` *url*] `upload` [`-r`] [`-t` *content-type*] *service* *source* *dest*  
+`psibase` [`-a` *url*] `upload` [`-r`] [`-t` *content-type*] *service* *source* [*dest*]  
 
 Upload a file to a service. The service must provide a `storeSys` action.
 
@@ -145,7 +145,7 @@ Upload a file to a service. The service must provide a `storeSys` action.
 
 - *dest*
 
-  Destination path within *service*
+  Destination path within *service*. If not specified, defaults to the file name of *source* or `/` for recursive uploads.
 
 - `-S`, `--sender` *sender*
 

--- a/doc/psidk/src/specifications/data-formats/package.md
+++ b/doc/psidk/src/specifications/data-formats/package.md
@@ -26,7 +26,7 @@ Properties associated with a service.
 
 ## data/&lt;service&gt;/*
 
-Files that will be uploaded using the `uploadSys` action.
+Files that will be uploaded using the `storeSys` action.
 
 ## script/postinstall.json
 

--- a/generator/tools/templates/react/deploy.sh
+++ b/generator/tools/templates/react/deploy.sh
@@ -7,4 +7,4 @@ echo Deploying __contract__Service to account $accname ...
 
 yarn
 yarn run build
-psibase -s $privkey upload-tree -S $accname $accname / dist/
+psibase -s $privkey upload -r -S $accname $accname dist/ /

--- a/services/system/AuthEcSys/ui/README.md
+++ b/services/system/AuthEcSys/ui/README.md
@@ -13,6 +13,6 @@ Main queries:
 
 Since it's a super basic and simple plugin, we decided to leave it as a single vanilla javascript file.
 
-The workflow is simply updating the js file and running `psibase upload-tree r-ath-ec-sys / .`
+The workflow is simply updating the js file and running `psibase upload -r r-ath-ec-sys . /`
 
 This will upload the index.js and you will be able to test the changes in your psibase instance right away.

--- a/services/system/AuthSys/ui/README.md
+++ b/services/system/AuthSys/ui/README.md
@@ -13,6 +13,6 @@ Main queries:
 
 Since it's a super basic and simple plugin, we decided to leave it as a single vanilla javascript file.
 
-The workflow is simply updating the js file and running `psibase upload-tree r-auth-sys / .`
+The workflow is simply updating the js file and running `psibase upload -r r-auth-sys . /`
 
 This will upload the index.js and you will be able to test the changes in your psibase instance right away.

--- a/services/user/AdminSys/ui/README.md
+++ b/services/user/AdminSys/ui/README.md
@@ -10,9 +10,4 @@
 ## Build Instructions
 
 -   building will create `dist` directory
--   `psibase upload-tree [contract-name] / ./dist`
-
-## Making sure your built files are bootstrapped with new tester and new chain
-
--   Update contents of `DefaultTestChain.cpp` to include your new files
--   If you want new chains (not test chains) bootstrapped with the files, update `boot.rs`
+-   copy to `$PREFIX/share/psibase/services/admin-sys`

--- a/services/user/CommonSys/ui/README.md
+++ b/services/user/CommonSys/ui/README.md
@@ -10,7 +10,7 @@
 ## Build Instructions
 
 -   building will create `dist` directory
--   `psibase upload-tree [service-name] / ./dist`
+-   `psibase upload -r [service-name] ./dist /`
 
 ## Making sure your built files are bootstrapped with new tester and new chain
 

--- a/services/user/FractalSys/ui/package.json
+++ b/services/user/FractalSys/ui/package.json
@@ -9,7 +9,7 @@
         "test": "vitest",
         "build": "tsc && vite build",
         "start": "vite preview",
-        "deploy": "psibase upload-tree fractal-sys / dist"
+        "deploy": "psibase upload -r fractal-sys dist /"
     },
     "dependencies": {
         "@dnd-kit/core": "^6.0.3",

--- a/services/user/InviteSys/ui/package.json
+++ b/services/user/InviteSys/ui/package.json
@@ -9,7 +9,7 @@
         "test": "vitest",
         "build": "tsc && vite build",
         "start": "vite preview",
-        "deploy": "psibase upload-tree invite-sys / dist"
+        "deploy": "psibase upload -r invite-sys dist /"
     },
     "dependencies": {
         "@dnd-kit/core": "^6.0.3",

--- a/services/user/PsiSpaceSys/include/services/user/PsiSpaceSys.hpp
+++ b/services/user/PsiSpaceSys/include/services/user/PsiSpaceSys.hpp
@@ -33,20 +33,19 @@ namespace SystemService
    /// Provide web hosting
    ///
    /// This service provides web hosting to non-service accounts. It supports both an
-   /// upload UI (TODO) and command-line upload using `psibase upload` and
-   /// `psibase upload tree`.
+   /// upload UI (TODO) and command-line upload using `psibase upload`.
    ///
    /// Uploading a directory tree:
    ///
    /// ```
-   /// psibase -a $ROOT_URL -s $PVT_KEY upload-tree -S $ACCOUNT psispace-sys / $DIR
+   /// psibase -a $ROOT_URL -s $PVT_KEY upload -r -S $ACCOUNT psispace-sys $DIR /
    /// ```
    ///
    /// Uploading a single file:
    ///
    /// ```
    /// psibase -a $ROOT_URL -s $PVT_KEY upload -S $ACCOUNT psispace-sys
-   ///         /index.html text/html $PATH_TO_FILE
+   ///           $PATH_TO_FILE /index.html
    /// ```
    ///
    /// You don't need the `-a` and `-s` options if your running a local test chain at

--- a/services/user/PsiSpaceSys/ui/README.md
+++ b/services/user/PsiSpaceSys/ui/README.md
@@ -8,7 +8,7 @@
 ## Build Instructions
 
 -   building will create `dist` directory
--   `psibase upload-tree psispace-sys / ./dist`
+-   `psibase upload -r psispace-sys ./dist /`
 
 ## Making sure your built files are bootstrapped with new tester and new chain
 


### PR DESCRIPTION
- Add `-r` which subsumes the functionality of `upload-tree`
- Make content-type an optional argument and default to deducing it from the file name
- Reorder the source and dest to be more consistent with unix conventions
- Make dest optional. With `-r`, the dest defaults to `/` which is almost always going to be the right thing. Without `-r`, the destination is derived from the source file name. i.e. `path/to/index.html` will be uploaded to `/index.html`
- If the dest does not have a leading `/`, add one automatically.