### PR TITLE
Handle AccountNumbers as query keys

### DIFF
--- a/libraries/psibase/common/include/psibase/AccountNumber.hpp
+++ b/libraries/psibase/common/include/psibase/AccountNumber.hpp
@@ -69,6 +69,11 @@ namespace psibase
       return true;
    }
 
+   inline constexpr bool psio_custom_schema(AccountNumber*)
+   {
+      return true;
+   }
+
    inline namespace literals
    {
       inline constexpr AccountNumber operator""_a(const char* s, unsigned long)

--- a/libraries/psibase/common/include/psibase/schema.hpp
+++ b/libraries/psibase/common/include/psibase/schema.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <psibase/AccountNumber.hpp>
+
+namespace psibase
+{
+   inline psio::schema_types::CustomTypes psibase_types()
+   {
+      auto result = psio::schema_types::standard_types();
+      result.insert<AccountNumber>("AccountNumber");
+      return result;
+   }
+}  // namespace psibase

--- a/services/user/Events/src/types.cpp
+++ b/services/user/Events/src/types.cpp
@@ -1,11 +1,13 @@
 #include "types.hpp"
 
+#include <psibase/schema.hpp>
+
 using namespace psio::schema_types;
 
 namespace UserService
 {
 
-   const CustomTypes psibase_builtins = standard_types();
+   const CustomTypes psibase_builtins = psibase::psibase_types();
 
    const AnyType u64Type = Int{.bits = 64, .isSigned = false};
 

--- a/services/user/Events/test/TestService.cpp
+++ b/services/user/Events/test/TestService.cpp
@@ -22,4 +22,9 @@ void TestService::sendString(const std::string& s)
    emit().history().str(s);
 }
 
+void TestService::sendAccount(psibase::AccountNumber a)
+{
+   emit().history().account(a);
+}
+
 PSIBASE_DISPATCH(TestService)

--- a/services/user/Events/test/TestService.hpp
+++ b/services/user/Events/test/TestService.hpp
@@ -10,6 +10,7 @@ struct TestService : psibase::Service<TestService>
    void sendOptional(std::optional<std::int32_t> opt);
    void sendOptional8(std::optional<std::uint8_t> opt);
    void sendString(const std::string& s);
+   void sendAccount(psibase::AccountNumber account);
    struct Events
    {
       struct Ui
@@ -21,6 +22,7 @@ struct TestService : psibase::Service<TestService>
          void opt(std::optional<std::int32_t> opt);
          void optb(std::optional<std::uint8_t> opt);
          void str(std::string s);
+         void account(psibase::AccountNumber a);
       };
       struct Merkle
       {
@@ -31,13 +33,15 @@ PSIO_REFLECT(TestService,
              method(send, i, d, v, s),
              method(sendOptional, opt),
              method(sendOptional8, opt),
-             method(sendString, s))
+             method(sendString, s),
+             method(sendAccount, a))
 
 PSIBASE_REFLECT_EVENTS(TestService);
 PSIBASE_REFLECT_HISTORY_EVENTS(TestService,
                                method(testEvent, i, d, v, s),
                                method(opt, opt),
                                method(optb, opt),
-                               method(str, s));
+                               method(str, s),
+                               method(account, a));
 PSIBASE_REFLECT_UI_EVENTS(TestService);
 PSIBASE_REFLECT_MERKLE_EVENTS(TestService);


### PR DESCRIPTION
- Converted to a Custom type in schema
- A collation sequence that matches the ordering of accounts is applied to columns with the AccountNumber type.
- Indexes ignore constraints that require collation sequences that do not match the collation sequence of the indexed column.