### PR TITLE
Add event emission in rust

### DIFF
--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -196,7 +196,7 @@ pub fn put_sequential<Type: Pack, V: Pack>(
     ty: &Type,
     value: &V,
 ) -> u64 {
-    put_sequential_bytes(db, &(service, ty, value).packed())
+    put_sequential_bytes(db, &(service, Some(ty), Some(value)).packed())
 }
 
 /// Remove a key-value pair if it exists

--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -196,11 +196,7 @@ pub fn put_sequential<Type: Pack, V: Pack>(
     ty: &Type,
     value: &V,
 ) -> u64 {
-    let mut packed = Vec::new();
-    service.pack(&mut packed);
-    ty.pack(&mut packed);
-    value.pack(&mut packed);
-    put_sequential_bytes(db, &packed)
+    put_sequential_bytes(db, &(service, ty, value).packed())
 }
 
 /// Remove a key-value pair if it exists

--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -291,3 +291,8 @@ pub fn kv_max<K: ToKey, V: UnpackOwned>(db_id: DbId, key: &K) -> Option<V> {
     let bytes = kv_max_bytes(db_id, &key.to_key());
     bytes.map(|v| V::unpack(&v[..], &mut 0).unwrap())
 }
+
+pub fn get_sequential_bytes(db_id: DbId, id: u64) -> Option<Vec<u8>> {
+    let size = unsafe { native_raw::getSequential(db_id, id) };
+    get_optional_result_bytes(size)
+}

--- a/rust/psibase_macros/src/service_macro.rs
+++ b/rust/psibase_macros/src/service_macro.rs
@@ -1406,8 +1406,7 @@ fn process_gql_union_member(
         #dispatch
 
         #psibase_mod::method_raw!(#name_str) => {
-            let (_, _, gql_imp_content) = <(#psibase_mod::AccountNumber, #psibase_mod::MethodNumber, #name) as #psibase_mod::fracpack::Unpack>::unpacked(gql_imp_data)?;
-            Ok(#event_struct::#name(gql_imp_content))
+            Ok(#event_struct::#name(#psibase_mod::decode_event_data::<#name>(gql_imp_data)?))
         },
     };
 }


### PR DESCRIPTION
This basically mirrors the existing C++ API for emission.

GraphQL support is significantly simplified.
```
#[event(history)]
fn created(prevEvent: u64, tokenId: TID, creator: AccountNumber, precision: Precision, max_supply: Quantity) {}
...
Wrapper::emit().ui().created(prev, tid, creator, precision, max_supply);
...
let e: event_structs::HistoryEvents = get_event(id)?;
let e: event_structs::history::created = get_event(id)?;
```