### PR TITLE
Organize thirdParty resources under common/resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,7 +337,7 @@ psibase_package(
 )
 
 set(COMMON_SYS ${CMAKE_CURRENT_SOURCE_DIR}/services/user/CommonSys)
-set(THIRD_SRC ${COMMON_SYS}/common/thirdParty/src)
+set(THIRD_SRC ${COMMON_SYS}/common/resources/thirdParty/src)
 set(THIRD_FILES
     ${THIRD_SRC}/htm.module.js
     ${THIRD_SRC}/iframeResizer.contentWindow.js

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -3,7 +3,7 @@ enable_testing()
 function(downloadThirdParty depName depUrl)
     ExternalProject_Add(
         ${depName}
-        PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/common/thirdParty
+        PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/common/resources/thirdParty
         URL ${depUrl}
         DOWNLOAD_NO_EXTRACT 1
         CONFIGURE_COMMAND ""

--- a/services/user/AdminSys/ui/vite.config.ts
+++ b/services/user/AdminSys/ui/vite.config.ts
@@ -10,7 +10,7 @@ const psibase = (_appletContract: string, isServing?: boolean) => {
         {
             find: "/common/iframeResizer.contentWindow.js",
             replacement: path.resolve(
-                "../../CommonSys/common/thirdParty/src/iframeResizer.contentWindow.js"
+                "../../CommonSys/common/resources/thirdParty/src/iframeResizer.contentWindow.js"
             ),
         },
         {

--- a/services/user/CommonSys/common/.gitignore
+++ b/services/user/CommonSys/common/.gitignore
@@ -1,1 +1,1 @@
-thirdParty/*
+resources/thirdParty/*

--- a/services/user/CommonSys/ui/vite.config.ts
+++ b/services/user/CommonSys/ui/vite.config.ts
@@ -9,7 +9,7 @@ const psibase = (appletContract: string, isServing?: boolean) => {
         {
             find: "/common/iframeResizer.contentWindow.js",
             replacement: path.resolve(
-                "../common/thirdParty/src/iframeResizer.contentWindow.js"
+                "../common/resources/thirdParty/src/iframeResizer.contentWindow.js"
             ),
         },
         {

--- a/services/user/ExploreSys/ui/vite.config.ts
+++ b/services/user/ExploreSys/ui/vite.config.ts
@@ -11,7 +11,7 @@ const psibase = (appletContract: string, isServing?: boolean) => {
         {
             find: "/common/iframeResizer.contentWindow.js",
             replacement: path.resolve(
-                "../../CommonSys/common/thirdParty/src/iframeResizer.contentWindow.js"
+                "../../CommonSys/common/resources/thirdParty/src/iframeResizer.contentWindow.js"
             ),
         },
         {


### PR DESCRIPTION
This moves the `thirdParty` directory from `/common` to `/common/resources`.