### PR TITLE
Relax the single-threaded timer accuracy test

### DIFF
--- a/libraries/psibase/native/tests/WatchdogTests.cpp
+++ b/libraries/psibase/native/tests/WatchdogTests.cpp
@@ -64,18 +64,29 @@ TEST_CASE("Watchdog zero limit")
 
 TEST_CASE("Watchdog required accuracy")
 {
-   std::atomic<bool> interrupted{false};
-   WatchdogManager   manager;
-   auto              duration = std::chrono::milliseconds(20);
-   auto              start    = CpuClock::now();
-   Watchdog          watchdog(manager, [&] { interrupted = true; });
-   watchdog.setLimit(duration);
-   while (!interrupted)
+   constexpr int run_count        = 5;
+   constexpr int allowed_failures = 1;
+   int           failed           = 0;
+   for (int i = 0; i < run_count; ++i)
    {
+      std::atomic<bool> interrupted{false};
+      WatchdogManager   manager;
+      auto              duration = std::chrono::milliseconds(20);
+      auto              start    = CpuClock::now();
+      Watchdog          watchdog(manager, [&] { interrupted = true; });
+      watchdog.setLimit(duration);
+      while (!interrupted)
+      {
+      }
+      auto end = CpuClock::now();
+      CHECK(end - start >= duration);
+      if (end - start - duration >= std::chrono::milliseconds(5))
+      {
+         ++failed;
+         INFO("overrun: " << (end - start - duration));
+         CHECK(failed <= allowed_failures);
+      }
    }
-   auto end = CpuClock::now();
-   CHECK(end - start >= duration);
-   CHECK(end - start - duration < std::chrono::milliseconds(5));
 }
 
 TEST_CASE("Watchdog maximum limit")

--- a/libraries/psibase/native/tests/WatchdogTests.cpp
+++ b/libraries/psibase/native/tests/WatchdogTests.cpp
@@ -83,7 +83,6 @@ TEST_CASE("Watchdog required accuracy")
       if (end - start - duration >= std::chrono::milliseconds(5))
       {
          ++failed;
-         INFO("overrun: " << (end - start - duration));
          CHECK(failed <= allowed_failures);
       }
    }


### PR DESCRIPTION
The multi-threaded test already allows overrun some of the time. I've been seeing occasional failures in the single-threaded test instead now.