### PR TITLE
Reduce system token precision

### DIFF
--- a/libraries/psio/include/psio/from_json.hpp
+++ b/libraries/psio/include/psio/from_json.hpp
@@ -738,6 +738,13 @@ namespace psio
       } while (depth);
    }
 
+   template <typename T>
+   concept PackValidatable = requires(T obj) {
+      {
+         clio_validate_packable(obj)
+      } -> std::same_as<bool>;
+   };
+
    /// \output_section Parse JSON (Reflected Objects)
    /// Parse JSON and convert to `obj`. This overload works with
    /// [reflected objects](standardese://reflection/).
@@ -769,6 +776,14 @@ namespace psio
                    from_json_skip_value(stream);
                 }
              });
+
+         if constexpr (PackValidatable<T>)
+         {
+            if (!clio_validate_packable(obj))
+            {
+               check(false, std::string(psio::reflect<T>::name) + " failed unpack validation.");
+            }
+         }
       }
       else
       {

--- a/services/user/Fractal/test/src/manual-fractal-test.cpp
+++ b/services/user/Fractal/test/src/manual-fractal-test.cpp
@@ -35,10 +35,10 @@ SCENARIO("Testing default psibase chain")
    sysIssuer.setTokenConf(sysToken, "untradeable"_m, false);
 
    // Distribute a few tokens
-   auto userBalance = 1'000'000e8;
+   auto userBalance = 1'000'000e4;
    sysIssuer.mint(sysToken, userBalance, memo);
-   sysIssuer.credit(sysToken, alice, 1'000e8, memo);
-   sysIssuer.credit(sysToken, bob, 1'000e8, memo);
+   sysIssuer.credit(sysToken, alice, 1'000e4, memo);
+   sysIssuer.credit(sysToken, bob, 1'000e4, memo);
 
    auto create = alice.to<Tokens>().create(4, 1'000'000e4);
    alice.to<Tokens>().mint(create.returnVal(), 100e4, memo);

--- a/services/user/Symbol/src/Symbol.cpp
+++ b/services/user/Symbol/src/Symbol.cpp
@@ -5,6 +5,7 @@
 #include <services/system/Transact.hpp>
 #include <services/system/commonErrors.hpp>
 
+#include <cmath>
 #include <psibase/serveSimpleUI.hpp>
 #include "services/user/Nft.hpp"
 #include "services/user/Tokens.hpp"
@@ -68,12 +69,17 @@ void Symbol::init()
       s.activePrice = s.activePrice * 2 / 3;
       return s;
    };
-   auto       symLengthTable = Tables().open<SymbolLengthTable>();
-   Quantity_t initialPrice   = (Quantity_t)1000e8;
-   auto       s              = SymbolLengthRecord{.symbolLength        = 3,
-                                                  .targetCreatedPerDay = 24,
-                                                  .floorPrice{(Quantity_t)100e8},
-                                                  .activePrice{initialPrice}};
+
+   auto precision   = to<Tokens>().getToken(Tokens::sysToken).precision;
+   auto getQuantity = [precision](Quantity_t q)
+   { return (Quantity_t)(q * std::pow(10, precision.value)); };
+   auto symLengthTable = Tables().open<SymbolLengthTable>();
+
+   Quantity_t initialPrice = getQuantity(1000);
+   auto       s            = SymbolLengthRecord{.symbolLength        = 3,
+                                                .targetCreatedPerDay = 24,
+                                                .floorPrice{getQuantity(100)},
+                                                .activePrice{initialPrice}};
    symLengthTable.put(s);           // Length 3
    symLengthTable.put(nextSym(s));  // Length 4
    symLengthTable.put(nextSym(s));  // Length 5

--- a/services/user/Tokens/include/services/user/tokenTypes.hpp
+++ b/services/user/Tokens/include/services/user/tokenTypes.hpp
@@ -35,6 +35,11 @@ namespace UserService
    };
    PSIO_REFLECT(Precision, value);
 
+   inline bool clio_validate_packable(const Precision& p)
+   {
+      return Precision::validate(p.value);
+   }
+
    void from_json(Precision& p, auto& stream)
    {
       from_json_object(stream,
@@ -53,12 +58,7 @@ namespace UserService
                           }
                        });
 
-      Precision::validate(p.value);
-   }
-
-   inline bool clio_validate_packable(const Precision& p)
-   {
-      return Precision::validate(p.value);
+      clio_validate_packable(p);
    }
 
    struct Quantity

--- a/services/user/Tokens/include/services/user/tokenTypes.hpp
+++ b/services/user/Tokens/include/services/user/tokenTypes.hpp
@@ -40,27 +40,6 @@ namespace UserService
       return Precision::validate(p.value);
    }
 
