### PR TITLE
Improve token service graphql queries

### DIFF
--- a/.vscode/tasks.json.sample
+++ b/.vscode/tasks.json.sample
@@ -15,6 +15,21 @@
                 }
             }
         }
+        // Keeping the below example to show how to run service unit tests:
+        // {
+        //     "label": "Test NFT",
+        //     "type": "shell",
+        //     "command": "cd build && psitest Nft-test-debug.wasm -s -r compact",
+        //     "group": {
+        //         "kind": "test",
+        //         "isDefault": false
+        //     },
+        //     "options": {
+        //         "statusbar": {
+        //             "label": "$(beaker) Test Nft"
+        //         }
+        //     }
+        // },
     ],
     "inputs": [
         {

--- a/libraries/psibase/common/include/psibase/db.hpp
+++ b/libraries/psibase/common/include/psibase/db.hpp
@@ -31,7 +31,7 @@ namespace psibase
       /// but readable by all services during RPC. Doesn't undo
       /// from aborting transactions, aborting blocks, or forking
       /// blocks. Individual nodes may modify this database or wipe
-      //  it entirely at will.
+      /// it entirely at will.
       ///
       /// The first 64 bits of the key match the service.
       subjective,

--- a/libraries/psibase/common/include/psibase/serveGraphQL.hpp
+++ b/libraries/psibase/common/include/psibase/serveGraphQL.hpp
@@ -355,7 +355,6 @@ namespace psibase
    ///
    /// Allows for a user-provided projection function that transforms elements from type T to Key
    /// before isolating a range within the container.
-   ///
    template <typename Connection, typename T, typename Key>
    Connection makeVirtualConnection(const std::vector<T>&             elements,
                                     const std::optional<Key>&         gt,

--- a/programs/psinode/tests/test_psibase.py
+++ b/programs/psinode/tests/test_psibase.py
@@ -89,7 +89,7 @@ class TestPsibase(unittest.TestCase):
         a.boot(packages=['Minimal', 'Explorer'])
         a.run_psibase(['install', 'Symbol', 'Tokens', 'TokenUsers'])
         a.wait(new_block())
-        a.graphql('tokens', '''query { userBalances(user: "alice") { user balance precision token symbol } }''')
+        a.graphql('tokens', '''query { userBalances(user: "alice") { edges { node { symbolId tokenId balance precision { value } } } } }''')
 
     @testutil.psinode_test
     def test_upgrade(self, cluster):

--- a/services/user/Tokens/include/services/user/tokenTables.hpp
+++ b/services/user/Tokens/include/services/user/tokenTables.hpp
@@ -92,10 +92,13 @@ namespace UserService
       BalanceKey key;
       uint64_t   balance;
 
+      auto byUserToken() const { return std::tuple{key.account, key.tokenId}; }
+
       auto operator<=>(const BalanceRecord&) const = default;
    };
    PSIO_REFLECT(BalanceRecord, key, balance);
-   using BalanceTable = psibase::Table<BalanceRecord, &BalanceRecord::key>;
+   using BalanceTable =
+       psibase::Table<BalanceRecord, &BalanceRecord::key, &BalanceRecord::byUserToken>;
 
    struct SharedBalanceKey
    {
@@ -112,10 +115,16 @@ namespace UserService
       SharedBalanceKey key;
       uint64_t         balance;
 
+      auto byCreditor() const { return key.creditor; }
+      auto byDebitor() const { return key.debitor; }
+
       auto operator<=>(const SharedBalanceRecord&) const = default;
    };
    PSIO_REFLECT(SharedBalanceRecord, key, balance);
-   using SharedBalanceTable = psibase::Table<SharedBalanceRecord, &SharedBalanceRecord::key>;
+   using SharedBalanceTable = psibase::Table<SharedBalanceRecord,
+                                             &SharedBalanceRecord::key,
+                                             &SharedBalanceRecord::byCreditor,
+                                             &SharedBalanceRecord::byDebitor>;
    // Todo - How can I add a secondary index for debitor? I imagine people will want to search for shared balances by debitor.
 
    struct TokenHolderRecord

--- a/services/user/Tokens/include/services/user/tokenTables.hpp
+++ b/services/user/Tokens/include/services/user/tokenTables.hpp
@@ -76,7 +76,6 @@ namespace UserService
                 maxSupply,
                 symbolId);
    using TokenTable = psibase::Table<TokenRecord, &TokenRecord::id>;
-   // Todo - add symbolId as secondary index when possible
 
    struct BalanceKey
    {
@@ -92,7 +91,7 @@ namespace UserService
       BalanceKey key;
       uint64_t   balance;
 
-      auto byUserToken() const { return std::tuple{key.account, key.tokenId}; }
+      auto byUserToken() const { return key.account; }
 
       auto operator<=>(const BalanceRecord&) const = default;
    };
@@ -125,7 +124,6 @@ namespace UserService
                                              &SharedBalanceRecord::key,
                                              &SharedBalanceRecord::byCreditor,
                                              &SharedBalanceRecord::byDebitor>;
-   // Todo - How can I add a secondary index for debitor? I imagine people will want to search for shared balances by debitor.
 
    struct TokenHolderRecord
    {

--- a/services/user/Tokens/include/services/user/tokenTables.hpp
+++ b/services/user/Tokens/include/services/user/tokenTables.hpp
@@ -91,7 +91,7 @@ namespace UserService
       BalanceKey key;
       uint64_t   balance;
 
-      auto byUserToken() const { return key.account; }
+      auto byUserToken() const { return std::tuple{key.account, key.tokenId}; }
 
       auto operator<=>(const BalanceRecord&) const = default;
    };
@@ -114,8 +114,8 @@ namespace UserService
       SharedBalanceKey key;
       uint64_t         balance;
 
-      auto byCreditor() const { return key.creditor; }
-      auto byDebitor() const { return key.debitor; }
+      auto byCreditor() const { return std::tuple{key.creditor, key.debitor, key.tokenId}; }
+      auto byDebitor() const { return std::tuple{key.debitor, key.creditor, key.tokenId}; }
 
       auto operator<=>(const SharedBalanceRecord&) const = default;
    };

