### PR TITLE
don't minify various libraries under active develoment

### DIFF
--- a/dev/DemoApp1/ui/vite.config.ts
+++ b/dev/DemoApp1/ui/vite.config.ts
@@ -16,4 +16,7 @@ export default defineConfig({
       },
     ],
   },
+  build: {
+    minify: false,
+  },
 });

--- a/services/user/CommonApi/common/packages/common-lib/vite.config.ts
+++ b/services/user/CommonApi/common/packages/common-lib/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       name: "@psibase/common-lib",
       fileName: "common-lib",
     },
+    minify: false,
   },
   plugins: [dts()],
 });

--- a/services/user/Supervisor/ui/vite.config.ts
+++ b/services/user/Supervisor/ui/vite.config.ts
@@ -19,5 +19,6 @@ export default defineConfig({
     },
     build: {
         target: "esnext",
+        minify: false,
     },
 });


### PR DESCRIPTION
I keep having to add these flags locally to make debugging easier. I think we should just leave them unminified and we can minify them  later when they are more stable. 