-   void from_json(Precision& p, auto& stream)
-   {
-      from_json_object(stream,
-                       [&](std::string_view key) -> void
-                       {
-                          bool found = false;
-                          psio::reflect<Precision>::get(key,
-                                                        [&](auto member)
-                                                        {
-                                                           from_json(p.*member, stream);
-                                                           found = true;
-                                                        });
-                          if (not found)
-                          {
-                             from_json_skip_value(stream);
-                          }
-                       });
-
-      clio_validate_packable(p);
-   }
-
    struct Quantity
    {
       using Quantity_t = uint64_t;

--- a/services/user/Tokens/src/RTokens.cpp
+++ b/services/user/Tokens/src/RTokens.cpp
@@ -202,7 +202,7 @@ struct TokenQuery
    auto userConf(AccountNumber user, psibase::EnumElement flag) const
    {
       auto holder = tokenService.open<TokenHolderTable>().getIndex<0>().get(user);
-      check(holder.has_value(), "Specified user does not hold any tokens");
+      check(holder.has_value(), "Token service has no record of user account");
       return holder->config.get(TokenHolderRecord::Configurations::value(flag));
    }
 };

--- a/services/user/Tokens/src/TokenUsers.json
+++ b/services/user/Tokens/src/TokenUsers.json
@@ -1,1 +1,14 @@
-[{"sender":"symbol","service":"tokens","method":"settokenconf","rawData":"0D0001000000807092B11BD8000000"},{"sender":"symbol","service":"tokens","method":"mint","rawData":"0C0001000000080000000E000000080000407A10F35A0000040000006D656D6F"},{"sender":"symbol","service":"tokens","method":"credit","rawData":"1400010000000F31660000000000080000000E000000080000E8764817000000040000006D656D6F"},{"sender":"symbol","service":"tokens","method":"credit","rawData":"140001000000BE52800000000000080000000E000000080000E8764817000000040000006D656D6F"}]
+[
+    {
+        "sender":"symbol","service":"tokens","method":"settokenconf","rawData":"0D0001000000807092B11BD8000000"
+    }, 
+    {
+        "sender":"symbol","service":"tokens","method":"mint","rawData":"0C0001000000080000000E000000080000E40B54020000000900000054657374206D696E74"
+    },
+    {
+        "sender":"symbol","service":"tokens","method":"credit","rawData":"1400010000000F31660000000000080000000E000000080080969800000000001500000054657374202D20696E697469616C20637265646974"
+    },
+    {
+        "sender":"symbol","service":"tokens","method":"credit","rawData":"140001000000BE52800000000000080000000E000000080080969800000000001500000054657374202D20696E697469616C20637265646974"
+    }
+]

--- a/services/user/Tokens/src/Tokens.cpp
+++ b/services/user/Tokens/src/Tokens.cpp
@@ -87,7 +87,7 @@ void Tokens::init()
    }
 
    // Create system token
