### PR TITLE
Change checkAuthSys signature to avoid passing the potentially large data, which is never actually used.

### DIFF
--- a/services/system/AuthAnySys/include/services/system/AuthAnySys.hpp
+++ b/services/system/AuthAnySys/include/services/system/AuthAnySys.hpp
@@ -10,13 +10,14 @@ namespace SystemService
 
       void checkAuthSys(uint32_t                    flags,
                         psibase::AccountNumber      requester,
-                        psibase::Action             action,
+                        psibase::AccountNumber      sender,
+                        ServiceMethod               action,
                         std::vector<ServiceMethod>  allowedActions,
                         std::vector<psibase::Claim> claims);
       void canAuthUserSys(psibase::AccountNumber user);
    };
    PSIO_REFLECT(AuthAnySys,  //
-                method(checkAuthSys, flags, requester, action, allowedActions, claims),
+                method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),
                 method(canAuthUserSys, user)
                 //
    )

--- a/services/system/AuthAnySys/src/AuthAnySys.cpp
+++ b/services/system/AuthAnySys/src/AuthAnySys.cpp
@@ -10,7 +10,8 @@ namespace SystemService
 {
    void AuthAnySys::checkAuthSys(uint32_t                    flags,
                                  psibase::AccountNumber      requester,
-                                 psibase::Action             action,
+                                 psibase::AccountNumber      sender,
+                                 ServiceMethod               action,
                                  std::vector<ServiceMethod>  allowedActions,
                                  std::vector<psibase::Claim> claims)
    {

--- a/services/system/AuthDelegateSys/include/services/system/AuthDelegateSys.hpp
+++ b/services/system/AuthDelegateSys/include/services/system/AuthDelegateSys.hpp
@@ -38,7 +38,8 @@ namespace SystemService
       /// This action forwards verification to the owning account
       void checkAuthSys(std::uint32_t               flags,
                         psibase::AccountNumber      requester,
-                        psibase::Action             action,
+                        psibase::AccountNumber      sender,
+                        ServiceMethod               action,
                         std::vector<ServiceMethod>  allowedActions,
                         std::vector<psibase::Claim> claims);
 
@@ -61,7 +62,7 @@ namespace SystemService
       Tables db{psibase::getReceiver()};
    };
    PSIO_REFLECT(AuthDelegateSys,  //
-                method(checkAuthSys, flags, requester, action, allowedActions, claims),
+                method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),
                 method(canAuthUserSys, user),
                 method(setOwner, owner)
                 //

--- a/services/system/AuthEcSys/include/services/system/AuthEcSys.hpp
+++ b/services/system/AuthEcSys/include/services/system/AuthEcSys.hpp
@@ -14,63 +14,66 @@ namespace SystemService
       {
          /// The account whose transactions will be required to contain the specified public key.
          psibase::AccountNumber account;
-         
+
          /// The public key included in the claims for each transaction sent by this account.
-         psibase::PublicKey     pubkey;
+         psibase::PublicKey pubkey;
 
          auto byPubkey() const { return std::tuple{pubkey, account}; }
       };
       PSIO_REFLECT(AuthRecord, account, pubkey)
-   } // namespace AuthEc 
+   }  // namespace AuthEcRecord
 
    /// The `auth-ec-sys` service is an auth service that can be used to authenticate actions for accounts
    ///
    /// Any account using this auth service must store in this service an ECDCSA public key that they own.
    /// This service will ensure that the specified public key is included in the transaction claims for any
