### PR TITLE
generate wasm compile-commands.json

### DIFF
--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_policy(VERSION 3.16)
 project(wasm)
 enable_testing()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(IS_WASM YES)
 set(BUILD_STATIC ON)
 get_filename_component(ROOT_SOURCE_DIR ${CMAKE_SOURCE_DIR}/.. ABSOLUTE)


### PR DESCRIPTION
This helps anyone who is using clang-format, they can point it at `build/wasm/compile-commands.json` to get better autocomplete.

This is already configured in the [psibase-contributor](https://github.com/gofractally/psibase-contributor) tool.