-   auto tid = tokService.create(Precision{4}, Quantity{1'000'000'000e8});
+   auto tid = tokService.create(Precision{4}, Quantity{1'000'000'000e4});
    check(tid == TID{1}, wrongSysTokenId);
 
    // Make system token default untradeable

--- a/services/user/Tokens/src/Tokens.cpp
+++ b/services/user/Tokens/src/Tokens.cpp
@@ -87,7 +87,7 @@ void Tokens::init()
    }
 
    // Create system token
-   auto tid = tokService.create(Precision{8}, Quantity{1'000'000'000e8});
+   auto tid = tokService.create(Precision{4}, Quantity{1'000'000'000e8});
    check(tid == TID{1}, wrongSysTokenId);
 
    // Make system token default untradeable
@@ -125,7 +125,6 @@ TID Tokens::create(Precision precision, Quantity maxSupply)
    auto nftService = to<Nft>();
 
    TID newId = (tokenIdx.begin() == tokenIdx.end()) ? 1 : (*(--tokenIdx.end())).id + 1;
-   Precision::fracpack_validate(precision);  // Todo remove if/when happens automatically
    check(TokenRecord::isValidKey(newId), invalidTokenId);
    check(maxSupply.value > 0, supplyGt0);
 

--- a/services/user/Tokens/test/src/Tokens-test.cpp
+++ b/services/user/Tokens/test/src/Tokens-test.cpp
@@ -40,7 +40,7 @@ SCENARIO("Using system token")
       auto bob   = t.from(t.addAccount("bob"_a));
 
       auto sysIssuer   = t.from(Symbol::service).to<Tokens>();
-      auto userBalance = 1'000'000e8;
+      auto userBalance = 1'000'000e4;
       auto sysToken    = Tokens::sysToken;
       sysIssuer.mint(sysToken, userBalance, memo);
 
@@ -89,7 +89,7 @@ SCENARIO("Creating a token")
 
       THEN("Alice may create a token")
       {
-         auto create = a.create(8, 1'000'000'000e8);
+         auto create = a.create(4, 1'000'000'000e4);
          CHECK(create.succeeded());
 
          AND_THEN("The token exists")
@@ -102,37 +102,24 @@ SCENARIO("Creating a token")
             }
          }
       }
-      THEN("Alice may not create a token with invalid precision")
-      {
-         Quantity  q{100e8};
-         Precision p0{0};
-         Precision p1{16};
-         Precision p2{17};
-
-         CHECK(a.create(p0, q).succeeded());
-         CHECK(a.create(p1, q).succeeded());
-         CHECK(a.create(p2, q).failed(Precision::errorInvalid));
-      }
       THEN("Alice may not create a token with invalid quantity")
       {
          Precision p{4};
-         Quantity  q0{0e8};
-         Quantity  q1{1e8};
-         Quantity  q2{2e8};
-         Quantity  q3{std::numeric_limits<Quantity::Quantity_t>::max()};
+         Quantity  q0{0e4};
+         Quantity  q1{1e4};
+         Quantity  q2{std::numeric_limits<Quantity::Quantity_t>::max()};
          CHECK(a.create(p, q0).failed(Errors::supplyGt0));
          CHECK(a.create(p, q1).succeeded());
          CHECK(a.create(p, q2).succeeded());
-         CHECK(a.create(p, q3).succeeded());
       }
       WHEN("Alice creates a token")
       {
-         auto tokenId = a.create(8, 1'000'000'000e8).returnVal();
+         auto tokenId = a.create(4, 1'000'000'000e4).returnVal();
          auto token1  = a.getToken(tokenId).returnVal();
 
          THEN("Alice may create a second token")
          {
-            auto create = a.create(8, 1'000'000'000e8);
+            auto create = a.create(4, 1'000'000'000e4);
             CHECK(create.succeeded());
 
             auto tokenId   = create.returnVal();
@@ -161,25 +148,25 @@ SCENARIO("Minting tokens")
       auto bob   = t.from(t.addAccount("bob"_a));
       auto b     = bob.to<Tokens>();
 
-      auto tokenId = a.create(8, 1'000'000'000e8).returnVal();
+      auto tokenId = a.create(4, 1'000'000'000e4).returnVal();
 
       THEN("Bob may not mint them")
       {
-         auto mint = b.mint(tokenId, 1'000e8, memo);
+         auto mint = b.mint(tokenId, 1'000e4, memo);
          CHECK(mint.failed(missingRequiredAuth));
       }
       THEN("Alice may not mint them with a nonexistent token ID")
       {
-         auto mint = a.mint(999, 1'000e8, memo);
+         auto mint = a.mint(999, 1'000e4, memo);
          CHECK(mint.failed(tokenDNE));
       }
       THEN("Alice may not mint more tokens than are allowed by the specified max supply")
       {
-         CHECK(a.mint(tokenId, 1'000'000'001e8, memo).failed(maxSupplyExceeded));
+         CHECK(a.mint(tokenId, 1'000'000'001e4, memo).failed(maxSupplyExceeded));
       }
       THEN("Alice may mint new tokens")
       {
-         Quantity quantity{1'000e8};
+         Quantity quantity{1'000e4};
          auto     mint = a.mint(tokenId, quantity, memo);
          CHECK(mint.succeeded());
 
@@ -218,10 +205,10 @@ SCENARIO("Recalling tokens")
       auto bob   = t.from(t.addAccount("bob"_a));
       auto b     = bob.to<Tokens>();
 
-      auto tokenId = a.create(8, 1'000'000'000e8).returnVal();
+      auto tokenId = a.create(4, 1'000'000'000e4).returnVal();
       auto token   = a.getToken(tokenId).returnVal();
-      a.mint(tokenId, 1'000e8, memo);
-      a.credit(tokenId, bob, 1'000e8, memo);
+      a.mint(tokenId, 1'000e4, memo);
+      a.credit(tokenId, bob, 1'000e4, memo);
 
       THEN("The token is recallable by default")
       {
@@ -230,7 +217,7 @@ SCENARIO("Recalling tokens")
       }
       THEN("Alice can recall Bob's tokens")
       {
-         auto recall = a.recall(tokenId, bob, 1'000e8, memo);
+         auto recall = a.recall(tokenId, bob, 1'000e4, memo);
          CHECK(recall.succeeded());
 
          AND_THEN("Bob's token balance has decreased")
@@ -251,7 +238,7 @@ SCENARIO("Recalling tokens")
 
          AND_THEN("Alice may not recall Bob's tokens")
          {
-            CHECK(a.recall(tokenId, bob, 1'000e8, memo).failed(tokenUnrecallable));
+            CHECK(a.recall(tokenId, bob, 1'000e4, memo).failed(tokenUnrecallable));
          }
          AND_THEN("The token issuer may not re-enable recallability")
          {
@@ -272,7 +259,7 @@ SCENARIO("Interactions with the Issuer NFT")
       auto bob   = t.from(t.addAccount("bob"_a));
       auto b     = bob.to<Tokens>();
 
-      auto tokenId = a.create(8, 1'000'000'000e8).returnVal();
+      auto tokenId = a.create(4, 1'000'000'000e4).returnVal();
       auto token   = a.getToken(tokenId).returnVal();
       auto nft     = alice.to<Nft>().getNft(token.ownerNft).returnVal();
 
@@ -298,20 +285,20 @@ SCENARIO("Interactions with the Issuer NFT")
          }
          THEN("Bob may mint new tokens")
          {  //
-            CHECK(b.mint(tokenId, 1'000e8, memo).succeeded());
+            CHECK(b.mint(tokenId, 1'000e4, memo).succeeded());
          }
          THEN("Alice may not mint new tokens")
          {
-            CHECK(a.mint(tokenId, 1'000e8, memo).failed(missingRequiredAuth));
+            CHECK(a.mint(tokenId, 1'000e4, memo).failed(missingRequiredAuth));
          }
          THEN("Alice may not recall Bob's tokens")
          {
-            b.mint(tokenId, 1'000e8, memo);
-            CHECK(a.recall(tokenId, bob, 1'000e8, memo).failed(missingRequiredAuth));
+            b.mint(tokenId, 1'000e4, memo);
+            CHECK(a.recall(tokenId, bob, 1'000e4, memo).failed(missingRequiredAuth));
          }
          THEN("Bob may recall Alice's tokens")
          {
-            Quantity q{1'000e8};
+            Quantity q{1'000e4};
             b.mint(tokenId, q, memo);
             b.credit(tokenId, alice, q, memo);
             CHECK(b.recall(tokenId, alice, q, memo).succeeded());
@@ -319,7 +306,7 @@ SCENARIO("Interactions with the Issuer NFT")
       }
       WHEN("Alice burns the issuer NFT")
       {
-         Quantity quantity{1'000e8};
+         Quantity quantity{1'000e4};
          a.mint(tokenId, quantity, memo);
          a.credit(tokenId, bob, quantity, memo);
          alice.to<Nft>().burn(nft.id);
@@ -359,68 +346,68 @@ SCENARIO("Burning tokens")
       auto bob   = t.from(t.addAccount("bob"_a));
       auto b     = bob.to<Tokens>();
 
-      auto tokenId = a.create(8, 1'000'000'000e8).returnVal();
+      auto tokenId = a.create(4, 1'000'000'000e4).returnVal();
       auto token   = a.getToken(tokenId).returnVal();
-      auto mint    = a.mint(tokenId, 200e8, memo);
-      a.credit(tokenId, bob, 100e8, memo);
+      auto mint    = a.mint(tokenId, 200e4, memo);
+      a.credit(tokenId, bob, 100e4, memo);
 
       THEN("Alice may not burn 101 tokens")
       {
-         CHECK(a.burn(tokenId, 101e8).failed(insufficientBalance));
+         CHECK(a.burn(tokenId, 101e4).failed(insufficientBalance));
       }
       THEN("Alice may burn 60 tokens")
       {
-         CHECK(a.burn(tokenId, 60e8).succeeded());
+         CHECK(a.burn(tokenId, 60e4).succeeded());
 
          AND_THEN("Alice may not burn 41 more")
          {
-            CHECK(a.burn(tokenId, 41e8).failed(insufficientBalance));
+            CHECK(a.burn(tokenId, 41e4).failed(insufficientBalance));
          }
          AND_THEN("Alice may burn 40 more")
          {  //
-            CHECK(a.burn(tokenId, 40e8).succeeded());
+            CHECK(a.burn(tokenId, 40e4).succeeded());
          }
       }
       WHEN("Alice burns 60 tokens")
       {
-         a.burn(tokenId, 60e8);
+         a.burn(tokenId, 60e4);
 
          THEN("She still owns 40 tokens")
          {  //
-            CHECK(a.getBalance(tokenId, alice).returnVal().balance == 40e8);
+            CHECK(a.getBalance(tokenId, alice).returnVal().balance == 40e4);
          }
          THEN("Bob still owns 100 tokens")
          {  //
-            CHECK(b.getBalance(tokenId, bob).returnVal().balance == 100e8);
+            CHECK(b.getBalance(tokenId, bob).returnVal().balance == 100e4);
          }
       }
       WHEN("Alice burns 100 tokens")
       {
-         a.burn(tokenId, 100e8);
+         a.burn(tokenId, 100e4);
 
          THEN("Her balance is 0")
          {  //
-            CHECK(a.getBalance(tokenId, alice).returnVal().balance == 0e8);
+            CHECK(a.getBalance(tokenId, alice).returnVal().balance == 0e4);
          }
          THEN("She may not burn any more")
          {
-            CHECK(a.burn(tokenId, 1e8).failed(insufficientBalance));
+            CHECK(a.burn(tokenId, 1e4).failed(insufficientBalance));
          }
          THEN("Bob may burn tokens")
          {  //
-            CHECK(b.burn(tokenId, 10e8).succeeded());
+            CHECK(b.burn(tokenId, 10e4).succeeded());
          }
          AND_WHEN("Bob burns 10 tokens")
          {
-            b.burn(tokenId, 10e8);
+            b.burn(tokenId, 10e4);
 
             THEN("Bob still has 90 tokens")
             {  //
-               CHECK(b.getBalance(tokenId, bob).returnVal().balance == 90e8);
+               CHECK(b.getBalance(tokenId, bob).returnVal().balance == 90e4);
             }
             THEN("Alice still has 0 tokens")
             {  //
-               CHECK(a.getBalance(tokenId, alice).returnVal().balance == 0e8);
+               CHECK(a.getBalance(tokenId, alice).returnVal().balance == 0e4);
             }
          }
       }
@@ -501,58 +488,58 @@ SCENARIO("Crediting/uncrediting/debiting tokens")
       auto bob   = t.from(t.addAccount("bob"_a));
       auto b     = bob.to<Tokens>();
 
-      auto tokenId = a.create(8, 1'000'000'000e8).returnVal();
+      auto tokenId = a.create(4, 1'000'000'000e4).returnVal();
       auto token   = a.getToken(tokenId).returnVal();
-      auto mint    = a.mint(tokenId, 200e8, memo);
-      a.credit(tokenId, bob, 100e8, memo);
+      auto mint    = a.mint(tokenId, 200e4, memo);
+      a.credit(tokenId, bob, 100e4, memo);
 
       THEN("Alice may not credit Bob 101 tokens")
       {
-         CHECK(a.credit(tokenId, bob, 101e8, memo).failed(insufficientBalance));
+         CHECK(a.credit(tokenId, bob, 101e4, memo).failed(insufficientBalance));
       }
       THEN("Alice may credit Bob 100 tokens")
       {
-         CHECK(a.credit(tokenId, bob, 100e8, memo).succeeded());
+         CHECK(a.credit(tokenId, bob, 100e4, memo).succeeded());
       }
       WHEN("Alice credits Bob 100 tokens")
       {
-         a.credit(tokenId, bob, 100e8, memo);
+         a.credit(tokenId, bob, 100e4, memo);
 
          THEN("Bob immediately has 200 tokens")
          {  //
-            CHECK(b.getBalance(tokenId, bob).returnVal().balance == 200e8);
+            CHECK(b.getBalance(tokenId, bob).returnVal().balance == 200e4);
          }
          THEN("Alice immediately has 0 tokens")
          {  //
-            CHECK(a.getBalance(tokenId, alice).returnVal().balance == 0e8);
+            CHECK(a.getBalance(tokenId, alice).returnVal().balance == 0e4);
          }
          THEN("Alice may not credit Bob 1 token")
          {
-            CHECK(a.credit(tokenId, bob, 1e8, memo).failed(insufficientBalance));
+            CHECK(a.credit(tokenId, bob, 1e4, memo).failed(insufficientBalance));
          }
          THEN("Bob may not debit any tokens")
          {
-            CHECK(b.debit(tokenId, alice, 1e8, memo).failed(insufficientBalance));
+            CHECK(b.debit(tokenId, alice, 1e4, memo).failed(insufficientBalance));
          }
          THEN("Alice may not uncredit any tokens")
          {
-            CHECK(a.uncredit(tokenId, bob, 1e8, memo).failed(insufficientBalance));
+            CHECK(a.uncredit(tokenId, bob, 1e4, memo).failed(insufficientBalance));
          }
          THEN("Bob may credit Alice 10 tokens")
          {
-            CHECK(b.credit(tokenId, alice, 10e8, memo).succeeded());
+            CHECK(b.credit(tokenId, alice, 10e4, memo).succeeded());
          }
          AND_WHEN("Bob credits Alice 10 tokens")
          {
-            b.credit(tokenId, alice, 10e8, memo);
+            b.credit(tokenId, alice, 10e4, memo);
 
             THEN("Bob has 190 tokens")
             {  //
-               CHECK(b.getBalance(tokenId, bob).returnVal().balance == 190e8);
+               CHECK(b.getBalance(tokenId, bob).returnVal().balance == 190e4);
             }
             THEN("Alice has 10 tokens")
             {  //
-               CHECK(a.getBalance(tokenId, alice).returnVal().balance == 10e8);
+               CHECK(a.getBalance(tokenId, alice).returnVal().balance == 10e4);
             }
          }
       }
@@ -570,11 +557,11 @@ SCENARIO("Crediting/uncrediting/debiting tokens, with manual-debit")
       auto bob   = t.from(t.addAccount("bob"_a));
       auto b     = bob.to<Tokens>();
 
-      auto tokenId = a.create(8, 1'000'000'000e8).returnVal();
+      auto tokenId = a.create(4, 1'000'000'000e4).returnVal();
       auto token   = a.getToken(tokenId).returnVal();
 
-      a.mint(tokenId, 200e8, memo);
-      a.credit(tokenId, bob, 100e8, memo);
+      a.mint(tokenId, 200e4, memo);
+      a.credit(tokenId, bob, 100e4, memo);
 
       AND_GIVEN("Alice turns on manual-debit")
       {
@@ -582,106 +569,106 @@ SCENARIO("Crediting/uncrediting/debiting tokens, with manual-debit")
 
          THEN("Alice may credit Bob 50 tokens")
          {
-            CHECK(a.credit(tokenId, bob, 50e8, memo).succeeded());
+            CHECK(a.credit(tokenId, bob, 50e4, memo).succeeded());
          }
          THEN("Bob may credit Alice 50 tokens")
          {
-            CHECK(b.credit(tokenId, alice, 50e8, memo).succeeded());
+            CHECK(b.credit(tokenId, alice, 50e4, memo).succeeded());
          }
          WHEN("Alice credits Bob 50 tokens")
          {
-            a.credit(tokenId, bob, 50e8, memo);
+            a.credit(tokenId, bob, 50e4, memo);
 
             THEN("The transfer happens immediately")
             {
-               CHECK(150e8 == b.getBalance(tokenId, bob).returnVal().balance);
-               CHECK(50e8 == a.getBalance(tokenId, alice).returnVal().balance);
+               CHECK(150e4 == b.getBalance(tokenId, bob).returnVal().balance);
+               CHECK(50e4 == a.getBalance(tokenId, alice).returnVal().balance);
             }
             THEN("Alice and Bob may not uncredit any tokens")
             {
-               CHECK(a.uncredit(tokenId, bob, 50e8, memo).failed(insufficientBalance));
-               CHECK(b.uncredit(tokenId, alice, 50e8, memo).failed(insufficientBalance));
+               CHECK(a.uncredit(tokenId, bob, 50e4, memo).failed(insufficientBalance));
+               CHECK(b.uncredit(tokenId, alice, 50e4, memo).failed(insufficientBalance));
             }
             THEN("Alice and Bob may not debit any tokens")
             {
-               CHECK(a.debit(tokenId, bob, 50e8, memo).failed(insufficientBalance));
-               CHECK(b.debit(tokenId, alice, 50e8, memo).failed(insufficientBalance));
+               CHECK(a.debit(tokenId, bob, 50e4, memo).failed(insufficientBalance));
+               CHECK(b.debit(tokenId, alice, 50e4, memo).failed(insufficientBalance));
             }
          }
          WHEN("Bob credits Alice 50 tokens")
          {
-            b.credit(tokenId, alice, 50e8, memo);
+            b.credit(tokenId, alice, 50e4, memo);
 
             THEN("Bob owns 50 tokens in his individual balance")
             {
-               CHECK(50e8 == b.getBalance(tokenId, bob).returnVal().balance);
+               CHECK(50e4 == b.getBalance(tokenId, bob).returnVal().balance);
                AND_THEN("Bob owns 50 tokens in his shared balance with Alice")
                {
-                  CHECK(50e8 == b.getSharedBal(tokenId, bob, alice).returnVal().balance);
+                  CHECK(50e4 == b.getSharedBal(tokenId, bob, alice).returnVal().balance);
                }
             }
             THEN("Bob may try to uncredit 51 tokens, but will only uncredit 50")
             {
-               CHECK(50e8 == b.getBalance(tokenId, bob).returnVal().balance);
-               CHECK(b.uncredit(tokenId, alice, 51e8, memo).succeeded());
-               CHECK(100e8 == b.getBalance(tokenId, bob).returnVal().balance);
+               CHECK(50e4 == b.getBalance(tokenId, bob).returnVal().balance);
+               CHECK(b.uncredit(tokenId, alice, 51e4, memo).succeeded());
+               CHECK(100e4 == b.getBalance(tokenId, bob).returnVal().balance);
             }
             THEN("Bob may uncredit 25 tokens")
             {
-               CHECK(b.uncredit(tokenId, alice, 25e8, memo).succeeded());
+               CHECK(b.uncredit(tokenId, alice, 25e4, memo).succeeded());
 
                AND_THEN("Bob may uncredit 25 tokens")
                {
-                  CHECK(b.uncredit(tokenId, alice, 25e8, memo).succeeded());
+                  CHECK(b.uncredit(tokenId, alice, 25e4, memo).succeeded());
                   AND_THEN("Bob owns 0 tokens in his shared balance with Alice")
                   {
-                     CHECK(0e8 == b.getSharedBal(tokenId, bob, alice).returnVal().balance);
+                     CHECK(0e4 == b.getSharedBal(tokenId, bob, alice).returnVal().balance);
 
                      AND_THEN("Bob may not uncredit any tokens")
                      {
-                        CHECK(b.uncredit(tokenId, alice, 1e8, memo).failed(insufficientBalance));
+                        CHECK(b.uncredit(tokenId, alice, 1e4, memo).failed(insufficientBalance));
                      }
                   }
                }
                AND_THEN("Alice may not debit 26 tokens")
                {
-                  CHECK(a.debit(tokenId, bob, 26e8, memo).failed(insufficientBalance));
+                  CHECK(a.debit(tokenId, bob, 26e4, memo).failed(insufficientBalance));
                }
                AND_THEN("Alice may debit 25 tokens")
                {
-                  CHECK(a.debit(tokenId, bob, 25e8, memo).succeeded());
+                  CHECK(a.debit(tokenId, bob, 25e4, memo).succeeded());
                   AND_THEN("Bob has 0 tokens in his shared balance with Alice")
                   {
-                     CHECK(0e8 == b.getSharedBal(tokenId, bob, alice).returnVal().balance);
+                     CHECK(0e4 == b.getSharedBal(tokenId, bob, alice).returnVal().balance);
                   }
                   AND_THEN("Bob owns 75 tokens in his individual balance")
                   {
-                     CHECK(75e8 == b.getBalance(tokenId, bob).returnVal().balance);
+                     CHECK(75e4 == b.getBalance(tokenId, bob).returnVal().balance);
                   }
                   AND_THEN("Alice owns 125 tokens in her individual balance")
                   {
-                     CHECK(125e8 == a.getBalance(tokenId, alice).returnVal().balance);
+                     CHECK(125e4 == a.getBalance(tokenId, alice).returnVal().balance);
                   }
                }
             }
             THEN("Alice may not debit 51 tokens")
             {
-               CHECK(a.debit(tokenId, bob, 51e8, memo).failed(insufficientBalance));
+               CHECK(a.debit(tokenId, bob, 51e4, memo).failed(insufficientBalance));
             }
             THEN("Alice may debit 50 tokens")
             {
-               CHECK(a.debit(tokenId, bob, 50e8, memo).succeeded());
+               CHECK(a.debit(tokenId, bob, 50e4, memo).succeeded());
                AND_THEN("Alice may not debit any more tokens")
                {
-                  CHECK(a.debit(tokenId, bob, 1e8, memo).failed(insufficientBalance));
+                  CHECK(a.debit(tokenId, bob, 1e4, memo).failed(insufficientBalance));
                }
                AND_THEN("Bob may not uncredit any more tokens")
                {
-                  CHECK(b.uncredit(tokenId, alice, 1e8, memo).failed(insufficientBalance));
+                  CHECK(b.uncredit(tokenId, alice, 1e4, memo).failed(insufficientBalance));
                }
                AND_THEN("Bob may credit an additional 25 tokens")
                {
-                  CHECK(b.credit(tokenId, alice, 25e8, memo).succeeded());
+                  CHECK(b.credit(tokenId, alice, 25e4, memo).succeeded());
                }
             }
          }
@@ -702,21 +689,22 @@ SCENARIO("Mapping a symbol to a token")
 
       // Issue system tokens
       auto sysIssuer   = t.from(Symbol::service).to<Tokens>();
-      auto userBalance = 1'000'000e8;
+      auto userBalance = 1'000'000e4;
       auto sysToken    = Tokens::sysToken;
       sysIssuer.setTokenConf(sysToken, untradeable, false);
       sysIssuer.mint(sysToken, userBalance, memo);
       sysIssuer.credit(sysToken, alice, userBalance, memo);
 
       // Mint a second token
-      auto newToken = a.create(8, userBalance).returnVal();
+      auto newToken = a.create(4, userBalance).returnVal();
       a.mint(newToken, userBalance, memo);
 
       // Purchase the symbol and claim the owner NFT
       auto symbolCost = alice.to<Symbol>().getPrice(3).returnVal();
       a.credit(sysToken, Symbol::service, symbolCost, memo);
-      auto symbolId     = "abc"_a;
-      auto create       = alice.to<Symbol>().create(symbolId, symbolCost);
+      auto symbolId = "abc"_a;
+      auto create   = alice.to<Symbol>().create(symbolId, symbolCost);
+      CHECK(create.succeeded());
       auto symbolRecord = alice.to<Symbol>().getSymbol(symbolId).returnVal();
       auto nftId        = symbolRecord.ownerNft;
 


### PR DESCRIPTION
* Sets max precision to 8 instead of 16
* Updates the precision class so min/max are enforced when unpacking from frackpack or json
* Updates the precision of the system token to 4
* Updates a bunch of tests to look up the previously hardcoded sys token precision