-   /// transaction sent by this account. 
+   /// transaction sent by this account.
    ///
    /// This service only supports K1 keys (Secp256K1) keys.
    class AuthEcSys : public psibase::Service<AuthEcSys>
    {
-   public:
+     public:
       static constexpr auto service = psibase::AccountNumber("auth-ec-sys");
-      using AuthTable = psibase::Table<AuthEcRecord::AuthRecord, &AuthEcRecord::AuthRecord::account, &AuthEcRecord::AuthRecord::byPubkey>;
-      using Tables    = psibase::ServiceTables<AuthTable>;
+      using AuthTable               = psibase::Table<AuthEcRecord::AuthRecord,
+                                       &AuthEcRecord::AuthRecord::account,
+                                       &AuthEcRecord::AuthRecord::byPubkey>;
+      using Tables                  = psibase::ServiceTables<AuthTable>;
 
       /// This is an implementation of the standard auth service interface defined in [SystemService::AuthInterface]
-      /// 
-      /// This action is automatically called by `transact-sys` when an account using this auth service submits a 
+      ///
+      /// This action is automatically called by `transact-sys` when an account using this auth service submits a
       /// transaction.
       ///
       /// This action verifies that the transaction contains a claim for the user's public key.
       void checkAuthSys(uint32_t                    flags,
                         psibase::AccountNumber      requester,
-                        psibase::Action             action,
+                        psibase::AccountNumber      sender,
+                        ServiceMethod               action,
                         std::vector<ServiceMethod>  allowedActions,
                         std::vector<psibase::Claim> claims);
 
       /// This is an implementation of the standard auth service interface defined by [SystemService::AuthInterface]
-      /// 
+      ///
       /// This action is automatically called by `account-sys` when an account is configured to use this auth service.
       ///
-      /// Verifies that a particular user is allowed to use a particular auth service. 
+      /// Verifies that a particular user is allowed to use a particular auth service.
       ///
       /// This action allows any user who has already set a public key using `AuthEcSys::setKey`.
       void canAuthUserSys(psibase::AccountNumber user);
 
       /// Set the sender's public key
-      /// 
-      /// This is the public key that must be claimed by the transaction whenever a sender using this auth service 
+      ///
+      /// This is the public key that must be claimed by the transaction whenever a sender using this auth service
       /// submits a transaction. Only accepts K1 keys.
       void setKey(psibase::PublicKey key);
 
-   private:
+     private:
       Tables db{psibase::getReceiver()};
    };
    PSIO_REFLECT(AuthEcSys,  //
-               method(checkAuthSys, flags, requester, action, allowedActions, claims),
-               method(canAuthUserSys, user),
-               method(setKey, key)
-               //
+                method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),
+                method(canAuthUserSys, user),
+                method(setKey, key)
+                //
    )
 }  // namespace SystemService

--- a/services/system/AuthEcSys/src/AuthEcSys.cpp
+++ b/services/system/AuthEcSys/src/AuthEcSys.cpp
@@ -13,7 +13,8 @@ namespace SystemService
 {
    void AuthEcSys::checkAuthSys(uint32_t                    flags,
                                 psibase::AccountNumber      requester,
-                                psibase::Action             action,
+                                psibase::AccountNumber      sender,
+                                ServiceMethod               action,
                                 std::vector<ServiceMethod>  allowedActions,
                                 std::vector<psibase::Claim> claims)
    {
@@ -32,7 +33,7 @@ namespace SystemService
       else if (type != AuthInterface::topActionReq)
          abortMessage("unsupported auth type");
 
-      auto row = db.open<AuthTable>().getIndex<0>().get(action.sender);
+      auto row = db.open<AuthTable>().getIndex<0>().get(sender);
 
       check(row.has_value(), "sender does not have a public key");
 
@@ -54,9 +55,10 @@ namespace SystemService
             return;
          }
       }
-      abortMessage("transaction does not include a claim for the key " + publicKeyToString(row->pubkey) +
-                   " needed to authenticate sender " + action.sender.str() + " for action " +
-                   action.service.str() + "::" + action.method.str());
+      abortMessage("transaction does not include a claim for the key " +
+                   publicKeyToString(row->pubkey) + " needed to authenticate sender " +
+                   sender.str() + " for action " + action.service.str() +
+                   "::" + action.method.str());
    }
 
    void AuthEcSys::canAuthUserSys(psibase::AccountNumber user)

