### PR TITLE
add account exists query

### DIFF
--- a/services/system/Accounts/include/services/system/Accounts.hpp
+++ b/services/system/Accounts/include/services/system/Accounts.hpp
@@ -64,7 +64,7 @@ namespace SystemService
 
       auto key() const { return accountNum; }
    };
-   PSIO_REFLECT(Account, accountNum, authService)
+   PSIO_REFLECT(Account, accountNum, authService, resourceBalance)
    using AccountTable = psibase::Table<Account, &Account::key>;
 
    /// This service facilitates the creation of new accounts

--- a/services/system/Accounts/src/RAccounts.cpp
+++ b/services/system/Accounts/src/RAccounts.cpp
@@ -19,12 +19,13 @@ namespace SystemService
 {
    struct AccountsQuery
    {
-      auto exists(AccountNumber account) const
-      {  //
-         return to<Accounts>().exists(account);
+      auto getAccount(AccountNumber account) const
+      {
+         Accounts::Tables tables{Accounts::service};
+         return tables.open<AccountTable>().get(account);
       }
    };
-   PSIO_REFLECT(AccountsQuery, method(exists, account));
+   PSIO_REFLECT(AccountsQuery, method(getAccount, account));
 
    std::optional<HttpReply> RAccounts::serveSys(HttpRequest request)
    {

--- a/services/system/Accounts/src/RAccounts.cpp
+++ b/services/system/Accounts/src/RAccounts.cpp
@@ -3,6 +3,7 @@
 #include <psibase/dispatch.hpp>
 #include <psibase/nativeTables.hpp>
 #include <psibase/serveContent.hpp>
+#include <psibase/serveGraphQL.hpp>
 #include <psibase/serveSimpleUI.hpp>
 #include <psio/from_json.hpp>
 #include <psio/to_json.hpp>
@@ -16,49 +17,22 @@ using Tables = psibase::ServiceTables<psibase::WebContentTable>;
 
 namespace SystemService
 {
+   struct AccountsQuery
+   {
+      auto exists(AccountNumber account) const
+      {  //
+         return to<Accounts>().exists(account);
+      }
+   };
+   PSIO_REFLECT(AccountsQuery, method(exists, account));
+
    std::optional<HttpReply> RAccounts::serveSys(HttpRequest request)
    {
-      auto to_json = [](const auto& obj)
-      {
-         auto json = psio::convert_to_json(obj);
-         return HttpReply{
-             .contentType = "application/json",
-             .body        = {json.begin(), json.end()},
-         };
-      };
-
-      if (request.method == "GET")
-      {
-         // TODO: replace with GraphQL
-         // if (request.target.starts_with("/api/accounts"))
-         // {
-         //    auto accountsTables = Accounts::Tables(Accounts::service);
-         //    auto accountTable     = accountsTables.open<AccountTable>();
-         //    auto accountIndex     = accountTable.getIndex<0>();
-
-         //    std::vector<Account> rows;
-         //    for (auto it = accountIndex.begin(); it != accountIndex.end(); ++it)
-         //       rows.push_back(*it);
-         //    return to_json(rows);
-         // }
-
-         // TODO: replace with GraphQL
-         if (request.target == "/accounts")
-         {
-            auto accountsTables = Accounts::Tables(Accounts::service);
-            auto accountTable   = accountsTables.open<AccountTable>();
-            auto accountIndex   = accountTable.getIndex<0>();
-
-            std::vector<Account> rows;
-            for (auto it = accountIndex.begin(); it != accountIndex.end(); ++it)
-               rows.push_back(*it);
-            return to_json(rows);
-         }
-      }
-
       if (auto result = psibase::serveSimpleUI<Accounts, false>(request))
          return result;
       if (auto result = psibase::serveContent(request, Tables{getReceiver()}))
+         return result;
+      if (auto result = psibase::serveGraphQL(request, AccountsQuery{}))
          return result;
       return std::nullopt;
    }  // serveSys


### PR DESCRIPTION
Allows the accounts plugin to more easily implement a check for whether a particular account exists, which then enables third-party plugins to check for the existence of accounts.