### PR TITLE
Upgrade DemoApp2 for cargo component 0.9.0

### DIFF
--- a/services/user/DemoApp2/plugin/Cargo.lock
+++ b/services/user/DemoApp2/plugin/Cargo.lock
@@ -12,14 +12,12 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 name = "demoapp2"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen",
+ "bitflags",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.16.0"
+name = "wit-bindgen-rt"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b76f1d099678b4f69402a421e888bbe71bf20320c2f3f3565d0e7484dbe5bc20"
-dependencies = [
- "bitflags",
-]
+checksum = "026d24a27f6712541fa534f2954bd9e0eb66172f033c2157c0f31d106255c497"

--- a/services/user/DemoApp2/plugin/Cargo.toml
+++ b/services/user/DemoApp2/plugin/Cargo.toml
@@ -6,10 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# This set ups WASI Preview 2 bindings to work with `cargo component 0.7.0`
-wit-bindgen = { version = "0.16.0", default-features = false, features = [
-    "realloc",
-] }
+# This sets up WASI Preview 2 bindings to work with `cargo component 0.9.0`
+bitflags = "2.4.2"
+wit-bindgen-rt = "0.21.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/services/user/DemoApp2/plugin/src/lib.rs
+++ b/services/user/DemoApp2/plugin/src/lib.rs
@@ -14,3 +14,5 @@ impl Guest for Component {
         return logged_in_user + " is logged in";
     }
 }
+
+bindings::export!(Component with_types_in bindings);


### PR DESCRIPTION
This is included in John's PR, but this bumps the bindings version 1 more minor version and gets these building in the feature branch.