--- a/services/system/AuthSys/include/services/system/AuthSys.hpp
+++ b/services/system/AuthSys/include/services/system/AuthSys.hpp
@@ -58,9 +58,9 @@ namespace SystemService
    {
       /// The account whose transactions will be required to contain the specified public key.
       psibase::AccountNumber account;
-      
+
       /// The public key included in the claims for each transaction sent by this account.
-      SubjectPublicKeyInfo   pubkey;
+      SubjectPublicKeyInfo pubkey;
 
       auto byPubkey() const { return std::tuple{pubkey, account}; }
    };
@@ -70,7 +70,7 @@ namespace SystemService
    ///
    /// Any account using this auth service must store in this service a public key that they own.
    /// This service will ensure that the specified public key is included in the transaction claims for any
-   /// transaction sent by this account. 
+   /// transaction sent by this account.
    ///
    /// This service supports K1 or R1 keys (Secp256K1 or Secp256R1) keys.
    class AuthSys : public psibase::Service<AuthSys>
@@ -81,29 +81,30 @@ namespace SystemService
       using Tables    = psibase::ServiceTables<AuthTable>;
 
       /// This is an implementation of the standard auth service interface defined in [SystemService::AuthInterface]
-      /// 
-      /// This action is automatically called by `transact-sys` when an account using this auth service submits a 
+      ///
+      /// This action is automatically called by `transact-sys` when an account using this auth service submits a
       /// transaction.
       ///
       /// This action verifies that the transaction contains a claim for the user's public key.
       void checkAuthSys(uint32_t                    flags,
                         psibase::AccountNumber      requester,
-                        psibase::Action             action,
+                        psibase::AccountNumber      sender,
+                        ServiceMethod               action,
                         std::vector<ServiceMethod>  allowedActions,
                         std::vector<psibase::Claim> claims);
 
       /// This is an implementation of the standard auth service interface defined in [SystemService::AuthInterface]
-      /// 
+      ///
       /// This action is automatically called by `account-sys` when an account is configured to use this auth service.
       ///
-      /// Verifies that a particular user is allowed to use a particular auth service. 
+      /// Verifies that a particular user is allowed to use a particular auth service.
       ///
       /// This action allows any user who has already set a public key using `AuthSys::setKey`.
       void canAuthUserSys(psibase::AccountNumber user);
 
       /// Set the sender's public key
-      /// 
-      /// This is the public key that must be claimed by the transaction whenever a sender using this auth service 
+      ///
+      /// This is the public key that must be claimed by the transaction whenever a sender using this auth service
       /// submits a transaction.
       void setKey(SubjectPublicKeyInfo key);
 
@@ -111,7 +112,7 @@ namespace SystemService
       Tables db{psibase::getReceiver()};
    };
    PSIO_REFLECT(AuthSys,  //
-                method(checkAuthSys, flags, requester, action, allowedActions, claims),
+                method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),
                 method(canAuthUserSys, user),
                 method(setKey, key)
                 //

--- a/services/system/AuthSys/src/AuthSys.cpp
+++ b/services/system/AuthSys/src/AuthSys.cpp
@@ -39,7 +39,8 @@ namespace SystemService
 
    void AuthSys::checkAuthSys(uint32_t                    flags,
                               psibase::AccountNumber      requester,
-                              psibase::Action             action,
+                              psibase::AccountNumber      sender,
+                              ServiceMethod               action,
                               std::vector<ServiceMethod>  allowedActions,
                               std::vector<psibase::Claim> claims)
    {
@@ -55,7 +56,7 @@ namespace SystemService
       else if (type != AuthInterface::topActionReq)
          abortMessage("unsupported auth type");
 
-      auto row = db.open<AuthTable>().getIndex<0>().get(action.sender);
+      auto row = db.open<AuthTable>().getIndex<0>().get(sender);
 
       check(row.has_value(), "sender does not have a public key");
 
@@ -77,9 +78,9 @@ namespace SystemService
             return;
          }
       }