--- a/services/user/Tokens/src/RTokens.cpp
+++ b/services/user/Tokens/src/RTokens.cpp
@@ -46,6 +46,18 @@ struct TokenQuery
       return balances;
    }
 
+   auto getTokenDetails(TID tokenId) const
+   {
+      for (auto token : tokenService.index<TokenTable, 0>())
+      {
+         if (token.id == tokenId)
+         {
+            return token;
+         }
+      }
+      return TokenRecord{};
+   }
+
    auto sharedBalances() const
    {  //
       return tokenService.index<SharedBalanceTable, 0>();

--- a/services/user/Tokens/src/RTokens.cpp
+++ b/services/user/Tokens/src/RTokens.cpp
@@ -13,59 +13,102 @@ using namespace UserService;
 using namespace std;
 using namespace psibase;
 
-auto tokenService = QueryableService<Tokens::Tables, Tokens::Events>{Tokens::service};
-
-struct UserBalanceRecord
+auto tokenService = Tokens::Tables{Tokens::service};
+namespace TokenQueryTypes
 {
-   AccountNumber user;
-   uint64_t      balance;
-   uint8_t       precision;
-   TID           token;
-   SID           symbol;
-};
-PSIO_REFLECT(UserBalanceRecord, user, balance, precision, token, symbol);
+   struct Balance
+   {
+      TID       id;
+      Precision precision;
+      SID       symbolId;
+      uint64_t  balance;
+   };
+   PSIO_REFLECT(Balance, id, precision, symbolId, balance);
 
+   struct Credit
+   {
+      TID           id;
+      Precision     precision;
+      SID           symbolId;
+      uint64_t      balance;
+      AccountNumber creditedTo;
+   };
+   PSIO_REFLECT(Credit, id, precision, symbolId, balance, creditedTo);
+
+   struct Debit
+   {
+      TID           id;
+      Precision     precision;
+      SID           symbolId;
+      uint64_t      balance;
+      AccountNumber debitableFrom;
+   };
+   PSIO_REFLECT(Debit, id, precision, symbolId, balance, debitableFrom);
+
+   struct AllBalances
+   {
+      vector<Balance> balances;
+      vector<Credit>  credits;
+      vector<Debit>   debits;
+   };
+   PSIO_REFLECT(AllBalances, balances, credits, debits);
+}  // namespace TokenQueryTypes
+
+using namespace TokenQueryTypes;
 struct TokenQuery
 {
    auto allBalances() const
    {  //
-      return tokenService.index<BalanceTable, 0>();
-   }
-   auto userBalances(AccountNumber user) const
-   {  //
-      vector<UserBalanceRecord> balances;
-      for (auto tokenType : tokenService.index<TokenTable, 0>())
-      {
-         auto tid = tokenType.id;
-         if (auto bal = tokenService.index<BalanceTable, 0>().get(BalanceKey{user, tid}))
-         {
-            balances.push_back(UserBalanceRecord{user, bal->balance, tokenType.precision.value, tid,
-                                                 tokenType.symbolId});
-         }
-      }
-      return balances;
+      return tokenService.open<BalanceTable>().getIndex<0>();
    }
 
-   auto getTokenDetails(TID tokenId) const
+   auto userBalances(AccountNumber user) const
    {
-      for (auto token : tokenService.index<TokenTable, 0>())
+      AllBalances balances;
+
+      auto tokenTypes = tokenService.open<TokenTable>().getIndex<0>();
+
+      // Balances of this user
+      auto balanceIdx = tokenService.open<BalanceTable>().getIndex<1>().subindex(user);
+      for (auto balance : balanceIdx)
       {
-         if (token.id == tokenId)
-         {
-            return token;
-         }
+         auto tokenOpt = tokenTypes.get(balance.key.tokenId);
+         check(tokenOpt.has_value(), "Invalid token type");
+         balances.balances.push_back(Balance{balance.key.tokenId, tokenOpt->precision,
+                                             tokenOpt->symbolId, balance.balance});
       }
-      return TokenRecord{};
+
+      // Credit balances for this user
+      auto creditIdx = tokenService.open<SharedBalanceTable>().getIndex<1>();
+      for (auto credit : creditIdx)
+      {
+         auto tokenOpt = tokenTypes.get(credit.key.tokenId);
+         check(tokenOpt.has_value(), "Invalid token type");
+         balances.credits.push_back(Credit{credit.key.tokenId, tokenOpt->precision,
+                                           tokenOpt->symbolId, credit.balance, credit.key.debitor});
+      }
+
+      // Debit balances for this user
+      auto debitIdx = tokenService.open<SharedBalanceTable>().getIndex<2>();
+      for (auto debit : debitIdx)
+      {
+         auto tokenOpt = tokenTypes.get(debit.key.tokenId);
+         check(tokenOpt.has_value(), "Invalid token type");
+         balances.debits.push_back(Debit{debit.key.tokenId, tokenOpt->precision, tokenOpt->symbolId,
+                                         debit.balance, debit.key.creditor});
+      }
+
+      return balances;
    }
 
    auto sharedBalances() const
    {  //
-      return tokenService.index<SharedBalanceTable, 0>();
+      return tokenService.open<SharedBalanceTable>().getIndex<0>();
    }
 
    auto tokens() const
    {  //
-      return tokenService.index<TokenTable, 0>();
+      return tokenService.open<TokenTable>().getIndex<0>();
    }
 
    auto userConf(AccountNumber user, psibase::EnumElement flag) const
@@ -73,6 +116,7 @@ struct TokenQuery
       return to<Tokens>().getUserConf(user, flag);
    }
 };
