### PR TITLE
disable mdbook external link checker

### DIFF
--- a/doc/psidk/book.toml.in
+++ b/doc/psidk/book.toml.in
@@ -42,6 +42,6 @@ runnable = false
 enable = true
 
 [output.linkcheck]
-follow-web-links = true
+follow-web-links = false
 traverse-parent-directories = false
 warning-policy = "ignore"


### PR DESCRIPTION
To help eliminate CI/CD indeterminism that is a frequent source of errors.
