### PR TITLE
Add `SplitKey` type for subindexing in token query service

### DIFF
--- a/libraries/psibase/common/include/psibase/Table.hpp
+++ b/libraries/psibase/common/include/psibase/Table.hpp
@@ -6,8 +6,8 @@
 #include <concepts>
 #include <cstdint>
 #include <functional>
-#include <psibase/RawNativeFunctions.hpp>
 #include <psibase/blob.hpp>
+#include <psibase/RawNativeFunctions.hpp>
 #include <psibase/serviceState.hpp>
 #include <psio/to_key.hpp>
 #include <span>
@@ -271,28 +271,10 @@ namespace psibase
    {
       std::span<const char> data;
    };
-
-   /// A split key is used to specify a subindex on indices with a struct key.
-   ///
-   /// For example, a primr
-   /// Warning: No type checking! It's up to the user to ensure that T + Rest
-   ///   is equivalent to the primary key)
-   template <typename Rest, typename T>
-   struct SplitKey
-   {
-      T value;
-   };
-
    template <typename S>
    void to_key(const KeyView& k, S& s)
    {
       s.write(k.data.data(), k.data.size());
-   }
-
-   template <typename Rest, typename T>
-   void to_key(SplitKey<Rest, T>& obj, auto& stream)
-   {
-      to_key(obj.value, stream);
    }
 
    template <typename T, typename U>
@@ -333,11 +315,6 @@ namespace psibase
    {
       static constexpr bool value = compatible_key<boost::mp11::mp_front<std::tuple<U...>>, T>;
    };
-   template <typename Rest, typename T, typename S>
-   struct compatible_tuple_prefix<SplitKey<Rest, T>, S>
-   {
-      static constexpr bool value = true;
-   };
 
    template <typename T, typename U>
    concept compatible_key_prefix_unqual =
@@ -365,11 +342,6 @@ namespace psibase
    struct key_suffix_unqual<T, T>
    {
       using type = std::tuple<>;
-   };
-   template <typename Rest, typename T, typename S>
-   struct key_suffix_unqual<SplitKey<Rest, T>, S>
-   {
-      using type = Rest;
    };
 
    template <typename T, typename U>
@@ -715,9 +687,9 @@ namespace psibase
 
    template <typename T>
    concept TableType = requires(T table) {
-      typename decltype(table)::key_type;
-      typename decltype(table)::value_type;
-   };
+                          typename decltype(table)::key_type;
+                          typename decltype(table)::value_type;
+                       };
 
    // TODO: allow tables to be forward declared.  The simplest method is:
    // struct xxx : Table<...> {};
@@ -813,5 +785,6 @@ namespace psibase
    {
    };
    PSIO_REFLECT(SingletonKey);
+
 
 }  // namespace psibase

--- a/services/user/Tokens/include/services/user/tokenTables.hpp
+++ b/services/user/Tokens/include/services/user/tokenTables.hpp
@@ -91,13 +91,10 @@ namespace UserService
       BalanceKey key;
       uint64_t   balance;
 
-      auto byUserToken() const { return std::tuple{key.account, key.tokenId}; }
-
       auto operator<=>(const BalanceRecord&) const = default;
    };
    PSIO_REFLECT(BalanceRecord, key, balance);
-   using BalanceTable =
-       psibase::Table<BalanceRecord, &BalanceRecord::key, &BalanceRecord::byUserToken>;
+   using BalanceTable = psibase::Table<BalanceRecord, &BalanceRecord::key>;
 
    struct SharedBalanceKey
    {
@@ -114,16 +111,13 @@ namespace UserService
       SharedBalanceKey key;
       uint64_t         balance;
 
-      auto byCreditor() const { return std::tuple{key.creditor, key.debitor, key.tokenId}; }
       auto byDebitor() const { return std::tuple{key.debitor, key.creditor, key.tokenId}; }
 
       auto operator<=>(const SharedBalanceRecord&) const = default;
    };
    PSIO_REFLECT(SharedBalanceRecord, key, balance);
-   using SharedBalanceTable = psibase::Table<SharedBalanceRecord,
-                                             &SharedBalanceRecord::key,
-                                             &SharedBalanceRecord::byCreditor,
-                                             &SharedBalanceRecord::byDebitor>;
+   using SharedBalanceTable = psibase::
+       Table<SharedBalanceRecord, &SharedBalanceRecord::key, &SharedBalanceRecord::byDebitor>;
 
    struct TokenHolderRecord
    {

--- a/services/user/Tokens/src/RTokens.cpp
+++ b/services/user/Tokens/src/RTokens.cpp
@@ -79,6 +79,34 @@ namespace TokenQueryTypes
 
 }  // namespace TokenQueryTypes
 
+/// A split key is used to specify a subindex on indices with a struct key.
+///
+/// Warning: No type checking! It's up to the user to ensure that T + Rest
+///   is equivalent to the primary key)
+template <typename Rest, typename T>
+struct SplitKey
+{
+   T value;
+};
+
+template <typename Rest, typename T>
+void to_key(SplitKey<Rest, T>& obj, auto& stream)
+{
+   to_key(obj.value, stream);
+}
+
+template <typename Rest, typename T, typename S>
+struct compatible_tuple_prefix<SplitKey<Rest, T>, S>
+{
+   static constexpr bool value = true;
+};
+
+template <typename Rest, typename T, typename S>
+struct key_suffix_unqual<SplitKey<Rest, T>, S>
+{
+   using type = Rest;
+};
+
 using namespace TokenQueryTypes;
 struct TokenQuery
 {

--- a/services/user/Tokens/src/RTokens.cpp
+++ b/services/user/Tokens/src/RTokens.cpp
@@ -98,7 +98,8 @@ struct TokenQuery
       vector<TokenBalance> balances;
 
       auto tokenTypeIdx = tokenService.open<TokenTable>().getIndex<0>();
-      auto balanceIdx   = tokenService.open<BalanceTable>().getIndex<1>().subindex(user);
+      auto balanceIdx   = tokenService.open<BalanceTable>().getIndex<0>().subindex(
+          SplitKey<TID, AccountNumber>{user});
 
       // Balances of this user
       for (auto balance : balanceIdx)
@@ -124,7 +125,8 @@ struct TokenQuery
       vector<Credit> credits;
 
       auto tokenTypeIdx = tokenService.open<TokenTable>().getIndex<0>();
-      auto creditIdx    = tokenService.open<SharedBalanceTable>().getIndex<1>();
+      auto creditIdx    = tokenService.open<SharedBalanceTable>().getIndex<0>().subindex(
+          SplitKey<std::tuple<TID, AccountNumber>, AccountNumber>{user});
 
       for (auto credit : creditIdx)
       {
@@ -149,7 +151,7 @@ struct TokenQuery
       vector<Debit> debits;
 
       auto tokenTypeIdx = tokenService.open<TokenTable>().getIndex<0>();
-      auto debitIdx     = tokenService.open<SharedBalanceTable>().getIndex<2>();
+      auto debitIdx     = tokenService.open<SharedBalanceTable>().getIndex<1>().subindex(user);
 
       for (auto debit : debitIdx)
       {


### PR DESCRIPTION
* Adds the `SplitKey` type to the token query service to allow subindexing on indices with a struct key
* Eliminates redundant token table indices