### PR TITLE
Show service stack trace on transaction failure

### DIFF
--- a/doc/psidk/src/run-infrastructure/cli/psibase.md
+++ b/doc/psidk/src/run-infrastructure/cli/psibase.md
@@ -37,6 +37,14 @@ psibase - The psibase blockchain command line client
   - A PKCS #11 URI
   - An EOS style base58-encoded private key beginning `PVT_K1_`
 
+- `--trace` *format*
+
+  For commands that push transactions to the chain, determines how the result is reported.
+  - `error`: If the transaction failed, show the error message
+  - `stack` (default): If the transaction failed, show a stack trace from the action that caused the error
+  - `full`: Shows all actions in the trace
+  - `json`: Shows the full transaction trace as JSON
+
 ## COMMANDS
 
 ### boot

--- a/libraries/psibase/native/src/TransactionContext.cpp
+++ b/libraries/psibase/native/src/TransactionContext.cpp
@@ -142,8 +142,16 @@ namespace psibase
       auto& atrace  = self.transactionTrace.actionTraces.emplace_back();
       atrace.action = action;  // TODO: avoid copy and redundancy between action and atrace.action
       ActionContext ac = {self, action, self.transactionTrace.actionTraces.back()};
-      auto&         ec = self.getExecutionContext(transactionServiceNum);
-      ec.execProcessTransaction(ac);
+      try
+      {
+         auto& ec = self.getExecutionContext(transactionServiceNum);
+         ec.execProcessTransaction(ac);
+      }
+      catch (std::exception& e)
+      {
+         atrace.error = e.what();
+         throw;
+      }
    }
 
    void TransactionContext::execVerifyProof(size_t i)
@@ -181,8 +189,16 @@ namespace psibase
       auto& atrace     = transactionTrace.actionTraces.emplace_back();
       atrace.action    = action;
       ActionContext ac = {*this, action, atrace};
-      auto&         ec = getExecutionContext(action.service);
-      ec.execVerify(ac);
+      try
+      {
+         auto& ec = getExecutionContext(action.service);
+         ec.execVerify(ac);
+      }
+      catch (std::exception& e)
+      {
+         atrace.error = e.what();
+         throw;
+      }
    }
 
    void TransactionContext::execNonTrxAction(uint64_t      callerFlags,
@@ -198,8 +214,16 @@ namespace psibase
 
       atrace.action    = action;
       ActionContext ac = {*this, action, atrace};
-      auto&         ec = getExecutionContext(action.service);
-      ec.execCalled(callerFlags, ac);
+      try
+      {
+         auto& ec = getExecutionContext(action.service);
+         ec.execCalled(callerFlags, ac);
+      }
+      catch (std::exception& e)
+      {
+         atrace.error = e.what();
+         throw;
+      }
    }
 
    void TransactionContext::execCalledAction(uint64_t      callerFlags,
@@ -208,8 +232,16 @@ namespace psibase
    {
       atrace.action    = action;
       ActionContext ac = {*this, action, atrace};
-      auto&         ec = getExecutionContext(action.service);
-      ec.execCalled(callerFlags, ac);
+      try
+      {
+         auto& ec = getExecutionContext(action.service);
+         ec.execCalled(callerFlags, ac);
+      }
+      catch (std::exception& e)
+      {
+         atrace.error = e.what();
+         throw;
+      }
    }
 
    // TODO: different wasmConfig, controlled by config file
@@ -224,8 +256,16 @@ namespace psibase
 
       atrace.action    = action;
       ActionContext ac = {*this, action, atrace};
-      auto&         ec = getExecutionContext(action.service);
-      ec.execServe(ac);
+      try
+      {
+         auto& ec = getExecutionContext(action.service);
+         ec.execServe(ac);
+      }
+      catch (std::exception& e)
+      {
+         atrace.error = e.what();
+         throw;
+      }
    }
 
    ExecutionContext& TransactionContext::getExecutionContext(AccountNumber service)