-      abortMessage("transaction does not include a claim for the key " + keyFingerprint(row->pubkey) +
-                   " needed to authenticate sender " + action.sender.str() + " for action " +
-                   action.service.str() + "::" + action.method.str());
+      abortMessage("transaction does not include a claim for the key " +
+                   keyFingerprint(row->pubkey) + " needed to authenticate sender " + sender.str() +
+                   " for action " + action.service.str() + "::" + action.method.str());
    }
 
    void AuthSys::canAuthUserSys(psibase::AccountNumber user)

--- a/services/system/ProducerSys/include/services/system/ProducerSys.hpp
+++ b/services/system/ProducerSys/include/services/system/ProducerSys.hpp
@@ -47,6 +47,6 @@ namespace SystemService
    PSIO_REFLECT(ProducerSys,
                 method(setConsensus, consensus),
                 method(setProducers, producers),
-                method(checkAuthSys, flags, requester, action, allowedActions, claims),
+                method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),
                 method(canAuthUserSys, user))
 }  // namespace SystemService

--- a/services/system/ProducerSys/include/services/system/ProducerSys.hpp
+++ b/services/system/ProducerSys/include/services/system/ProducerSys.hpp
@@ -38,7 +38,8 @@ namespace SystemService
       // Allows this service to be used as an auth service for `prods-weak` and `prods-strong`.
       void checkAuthSys(uint32_t                    flags,
                         psibase::AccountNumber      requester,
-                        psibase::Action             action,
+                        psibase::AccountNumber      sender,
+                        ServiceMethod               action,
                         std::vector<ServiceMethod>  allowedActions,
                         std::vector<psibase::Claim> claims);
       void canAuthUserSys(psibase::AccountNumber user);

--- a/services/system/ProducerSys/src/ProducerSys.cpp
+++ b/services/system/ProducerSys/src/ProducerSys.cpp
@@ -92,7 +92,8 @@ namespace SystemService
 
    void ProducerSys::checkAuthSys(uint32_t                    flags,
                                   psibase::AccountNumber      requester,
-                                  psibase::Action             action,
+                                  psibase::AccountNumber      sender,
+                                  ServiceMethod               action,
                                   std::vector<ServiceMethod>  allowedActions,
                                   std::vector<psibase::Claim> claims)
    {
@@ -129,11 +130,10 @@ namespace SystemService
           expectedClaims, [&](const auto& claim)
           { return claim == Claim{} || std::ranges::binary_search(claims, claim, compare_claim); });
 
-      auto threshold =
-          expectedClaims.empty()
-              ? 0
-              : std::visit([&](const auto& c) { return getThreshold(c, action.sender); },
-                           status->consensus);
+      auto threshold = expectedClaims.empty()
+                           ? 0
+                           : std::visit([&](const auto& c) { return getThreshold(c, sender); },
+                                        status->consensus);
       if (matching < threshold)
       {
          abortMessage("runAs: have " + std::to_string(matching) + "/" + std::to_string(threshold) +

--- a/services/system/TransactionSys/include/services/system/TransactionSys.hpp
+++ b/services/system/TransactionSys/include/services/system/TransactionSys.hpp
@@ -116,6 +116,7 @@ namespace SystemService
       ///                     the sender of the `runAs` action.
       ///                     This is often different from
       ///                     `action.sender`.
+      /// * `sender`          The sender being requested for the action.
       /// * `action`:         Action to authenticate
       /// * `allowedActions`: Argument from `runAs`
       /// * `claims`:         Claims in transaction (e.g. public keys).
@@ -124,7 +125,8 @@ namespace SystemService
       // TODO: return error message instead?
       void checkAuthSys(uint32_t                    flags,
                         psibase::AccountNumber      requester,
-                        psibase::Action             action,
+                        psibase::AccountNumber      sender,
+                        ServiceMethod               action,
                         std::vector<ServiceMethod>  allowedActions,
                         std::vector<psibase::Claim> claims);
 
@@ -139,7 +141,7 @@ namespace SystemService
       void canAuthUserSys(psibase::AccountNumber user);
    };
    PSIO_REFLECT(AuthInterface,
-                method(checkAuthSys, flags, requester, action, allowedActions, claims),
+                method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),
                 method(canAuthUserSys, user))
 
    struct TransactionSysStatus
