### PR TITLE
Rust Fracpack: Omit trailing optionals

### DIFF
--- a/rust/burst-transfer/src/main.rs
+++ b/rust/burst-transfer/src/main.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::AtomicI32;
 
 use anyhow::{anyhow, Context};
 use psibase::fracpack::Pack;
+use psibase::{AnyPrivateKey, TraceFormat};
 
 /// Randomly push transfers to a blockchain in bursts
 #[derive(clap::Parser, Debug)]
@@ -18,7 +19,7 @@ struct Args {
 
     /// Sign with this key (repeatable)
     #[clap(short = 's', long, value_name = "KEY")]
-    sign: Vec<psibase::PrivateKey>,
+    sign: Vec<AnyPrivateKey>,
 
     /// Token symbol
     #[clap(required = true)]
@@ -40,6 +41,15 @@ struct Args {
     /// maintain <BURST_SIZE> transactions in flight.
     #[clap(short = 'd', long, default_value_t = 1000)]
     delay: u32,
+
+    /// Controls how transaction traces are reported. Possible values are
+    /// error, stack, full, or json
+    #[clap(long, value_name = "FORMAT", default_value = "stack")]
+    trace: TraceFormat,
+
+    /// Controls whether the transaction's console output is shown
+    #[clap(long, action=clap::ArgAction::Set, require_equals=true, default_value="true", default_missing_value="true")]
+    console: bool,
 }
 
 // Get the url for a service's path
@@ -169,6 +179,9 @@ async fn transfer_impl(
         &args.api,
         reqwest::Client::new(),
         psibase::sign_transaction(trx, &args.sign)?.packed(),
+        args.trace,
+        args.console,
+        None,
     )
     .await?;
     Ok(())

--- a/rust/psibase_macros/src/fracpack_macro.rs
+++ b/rust/psibase_macros/src/fracpack_macro.rs
@@ -302,10 +302,11 @@ fn process_struct(
 
     let check_optional_fields = fields.iter().map(|field| {
         let name = &field.name;
+        let ty = &field.ty;
         if opts.definition_will_not_change {
             quote! {true}
         } else {
-            quote! {!self.#name.is_empty_optional()}
+            quote! {!<#ty as #fracpack_mod::Pack>::is_empty_optional(&self.#name)}
         }
     });
 
@@ -329,7 +330,7 @@ fn process_struct(
         })
         .fold(quote! {0}, |acc, new| quote! {#acc + #new});
 
-    let heap_size = fields
+    let fixed_data_size = fields
         .iter()
         .enumerate()
         .map(|(i, field)| {
@@ -453,7 +454,7 @@ fn process_struct(
                     ];
                     let last_non_empty_index = non_empty_fields.iter().rposition(|&is_non_empty| is_non_empty).unwrap_or(usize::MAX);
 
-                    let heap = #heap_size;
+                    let heap = #fixed_data_size;
                     assert!(heap as u16 as u32 == heap); // TODO: return error
 
 

--- a/rust/test_fracpack/src/lib.rs
+++ b/rust/test_fracpack/src/lib.rs
@@ -160,3 +160,34 @@ pub struct ThreeElementsFixedStruct {
     pub element_2: i16,
     pub element_3: i16,
 }
+
+#[derive(Pack, Unpack, Debug, PartialEq)]
+#[fracpack(fracpack_mod = "fracpack")]
+pub struct MultipleTrailingOptions {
+    pub a: u32,
+    pub b: u64,
+    pub s: String,
+    pub opt_x: Option<u32>,
+    pub opt_y: Option<String>,
+    pub opt_z: Option<u64>,
+}
+
+#[derive(Pack, Unpack, Debug, PartialEq)]
+#[fracpack(fracpack_mod = "fracpack")]
+#[fracpack(definition_will_not_change)]
+pub struct UnextensibleMultipleTrailingOptions {
+    pub a: u32,
+    pub b: u64,
+    pub s: String,
+    pub opt_x: Option<u32>,
+    pub opt_y: Option<String>,
+    pub opt_z: Option<u64>,
+}
+
+#[derive(Pack, Unpack, Debug, PartialEq)]
+#[fracpack(fracpack_mod = "fracpack")]
+pub struct OptionInTheMiddle {
+    pub a: u32,
+    pub opt_b: Option<String>,
+    pub c: u32,
+}

--- a/rust/test_fracpack/src/lib.rs
+++ b/rust/test_fracpack/src/lib.rs
@@ -191,3 +191,16 @@ pub struct OptionInTheMiddle {
     pub opt_b: Option<String>,
     pub c: u32,
 }
+
+type MyOpt<T> = Option<T>;
+
+#[derive(Pack, Unpack, Debug, PartialEq)]
+#[fracpack(fracpack_mod = "fracpack")]
+pub struct TrailingWithAliasedOptionType {
+    pub a: u32,
+    pub b: u64,
+    pub s: String,
+    pub opt_x: MyOpt<u32>,
+    pub opt_y: MyOpt<String>,
+    pub opt_z: MyOpt<u64>,
+}

--- a/rust/test_fracpack/tests/test.cpp
+++ b/rust/test_fracpack/tests/test.cpp
@@ -260,10 +260,7 @@ void check_same(const auto& rust, const auto& cpp)
               psio::bytes{std::vector<char>((const char*)rust.data(),
                                             (const char*)(rust.data() + rust.size()))})
               .c_str());
-   printf("        cpp:  %s\n",
-          psio::convert_to_json(
-              psio::bytes{std::vector<char>(cpp.data(), (const char*)(cpp.data() + cpp.size()))})
-              .c_str());
+   printf("        cpp:  %s\n", psio::convert_to_json(cpp).c_str());
    if (rust.size() == cpp.size() && !memcmp(rust.data(), cpp.data(), rust.size()))
       return;
    throw std::runtime_error("rust and c++ packed differ");

--- a/rust/test_fracpack/tests/test.hpp
+++ b/rust/test_fracpack/tests/test.hpp
@@ -12,6 +12,7 @@
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #pragma GCC diagnostic ignored "-Wambiguous-reversed-operator"
 #include <psio/bytes.hpp>
+#include <psio/shared_view_ptr.hpp>
 #include <psio/fracpack.hpp>
 #pragma GCC diagnostic pop
 

--- a/rust/test_fracpack/tests/test.rs
+++ b/rust/test_fracpack/tests/test.rs
@@ -319,6 +319,7 @@ fn round_trip_fields(index: usize, obj: &OuterStruct) {
     do_rt!(index, obj, field_option_sns);
     println!("compared sns");
     do_rt!(index, obj, field_option_inner);
+    do_rt!(index, obj, field_option_u_inner);
     do_rt!(index, obj, field_o_o_i8);
     do_rt!(index, obj, field_o_o_str);
     do_rt!(index, obj, field_o_o_str2);
@@ -336,7 +337,6 @@ fn t1() -> Result<()> {
         let unpacked = OuterStruct::unpack(&packed[..], &mut 0)?;
         assert_eq!(*t, unpacked);
         test_fracpack::bridge::ffi::round_trip_outer_struct(i, &packed[..]);
-        // TODO: optionals after fixed-data portion ends
     }
     Ok(())
 }
@@ -454,6 +454,184 @@ fn test_tuples() {
     pack_and_compare(
         &sws_tuple,
         "16000A0000000B000000000000000C0008000000A4709D3F020000006869",
+    );
+}
+
+#[test]
+fn test_full_outer_struct() {
+    let outer_struct = &get_tests1()[0];
+    pack_and_compare(outer_struct, "8200010200030000000400000000000000FBFAFFF9FFFFFFF8FFFFFFFFFFFFFF000000000AD7134100000000000025C0540000006200000000000000A4000000A1000000010000009B0000009F000000010000009800000001000000000000009000000001000000010000000100000001000000010000000100000001000000740000001000D204000001000000010000000000000000000000003400000000000100000000000000000000000000000000000100000021000000000000000000000001000000000000000000000000040000000000000000000000000000000B0C000D00000000000000F2F1FFFFFF00008CC100000000");
+}
+
+#[test]
+fn test_trailing_options() {
+    let all_values_present = MultipleTrailingOptions {
+        a: 1,
+        b: 2,
+        s: "hi".to_string(),
+        opt_x: Some(3),
+        opt_y: Some("bye".to_string()),
+        opt_z: Some(4),
+    };
+    pack_and_compare(
+        &all_values_present,
+        "1C000100000002000000000000001000000012000000120000001500000002000000686903000000030000006279650400000000000000",
+    );
+
+    let empty_last_option = MultipleTrailingOptions {
+        a: 1,
+        b: 2,
+        s: "hi".to_string(),
+        opt_x: Some(3),
+        opt_y: Some("bye".to_string()),
+        opt_z: None,
+    };
+    pack_and_compare(
+        &empty_last_option,
+        "18000100000002000000000000000C0000000E0000000E0000000200000068690300000003000000627965",
+    );
+
+    let empty_last_two_options = MultipleTrailingOptions {
+        a: 1,
+        b: 2,
+        s: "hi".to_string(),
+        opt_x: Some(3),
+        opt_y: None,
+        opt_z: None,
+    };
+    pack_and_compare(
+        &empty_last_two_options,
+        "1400010000000200000000000000080000000A00000002000000686903000000",
+    );
+
+    let empty_trailing_options = MultipleTrailingOptions {
+        a: 1,
+        b: 2,
+        s: "hi".to_string(),
+        opt_x: None,
+        opt_y: None,
+        opt_z: None,
+    };
+    pack_and_compare(
+        &empty_trailing_options,
+        "100001000000020000000000000004000000020000006869",
+    );
+
+    let inner_struct = InnerStruct {
+        inner_u32: 1234,
+        var: None,
+        inner_option_u32: None,
+        inner_option_str: Some("".to_string()),
+        inner_option_vec_u16: None,
+        inner_o_vec_o_u16: None,
+    };
+    pack_and_compare(&inner_struct, "1000D2040000010000000100000000000000");
+}
+
+#[test]
+fn options_but_not_trailing() {
+    let empty_middle_option = OptionInTheMiddle {
+        a: 1,
+        opt_b: None,
+        c: 2,
+    };
+    pack_and_compare(&empty_middle_option, "0C00010000000100000002000000");
+
+    let def_wont_change_inner_struct = DefWontChangeInnerStruct {
+        field_bool: false,
+        field_u32: 0,
+        field_var: Variant::ItemU32(0),
+        field_i16: 0,
+        field_o_var: None,
+        field_str: "".to_string(),
+        field_a_i16_3: [0, 0, 0],
+        field_f32: 0.0,
+        field_o_v_i8: None,
+        field_a_s_2: ["".to_string(), "".to_string()],
+        field_f64: 0.0,
+        field_o_str: None,
+        field_v_u16: vec![],
+        field_i32: 0,
+    };
+    pack_and_compare(
+        &def_wont_change_inner_struct,
+        "0000000000340000000000010000000000000000000000000000000000010000002100000000000000000000000100000000000000000000000004000000000000000000000000000000",
+    );
+
+    let def_wont_change_inner_struct2 = DefWontChangeInnerStruct {
+        field_bool: true,
+        field_u32: 44,
+        field_var: Variant::ItemStr("xyz".to_string()),
+        field_i16: 55,
+        field_o_var: Some(Variant::ItemU32(88)),
+        field_str: "byebye".to_string(),
+        field_a_i16_3: [77, 88, 99],
+        field_f32: 6.4,
+        field_o_v_i8: Some(vec![44, 55, 66]),
+        field_a_s_2: ["aa".to_string(), "bb".to_string()],
+        field_f64: 128.128,
+        field_o_str: Some("lo".to_string()),
+        field_v_u16: vec![3, 2, 1],
+        field_i32: -999,
+    };
+    pack_and_compare(
+        &def_wont_change_inner_struct2,
+        "012C0000003400000037003A0000003F0000004D0058006300CDCCCC403B0000003E0000006ABC749318046040460000004800000019FCFFFF01070000000300000078797A00040000005800000006000000627965627965030000002C3742080000000A000000020000006161020000006262020000006C6F06000000030002000100",
+    );
+}
+
+#[test]
+fn test_trailing_options_unextensible() {
+    let all_values_present = UnextensibleMultipleTrailingOptions {
+        a: 1,
+        b: 2,
+        s: "hi".to_string(),
+        opt_x: Some(3),
+        opt_y: Some("bye".to_string()),
+        opt_z: Some(4),
+    };
+    pack_and_compare(
+        &all_values_present,
+        "0100000002000000000000001000000012000000120000001500000002000000686903000000030000006279650400000000000000",
+    );
+
+    let empty_last_option = UnextensibleMultipleTrailingOptions {
+        a: 1,
+        b: 2,
+        s: "hi".to_string(),
+        opt_x: Some(3),
+        opt_y: Some("bye".to_string()),
+        opt_z: None,
+    };
+    pack_and_compare(
+        &empty_last_option,
+        "010000000200000000000000100000001200000012000000010000000200000068690300000003000000627965",
+    );
+
+    let empty_last_two_options = UnextensibleMultipleTrailingOptions {
+        a: 1,
+        b: 2,
+        s: "hi".to_string(),
+        opt_x: Some(3),
+        opt_y: None,
+        opt_z: None,
+    };
+    pack_and_compare(
+        &empty_last_two_options,
+        "0100000002000000000000001000000012000000010000000100000002000000686903000000",
+    );
+
+    let empty_trailing_options = UnextensibleMultipleTrailingOptions {
+        a: 1,
+        b: 2,
+        s: "hi".to_string(),
+        opt_x: None,
+        opt_y: None,
+        opt_z: None,
+    };
+    pack_and_compare(
+        &empty_trailing_options,
+        "01000000020000000000000010000000010000000100000001000000020000006869",
     );
 }
 


### PR DESCRIPTION
Fracpack fix, plus adjust the `burst-transfer` rust tool just to fix our `cargo build`.