--- a/libraries/psibase_http/include/psibase/http.hpp
+++ b/libraries/psibase_http/include/psibase/http.hpp
@@ -19,15 +19,13 @@
 
 namespace psibase::http
 {
-   using push_boot_result   = std::optional<std::string>;
-   using push_boot_callback = std::function<void(push_boot_result)>;
-   using push_boot_t =
-       std::function<void(std::vector<char> packed_signed_transactions, push_boot_callback)>;
-
    using push_transaction_result   = std::variant<TransactionTrace, std::string>;
    using push_transaction_callback = std::function<void(push_transaction_result)>;
    using push_transaction_t =
        std::function<void(std::vector<char> packed_signed_trx, push_transaction_callback)>;
+
+   using push_boot_t =
+       std::function<void(std::vector<char> packed_signed_transactions, push_transaction_callback)>;
 
    using shutdown_t = std::function<void(std::vector<char>)>;
 

--- a/libraries/psio/include/psio/from_json.hpp
+++ b/libraries/psio/include/psio/from_json.hpp
@@ -89,7 +89,7 @@ namespace psio
                case from_json_error::expected_end_array:                  return "Expected ]";
                case from_json_error::expected_positive_uint:              return "Expected positive integer";
                case from_json_error::expected_field:                      return "Expected field";
-               case from_json_error::expected_variant:                    return R"(Expected variant: ["type", value])";
+               case from_json_error::expected_variant:                    return R"(Expected variant: {"type": value})";
                case from_json_error::expected_public_key:                 return "Expected public key";
                case from_json_error::expected_private_key:                return "Expected private key";
                case from_json_error::expected_signature:                  return "Expected signature";
@@ -593,16 +593,15 @@ namespace psio
    template <typename... T, typename S>
    void from_json(std::variant<T...>& result, S& stream)
    {
-      stream.get_start_array();
-      std::string_view type;
-      from_json(type, stream);
+      stream.get_start_object();
+      std::string_view  type         = stream.get_key();
       const char* const type_names[] = {get_type_name((T*)nullptr)...};
       uint32_t type_idx = std::find(type_names, type_names + sizeof...(T), type) - type_names;
       if (type_idx >= sizeof...(T))
          abort_error(from_json_error::invalid_type_for_variant);
       set_variant_impl(result, type_idx);
       std::visit([&](auto& x) { from_json(x, stream); }, result);
-      stream.get_end_array();
+      stream.get_end_object();
    }
 
    /**

--- a/libraries/psio/include/psio/to_json.hpp
+++ b/libraries/psio/include/psio/to_json.hpp
@@ -229,17 +229,17 @@ template <typename S> void to_json(float value, S& stream)              { return
    template <typename... T, typename S>
    void to_json(const std::variant<T...>& obj, S& stream)
    {
-      stream.write('[');
+      stream.write('{');
       increase_indent(stream);
       write_newline(stream);
       std::visit(
           [&](const auto& t) { to_json(get_type_name<std::decay_t<decltype(t)>>(), stream); }, obj);
-      stream.write(',');
+      stream.write(':');
       write_newline(stream);
       std::visit([&](auto& x) { return to_json(x, stream); }, obj);
       decrease_indent(stream);
       write_newline(stream);
-      stream.write(']');
+      stream.write('}');
    }
 
    template <typename... T, typename S>

--- a/programs/psinode/tests/psinode.py
+++ b/programs/psinode/tests/psinode.py
@@ -234,7 +234,7 @@ class API:
             mode = 'CftConsensus'
         elif algorithm == 'bft':
             mode = 'BftConsensus'
-        return self.push_action('producer-sys', 'producer-sys', 'setConsensus', {'consensus':[mode, {'producers': producers}]})
+        return self.push_action('producer-sys', 'producer-sys', 'setConsensus', {'consensus':{mode: {'producers': producers}}})
 
     # Queries
     def graphql(self, service, query):

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2326,6 +2326,7 @@ dependencies = [
  "sec1",
  "secp256k1",
  "serde",
+ "serde-aux",
  "serde-wasm-bindgen",
  "serde_bytes",
  "serde_json",
@@ -2770,6 +2771,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-aux"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86348501c129f3ad50c2f4635a01971f76974cd8a3f335988a0f1581c082765"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/rust/psibase/Cargo.toml
+++ b/rust/psibase/Cargo.toml
@@ -30,6 +30,7 @@ psibase_names = { path = "../psibase_names" }
 regex = "1"
 ripemd = "0.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
+serde-aux = "4.4"
 serde_bytes = "0.11.12"
 serde_json = "1.0"
 serde-wasm-bindgen = "0.6.0"

--- a/rust/psibase/src/main.rs
+++ b/rust/psibase/src/main.rs
@@ -49,6 +49,8 @@ struct Args {
     #[clap(long)]
     suppress_ok: bool,
 
+    /// Controls how transaction traces are reported. Possible values are
+    /// error, stack, full, or json
     #[clap(long, value_name = "FORMAT", default_value = "stack")]
     trace: TraceFormat,
 

--- a/rust/psibase/src/main.rs
+++ b/rust/psibase/src/main.rs
@@ -12,7 +12,8 @@ use psibase::{
     push_transaction, reg_server, set_auth_service_action, set_code_action, set_key_action,
     sign_transaction, AccountNumber, Action, AnyPrivateKey, AnyPublicKey, AutoAbort,
     DirectoryRegistry, ExactAccountNumber, HTTPRegistry, JointRegistry, PackageList,
-    PackageRegistry, SignedTransaction, Tapos, TaposRefBlock, TimePointSec, Transaction,
+    PackageRegistry, SignedTransaction, Tapos, TaposRefBlock, TimePointSec, TraceFormat,
+    Transaction,
 };
 use regex::Regex;
 use reqwest::Url;
@@ -48,6 +49,9 @@ struct Args {
     /// Suppress "Ok" message
     #[clap(long)]
     suppress_ok: bool,
+
+    #[clap(long, value_name = "FORMAT", default_value = "stack")]
+    trace: TraceFormat,
 
     #[clap(subcommand)]
     command: Command,
@@ -301,6 +305,7 @@ async fn create(
         &args.api,
         client,
         sign_transaction(trx, &args.sign)?.packed(),
+        args.trace,
     )
     .await?;
     if !args.suppress_ok {
@@ -342,6 +347,7 @@ async fn modify(
         &args.api,
         client,
         sign_transaction(trx, &args.sign)?.packed(),
+        args.trace,
     )
     .await?;
     if !args.suppress_ok {
@@ -400,6 +406,7 @@ async fn deploy(
         &args.api,
         client,
         sign_transaction(trx, &args.sign)?.packed(),
+        args.trace,
     )
     .await?;
     if !args.suppress_ok {
@@ -460,6 +467,7 @@ async fn upload(
         &args.api,
         client,
         sign_transaction(trx, &args.sign)?.packed(),
+        args.trace,
     )
     .await?;
     if !args.suppress_ok {
@@ -529,7 +537,7 @@ async fn monitor_trx(
     progress: ProgressBar,
     n: u64,
 ) -> Result<(), anyhow::Error> {
-    let result = push_transaction(&args.api, client.clone(), trx.packed()).await;
+    let result = push_transaction(&args.api, client.clone(), trx.packed(), args.trace).await;
     if let Err(err) = result {
         progress.suspend(|| {
             println!("=====\n{:?}", err);
@@ -608,7 +616,7 @@ async fn boot(
     push_boot(args, &client, boot_transactions.packed()).await?;
     progress.inc(1);
     for transaction in transactions {
-        push_transaction(&args.api, client.clone(), transaction.packed()).await?;
+        push_transaction(&args.api, client.clone(), transaction.packed(), args.trace).await?;
         progress.inc(1)
     }
     if !args.suppress_ok {
@@ -753,6 +761,7 @@ async fn monitor_install_trx(
         &args.api,
         client.clone(),
         sign_transaction(trx, &args.sign)?.packed(),
+        args.trace,
     )
     .await;
 

--- a/rust/psibase/src/rpc.rs
+++ b/rust/psibase/src/rpc.rs
@@ -1,13 +1,15 @@
+use crate::TransactionTrace;
 use anyhow::Context;
 use async_graphql::{InputObject, SimpleObject};
 use custom_error::custom_error;
 use reqwest::Url;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use std::str::FromStr;
 
 custom_error! { Error
     Message{message:String}                         = "{message}",
-    ExecutionFailed{message:String, trace:Value}    = "{message}",
+    ExecutionFailed{message:String}    = "{message}",
+    UnknownTraceFormat = "Unknown trace format"
 }
 
 async fn as_text(builder: reqwest::RequestBuilder) -> Result<String, anyhow::Error> {
@@ -53,37 +55,66 @@ pub async fn get_tapos_for_head(
         .context("Failed to get tapos for head block")
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum TraceFormat {
+    Message,
+    Stack,
+    Full,
+    Json,
+}
+
+impl TraceFormat {
+    pub fn error_for_trace(&self, trace: TransactionTrace) -> Result<(), anyhow::Error> {
+        if let Some(e) = &trace.error {
+            if !e.is_empty() {
+                let message = match self {
+                    TraceFormat::Message => e.to_string(),
+                    TraceFormat::Stack => trace.fmt_stack(),
+                    TraceFormat::Full => trace.to_string(),
+                    TraceFormat::Json => serde_json::to_string(&trace)?,
+                };
+                Err(Error::ExecutionFailed { message })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for TraceFormat {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, anyhow::Error> {
+        match s {
+            "message" => Ok(TraceFormat::Message),
+            "stack" => Ok(TraceFormat::Stack),
+            "full" => Ok(TraceFormat::Full),
+            "json" => Ok(TraceFormat::Json),
+            _ => Err(Error::UnknownTraceFormat)?,
+        }
+    }
+}
+
 async fn push_transaction_impl(
     base_url: &Url,
     client: reqwest::Client,
     packed: Vec<u8>,
+    fmt: TraceFormat,
 ) -> Result<(), anyhow::Error> {
-    let trace: Value = as_json(
+    let trace: TransactionTrace = as_json(
         client
             .post(base_url.join("native/push_transaction")?)
             .body(packed),
     )
     .await?;
-    // println!("{:#?}", trace);
-    let err = trace.get("error").and_then(|v| v.as_str());
-    if let Some(e) = err {
-        if !e.is_empty() {
-            return Err(Error::ExecutionFailed {
-                message: e.to_string(),
-                trace,
-            }
-            .into());
-        }
-    }
-    Ok(())
+    fmt.error_for_trace(trace)
 }
 
 pub async fn push_transaction(
     base_url: &Url,
     client: reqwest::Client,
     packed: Vec<u8>,
+    fmt: TraceFormat,
 ) -> Result<(), anyhow::Error> {
-    push_transaction_impl(base_url, client, packed)
+    push_transaction_impl(base_url, client, packed, fmt)
         .await
         .context("Failed to push transaction")?;
     Ok(())

--- a/rust/psibase/src/trace.rs
+++ b/rust/psibase/src/trace.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::{Action, Hex, Pack, Reflect, Unpack};
 use serde::{Deserialize, Serialize};
+use serde_aux::prelude::deserialize_number_from_string;
 
 #[derive(Debug, Clone, Pack, Unpack, Reflect, Serialize, Deserialize)]
 #[fracpack(fracpack_mod = "fracpack")]
@@ -11,6 +12,7 @@ pub struct ActionTrace {
     pub action: Action,
     pub raw_retval: Hex<Vec<u8>>,
     pub inner_traces: Vec<InnerTrace>,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub total_time: i64,
     pub error: Option<String>,
 }
@@ -159,4 +161,44 @@ fn format_transaction_trace(
         format_string(e, indent + 11, f)?;
     }
     Ok(())
+}
+
+fn format_error_stack<T: std::fmt::Write>(atrace: &ActionTrace, f: &mut T) -> fmt::Result {
+    if atrace.error.is_some() {
+        writeln!(
+            f,
+            "{} => {}::{}",
+            atrace.action.sender, atrace.action.service, atrace.action.method
+        )?;
+        for inner in &atrace.inner_traces {
+            match &inner.inner {
+                InnerTraceEnum::ConsoleTrace(_) => (),
+                InnerTraceEnum::EventTrace(_) => (),
+                InnerTraceEnum::ActionTrace(a) => format_error_stack(a, f)?,
+            }
+        }
+    }
+    Ok(())
+}
+
+fn format_transaction_error_stack<T: std::fmt::Write>(
+    ttrace: &TransactionTrace,
+    f: &mut T,
+) -> fmt::Result {
+    for a in &ttrace.action_traces {
+        format_error_stack(a, f)?;
+        if let Some(message) = &ttrace.error {
+            writeln!(f, "{}", message)?;
+        }
+        break;
+    }
+    Ok(())
+}
+
+impl TransactionTrace {
+    pub fn fmt_stack(&self) -> String {
+        let mut result = String::new();
+        format_transaction_error_stack(self, &mut result).unwrap();
+        result
+    }
 }


### PR DESCRIPTION
- Change psio json serialization of variant to {type:value} to match serde. It's the same number of characters and the serde version seems more sane.
- Allow rust deserialization of TransactionTrace to handle number-as-string.
- Ensure that the ActionTrace::error field is set
- Add --trace=error|stack|full|json to determine the verbosity