+
 PSIO_REFLECT(TokenQuery,
              method(allBalances),
              method(userBalances, user),
@@ -82,7 +126,7 @@ PSIO_REFLECT(TokenQuery,
 
 optional<HttpReply> RTokens::serveSys(HttpRequest request)
 {
-   if (auto result = servePackAction<Tokens>(request))
+   if (auto result = serveSimpleUI<Tokens, false>(request))
       return result;
 
    if (auto result = serveContent(request, ServiceTables<WebContentTable>{getReceiver()}))

--- a/services/user/XAdmin/ui/yarn.lock
+++ b/services/user/XAdmin/ui/yarn.lock
@@ -2447,8 +2447,16 @@ source-map-js@^1.2.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2501,7 +2509,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
This adds a new capability to graphql queries in C++: A vector of objects dynamically constructed at query time can be more easily queried using graphql.

The tokens query service uses this to allow for pagination on a dynamically constructed vector of objects, rather than returning the entire vector.

-------

New queries:
1. `userBalances(AccountNumber user, ...pagination)`
2. `userCredits(AccountNumber user, ...pagination)`
3. `userDebits(AccountNumber user, ...pagination)`
4. `tokenDetails(TID tokenId)`

The first three queries manually construct an index that combines the normal balance table row with details about the token (symbolID and precision) in order to return all relevant details within a single query.

The fourth new query `tokenDetails` returns details about a token given its ID, including the current owner of the issuer NFT, and the auth-service set by that owner account.