@@ -198,14 +200,14 @@ namespace SystemService
 
       /// This action enables the boot procedure to be split across multiple blocks
       ///
-      /// It is only called once, immediately after the boot transaction. 
+      /// It is only called once, immediately after the boot transaction.
       ///
-      /// `bootTransactions` defines the list of subsequent transaction hashes to which 
-      /// the node operator is committing as part of the boot sequence. The subsequent 
-      /// transactions listed must then be pushed in order, and no other transactions 
+      /// `bootTransactions` defines the list of subsequent transaction hashes to which
+      /// the node operator is committing as part of the boot sequence. The subsequent
+      /// transactions listed must then be pushed in order, and no other transactions
       /// will be accepted until [finishBoot] is run.
       void startBoot(psio::view<const std::vector<psibase::Checksum256>> bootTransactions);
-      
+
       /// Only called once during chain initialization
       ///
       /// This enables the auth checking system. Before this point, `TransactionSys`

--- a/services/system/TransactionSys/src/TransactionSys.cpp
+++ b/services/system/TransactionSys/src/TransactionSys.cpp
@@ -152,7 +152,9 @@ namespace SystemService
             }
 
             Actor<AuthInterface> auth(TransactionSys::service, account->authService);
-            auth.checkAuthSys(flags, requester, action, allowedActions, std::vector<Claim>{});
+            auth.checkAuthSys(flags, requester, action.sender,
+                              ServiceMethod{action.service, action.method}, allowedActions,
+                              std::vector<Claim>{});
          }  // if (requester != account->authService)
       }     // if(enforceAuth)
 
@@ -322,7 +324,8 @@ namespace SystemService
             if (args.checkFirstAuthAndExit)
                flags |= AuthInterface::readOnlyFlag;
             // This can execute user defined code, so we must set the timer first
-            auth.checkAuthSys(flags, psibase::AccountNumber{}, act, std::vector<ServiceMethod>{},
+            auth.checkAuthSys(flags, psibase::AccountNumber{}, act.sender,
+                              ServiceMethod{act.service, act.method}, std::vector<ServiceMethod>{},
                               trx.claims);
          }
          if (args.checkFirstAuthAndExit)

--- a/services/user/InviteSys/include/services/user/AuthInviteSys.hpp
+++ b/services/user/InviteSys/include/services/user/AuthInviteSys.hpp
@@ -15,7 +15,8 @@ namespace UserService
 
       void checkAuthSys(uint32_t                                  flags,
                         psibase::AccountNumber                    requester,
-                        psibase::Action                           action,
+                        psibase::AccountNumber                    sender,
+                        SystemService::ServiceMethod              action,
                         std::vector<SystemService::ServiceMethod> allowedActions,
                         std::vector<psibase::Claim>               claims);
       void canAuthUserSys(psibase::AccountNumber user);
@@ -27,7 +28,7 @@ namespace UserService
       void storeSys(std::string path, std::string contentType, std::vector<char> content);
    };
    PSIO_REFLECT(AuthInviteSys,  //
-                method(checkAuthSys, flags, requester, action, allowedActions, claims),
+                method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),
                 method(canAuthUserSys, user),
                 method(requireAuth, pubkey),
                 method(serveSys, request),

--- a/services/user/InviteSys/src/AuthInviteSys.cpp
+++ b/services/user/InviteSys/src/AuthInviteSys.cpp
@@ -15,7 +15,8 @@ namespace UserService
 {
    void AuthInviteSys::checkAuthSys(uint32_t                   flags,
                                     AccountNumber              requester,
-                                    Action                     action,
+                                    AccountNumber              sender,
+                                    ServiceMethod              action,
                                     std::vector<ServiceMethod> allowedActions,
                                     std::vector<Claim>         claims)
    {


### PR DESCRIPTION
This should increase the effective maximum action size, though it doesn't fully resolve it.