### PR TITLE
Remove outdated flags from build script

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -48,7 +48,7 @@ echo =====
 ${DOCKER} sccache -s
 echo =====
 mkdir -p build
-${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_WASM=yes -DBUILD_DEBUG_WASM=yes -DBUILD_DOC=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
+${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_DEBUG_WASM=yes -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache .."
 echo =====
 ${DOCKER} bash -c "cd build && make -j $(nproc)"
 echo =====


### PR DESCRIPTION
Sparky pointed out that the build script wasn't updated since
https://github.com/gofractally/psibase/pull/569
