### PR TITLE
Update nft service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,7 @@ psibase_package(
     NAME Nft
     VERSION ${PSIBASE_VERSION}
     SERVICE nft
-    PACKAGE_DEPENDS "Accounts(^${PSIBASE_VERSION})" "HttpServer(^${PSIBASE_VERSION})"
+    PACKAGE_DEPENDS "Accounts(^${PSIBASE_VERSION})" "HttpServer(^${PSIBASE_VERSION})" "Events(^${PSIBASE_VERSION})"
     WASM ${CMAKE_CURRENT_BINARY_DIR}/Nft.wasm
     INIT
     DEPENDS wasm

--- a/services/user/Nft/include/services/user/Nft.hpp
+++ b/services/user/Nft/include/services/user/Nft.hpp
@@ -43,12 +43,11 @@ namespace UserService
          // clang-format off
          struct History
          {
-            void minted(uint64_t prevEvent, NID nftId, Account issuer) {}
-            void burned(uint64_t prevEvent, NID nftId) {}
-            void userConfSet(uint64_t prevEvent, Account account, psibase::EnumElement flag, bool enable) {}
-            void credited(uint64_t prevEvent, NID nftId, Account sender, Account receiver, MemoView memo) {}
-            void uncredited(uint64_t prevEvent, NID nftId, Account sender, Account receiver, MemoView memo) {}
-            void transferred(uint64_t prevEvent, NID nftId, Account creditor, Account debitor, MemoView memo) {}
+            void minted(NID nftId, Account issuer) {}
+            void burned(NID nftId, Account owner) {}
+            void userConfSet(Account account, psibase::EnumElement flag, bool enable) {}
+            void credited(NID nftId, Account sender, Account receiver, MemoView memo) {}
+            void uncredited(NID nftId, Account sender, Account receiver, MemoView memo) {}
          };
          // clang-format on
 
@@ -57,10 +56,9 @@ namespace UserService
          };
          struct Merkle
          {
+            void transferred(NID nftId, Account creditor, Account debitor, MemoView memo) {}
          };
       };
-      using NftEvents  = psibase::EventIndex<&NftRecord::eventHead, "prevEvent">;
-      using UserEvents = psibase::EventIndex<&NftHolderRecord::eventHead, "prevEvent">;
    };
 
    // clang-format off
@@ -82,16 +80,15 @@ namespace UserService
    );
    PSIBASE_REFLECT_EVENTS(Nft);
    PSIBASE_REFLECT_HISTORY_EVENTS(Nft,
-      method(minted, prevEvent, nftId, issuer),
-      method(burned, prevEvent, nftId),
-      method(userConfSet, prevEvent, account, flag, enable),
-      method(credited, prevEvent, nftId, sender, receiver, memo),
-      method(uncredited, prevEvent, nftId, sender, receiver, memo),
-      method(transferred, prevEvent, nftId, creditor, debitor, memo)
+      method(minted, nftId, issuer),
+      method(burned, nftId, owner),
+      method(userConfSet, account, flag, enable),
+      method(credited, nftId, sender, receiver, memo),
+      method(uncredited, nftId, sender, receiver, memo)
    );
    PSIBASE_REFLECT_UI_EVENTS(Nft);
-   PSIBASE_REFLECT_MERKLE_EVENTS(Nft);
-
+   PSIBASE_REFLECT_MERKLE_EVENTS(Nft,
+      method(transferred, nftId, creditor, debitor, memo)
+   );
    // clang-format on
-
 }  // namespace UserService

--- a/services/user/Nft/include/services/user/nftTables.hpp
+++ b/services/user/Nft/include/services/user/nftTables.hpp
@@ -13,13 +13,11 @@ namespace UserService
       psibase::AccountNumber account;
       psibase::Bitset<8>     config;
 
-      uint64_t eventHead;
-
       using Configurations = psibase::Enum<psibase::EnumElement{"manualDebit"}>;
 
       auto operator<=>(const NftHolderRecord&) const = default;
    };
-   PSIO_REFLECT(NftHolderRecord, account, config, eventHead);
+   PSIO_REFLECT(NftHolderRecord, account, config);
    using NftHolderTable = psibase::Table<NftHolderRecord, &NftHolderRecord::account>;
 
    struct NftRecord
@@ -28,23 +26,32 @@ namespace UserService
       psibase::AccountNumber issuer;
       psibase::AccountNumber owner;
 
-      uint64_t eventHead;
-
       static bool isValidKey(const NID& id) { return id != 0; }
+
+      auto byOwner() const { return std::tuple{owner, id}; }
+      auto byIssuer() const { return std::tuple{issuer, id}; }
 
       auto operator<=>(const NftRecord&) const = default;
    };
-   PSIO_REFLECT(NftRecord, id, issuer, owner, eventHead);
-   using NftTable = psibase::Table<NftRecord, &NftRecord::id>;
+   PSIO_REFLECT(NftRecord, id, issuer, owner);
+   using NftTable =
+       psibase::Table<NftRecord, &NftRecord::id, &NftRecord::byOwner, &NftRecord::byIssuer>;
 
    struct CreditRecord
    {
       NID                    nftId;
       psibase::AccountNumber debitor;
+      psibase::AccountNumber creditor;
+
+      auto byCreditor() const { return std::tuple{creditor, nftId}; }
+      auto byDebitor() const { return std::tuple{debitor, nftId}; }
 
       auto operator<=>(const CreditRecord&) const = default;
    };
-   PSIO_REFLECT(CreditRecord, nftId, debitor);
-   using CreditTable = psibase::Table<CreditRecord, &CreditRecord::nftId>;
+   PSIO_REFLECT(CreditRecord, nftId, debitor, creditor);
+   using CreditTable = psibase::Table<CreditRecord,
+                                      &CreditRecord::nftId,
+                                      &CreditRecord::byCreditor,
+                                      &CreditRecord::byDebitor>;
 
 }  // namespace UserService

--- a/services/user/Nft/test/src/Nft-test.cpp
+++ b/services/user/Nft/test/src/Nft-test.cpp
@@ -15,7 +15,6 @@ using std::optional;
 using std::pair;
 using std::string;
 using std::vector;
-using UserService::NftRecord;
 
 namespace
 {


### PR DESCRIPTION
* Updates the event emission to use the new `events` service.
* Removes old event tracking data from tables
* Updates queries (makes them similar to the new token service queries)

