### PR TITLE
Add logging of transaction and query console output

### DIFF
--- a/doc/psidk/src/run-infrastructure/configuration/logging.md
+++ b/doc/psidk/src/run-infrastructure/configuration/logging.md
@@ -164,6 +164,7 @@ Examples:
 | `Escape`         | Formatters                        | N/A                             | Escapes a list of characters in a subformat.                                        |
 | `FrameDec`       | Formatters                        | N/A                             | Prefixes a nested format with a decimal octet count                                 |
 | `Host`           | All records                       | `=`, `!=`                       | The system's FQDN (not the HTTP server's virtual hostname)                          |
+| `Indent`         | Formatters                        | N/A                             | Formats an indented block                                                           |
 | `Json`           | Formatters                        | N/A                             | Formats the entire log record as JSON                                               |
 | `Message`        | Formatters                        | N/A                             | The log message                                                                     |
 | `PeerId`         | p2p connections                   | `=`, `!=`, `<`, `>`, `<=`, `>=` |                                                                                     |
@@ -179,6 +180,8 @@ Examples:
 | `Severity`       | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | The value is one of `debug`, `info`, `notice`, `warning`, `error`, or `critical`    |
 | `Syslog`         | Formatters                        | N/A                             | Formats a [syslog](#syslog) header.                                                 |
 | `TimeStamp`      | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | ISO 8601 extended format                                                            |
+| `Trace`          | transactions and HTTP requests    | None                            | The transaction trace formatted as JSON                                             |
+| `TraceConsole`   | transactions and HTTP requests    | None                            | The console output of the transation. Can be multiple lines.                        |
 | `TransactionId`  | transactions                      | `=`, `!=`                       |                                                                                     |
 
 ### Severity
@@ -203,6 +206,13 @@ Characters can be backslash-escaped using `{Escape:chars:subformat}`. *chars* sp
 Example:
 - Escape a JSON string: `{{{"message":"{Escape:\":{Message}}"}}}`
 - Escape a shell command: ``foo "{Escape:\"`$:{Message}}"``
+
+### Indent
+
+Every line of a multi-line format can be indented with `{Indent:width:subformat}`.
+
+Example:
+- `{Indent:4:{TraceConsole}}`
 
 ### Syslog
 

--- a/doc/psidk/src/run-infrastructure/configuration/logging.md
+++ b/doc/psidk/src/run-infrastructure/configuration/logging.md
@@ -181,7 +181,7 @@ Examples:
 | `Syslog`         | Formatters                        | N/A                             | Formats a [syslog](#syslog) header.                                                 |
 | `TimeStamp`      | All records                       | `=`, `!=`, `<`, `>`, `<=`, `>=` | ISO 8601 extended format                                                            |
 | `Trace`          | transactions and HTTP requests    | None                            | The transaction trace formatted as JSON                                             |
-| `TraceConsole`   | transactions and HTTP requests    | None                            | The console output of the transation. Can be multiple lines.                        |
+| `TraceConsole`   | transactions and HTTP requests    | None                            | The console output of the transation. Can contain arbitrary bytes.                  |
 | `TransactionId`  | transactions                      | `=`, `!=`                       |                                                                                     |
 
 ### Severity
@@ -227,3 +227,7 @@ If both a format and facility are specified, they should be separated by a `;`.
 Examples:
 - `{Syslog:local1;rfc5424}`
 - `{Syslog:glibc}`: Suitable for writing to `/dev/log` on linux systems.
+
+### TraceConsole
+
+This is the raw console output of a transaction. It is fully controlled by the service author and is not sanitized in any way. It should be escaped or encoded in a way that prevents lines in the contents from being treated as separate log records by any downstream tools.

--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -33,8 +33,7 @@ namespace psibase
    {
       auto getProducers = [](auto& consensus) -> auto&
       {
-         return std::visit(
-             [](auto& c) -> auto& { return c.producers; }, consensus);
+         return std::visit([](auto& c) -> auto& { return c.producers; }, consensus);
       };
       auto& prods = getProducers(status.consensus);
       if (prods.size() == 1)
@@ -202,8 +201,7 @@ namespace psibase
       if (status->nextConsensus && std::get<1>(*status->nextConsensus) == status->current.blockNum)
       {
          auto& nextConsensus = std::get<0>(*status->nextConsensus);
-         auto& prods         = std::visit(
-             [](auto& c) -> auto& { return c.producers; }, nextConsensus);
+         auto& prods = std::visit([](auto& c) -> auto& { return c.producers; }, nextConsensus);
          // Special case: If no producers are specified, use the producers of the current block
          if (prods.empty())
          {
@@ -405,6 +403,7 @@ namespace psibase
             session.commit();
             active = true;
          }
+         BOOST_LOG_SCOPED_LOGGER_TAG(trxLogger, "Trace", trace);
          PSIBASE_LOG(trxLogger, info) << "Transaction succeeded";
          return std::move(t.subjectiveData);
       }

--- a/libraries/psibase_http/http.cpp
+++ b/libraries/psibase_http/http.cpp
@@ -767,6 +767,9 @@ namespace psibase::http
             auto result  = psio::from_frac<std::optional<HttpReply>>(atrace.rawRetval);
             auto endTime = steady_clock::now();
 
+            trace.actionTraces.push_back(std::move(atrace));
+            BOOST_LOG_SCOPED_LOGGER_TAG(send.self.logger, "Trace", std::move(trace));
+
             // TODO: consider bundling into a single attribute
             BOOST_LOG_SCOPED_LOGGER_TAG(
                 send.self.logger, "PackTime",

--- a/programs/psinode/config.in
+++ b/programs/psinode/config.in
@@ -20,4 +20,4 @@ admin-authz = rw:loopback
 [logger.stderr]
 type   = console
 filter = Severity >= info
-format = [{TimeStamp}] [{Severity}]{?: [{RemoteEndpoint}]}: {Message}{?: {TransactionId}}{?: {BlockId}}{?RequestMethod:: {RequestMethod} {RequestHost}{RequestTarget}{?: {ResponseStatus}{?: {ResponseBytes}}}}{?: {ResponseTime} µs}
+format = [{TimeStamp}] [{Severity}]{?: [{RemoteEndpoint}]}: {Message}{?: {TransactionId}}{?: {BlockId}}{?RequestMethod:: {RequestMethod} {RequestHost}{RequestTarget}{?: {ResponseStatus}{?: {ResponseBytes}}}}{?: {ResponseTime} µs}{Indent:4:{TraceConsole}}


### PR DESCRIPTION
The default format shows it indented 4 spaces. The output is controlled by the service author and is not sanitized. Beware if sending it to an automated consumer.