### PR TITLE
Move tracking of selected chain to wasm

### DIFF
--- a/libraries/psibase/CMakeLists.txt
+++ b/libraries/psibase/CMakeLists.txt
@@ -122,6 +122,7 @@ function(add suffix)
             service/src/ossl.c
             service/src/time.c
             tester/src/tester_intrinsics.cpp
+            tester/src/chain_polyfill.cpp
             tester/src/wasi_polyfill/system.cpp
         )
         target_compile_options(psitestlib${suffix} PUBLIC -DCOMPILING_TESTS)

--- a/libraries/psibase/tester/src/chain_polyfill.cpp
+++ b/libraries/psibase/tester/src/chain_polyfill.cpp
@@ -1,0 +1,102 @@
+#include <psibase/RawNativeFunctions.hpp>
+
+using namespace psibase;
+using std::uint32_t;
+
+namespace psibase::tester::raw
+{
+   extern uint32_t getSelectedChain();
+
+#define TESTER_NATIVE(name) [[clang::import_module("psibase"), clang::import_name(#name)]]
+
+   TESTER_NATIVE(abortMessage) void abortMessage(const char* message, uint32_t len);
+
+   TESTER_NATIVE(getResult)
+   uint32_t getResult(const char* dest, uint32_t destSize, uint32_t offset);
+
+   TESTER_NATIVE(getKey) uint32_t getKey(const char* dest, uint32_t destSize);
+
+   TESTER_NATIVE(kvGet)
+   std::uint32_t kvGet(uint32_t chain, DbId db, const char* key, uint32_t keyLen);
+
+   TESTER_NATIVE(getSequential) uint32_t getSequential(uint32_t chain, DbId db, uint64_t id);
+
+   TESTER_NATIVE(kvGreaterEqual)
+   uint32_t kvGreaterEqual(uint32_t    chain,
+                           DbId        db,
+                           const char* key,
+                           uint32_t    keyLen,
+                           uint32_t    matchKeySize);
+
+   TESTER_NATIVE(kvLessThan)
+   uint32_t kvLessThan(uint32_t    chain,
+                       DbId        db,
+                       const char* key,
+                       uint32_t    keyLen,
+                       uint32_t    matchKeySize);
+
+   TESTER_NATIVE(kvMax) uint32_t kvMax(uint32_t chain, DbId db, const char* key, uint32_t keyLen);
+
+#undef TESTER_NATIVE
+}  // namespace psibase::tester::raw
+
+uint32_t psibase::raw::getResult(const char* dest, uint32_t destSize, uint32_t offset)
+{
+   return psibase::tester::raw::getResult(dest, destSize, offset);
+}
+
+uint32_t psibase::raw::getKey(const char* dest, uint32_t destSize)
+{
+   return psibase::tester::raw::getKey(dest, destSize);
+}
+
+void psibase::raw::abortMessage(const char* message, uint32_t len)
+{
+   return psibase::tester::raw::abortMessage(message, len);
+}
+
+void psibase::raw::writeConsole(const char* message, uint32_t len)
+{
+   ::write(1, message, len);
+}
+
+// PSIBASE_NATIVE(getCurrentAction) uint32_t getCurrentAction();
+// PSIBASE_NATIVE(call) uint32_t call(const char* action, uint32_t len);
+// PSIBASE_NATIVE(setRetval) void setRetval(const char* retval, uint32_t len);
+// PSIBASE_NATIVE(kvPut)
+// void kvPut(DbId db, const char* key, uint32_t keyLen, const char* value, uint32_t valueLen);
+// PSIBASE_NATIVE(putSequential)
+// uint64_t putSequential(DbId db, const char* value, uint32_t valueLen);
+// PSIBASE_NATIVE(kvRemove) void kvRemove(DbId db, const char* key, uint32_t keyLen);
+
+uint32_t psibase::raw::kvGet(DbId db, const char* key, uint32_t keyLen)
+{
+   return psibase::tester::raw::kvGet(psibase::tester::raw::getSelectedChain(), db, key, keyLen);
+}
+
+uint32_t psibase::raw::getSequential(DbId db, uint64_t id)
+{
+   return psibase::tester::raw::getSequential(psibase::tester::raw::getSelectedChain(), db, id);
+}
+
+uint32_t psibase::raw::kvGreaterEqual(DbId        db,
+                                      const char* key,
+                                      uint32_t    keyLen,
+                                      uint32_t    matchKeySize)
+{
+   return psibase::tester::raw::kvGreaterEqual(psibase::tester::raw::getSelectedChain(), db, key,
+                                               keyLen, matchKeySize);
+}
+
+uint32_t psibase::raw::kvLessThan(DbId db, const char* key, uint32_t keyLen, uint32_t matchKeySize)
+{
+   return psibase::tester::raw::kvLessThan(psibase::tester::raw::getSelectedChain(), db, key,
+                                           keyLen, matchKeySize);
+}
+
+uint32_t psibase::raw::kvMax(DbId db, const char* key, uint32_t keyLen)
+{
+   return psibase::tester::raw::kvMax(psibase::tester::raw::getSelectedChain(), db, key, keyLen);
+}
+
+// PSIBASE_NATIVE(setMaxTransactionTime) void setMaxTransactionTime(uint64_t ns);

--- a/programs/psitest/main.cpp
+++ b/programs/psitest/main.cpp
@@ -191,7 +191,6 @@ struct state
    std::vector<file>                        files;
    std::vector<std::unique_ptr<test_chain>> chains;
    std::shared_ptr<WatchdogManager>         watchdogManager = std::make_shared<WatchdogManager>();
-   std::optional<uint32_t>                  selected_chain_index;
    std::vector<char>                        result_key;
    std::vector<char>                        result_value;
 };
@@ -983,16 +982,12 @@ struct callbacks
    {
       state.chains.push_back(
           std::make_unique<test_chain>(state, hot_bytes, warm_bytes, cool_bytes, cold_bytes));
-      if (state.chains.size() == 1)
-         state.selected_chain_index = 0;
       return state.chains.size() - 1;
    }
 
    void testerDestroyChain(uint32_t chain)
    {
       assert_chain(chain, false);
-      if (state.selected_chain_index && *state.selected_chain_index == chain)
-         state.selected_chain_index.reset();
       state.chains[chain].reset();
       while (!state.chains.empty() && !state.chains.back())
       {
@@ -1191,17 +1186,9 @@ struct callbacks
       return state.result_value.size();
    }
 
-   void testerSelectChainForDb(uint32_t chain_index)
+   psibase::NativeFunctions& native(std::uint32_t chain_index)
    {
-      assert_chain(chain_index);
-      state.selected_chain_index = chain_index;
-   }
-
-   psibase::NativeFunctions& native()
-   {
-      if (!state.selected_chain_index)
-         throw std::runtime_error("no chain is selected");
-      return assert_chain(*state.selected_chain_index).native();
+      return assert_chain(chain_index).native();
    }
 
    void setResult(psibase::NativeFunctions& n)
@@ -1226,49 +1213,55 @@ struct callbacks
       return state.result_key.size();
    }
 
-   uint32_t kvGet(uint32_t db, eosio::vm::span<const char> key)
+   uint32_t kvGet(std::uint32_t chain_index, uint32_t db, eosio::vm::span<const char> key)
    {
-      auto& n      = native();
+      auto& n      = native(chain_index);
       auto  result = n.kvGet(db, key);
       setResult(n);
       return result;
    }
 
-   uint32_t getSequential(uint32_t db, uint64_t indexNumber)
+   uint32_t getSequential(std::uint32_t chain_index, uint32_t db, uint64_t indexNumber)
    {
-      auto& n      = native();
+      auto& n      = native(chain_index);
       auto  result = n.getSequential(db, indexNumber);
       setResult(n);
       return result;
    }
 
-   uint32_t kvGreaterEqual(uint32_t db, eosio::vm::span<const char> key, uint32_t matchKeySize)
+   uint32_t kvGreaterEqual(std::uint32_t               chain_index,
+                           uint32_t                    db,
+                           eosio::vm::span<const char> key,
+                           uint32_t                    matchKeySize)
    {
-      auto& n      = native();
+      auto& n      = native(chain_index);
       auto  result = n.kvGreaterEqual(db, key, matchKeySize);
       setResult(n);
       return result;
    }
 
-   uint32_t kvLessThan(uint32_t db, eosio::vm::span<const char> key, uint32_t matchKeySize)
+   uint32_t kvLessThan(std::uint32_t               chain_index,
+                       uint32_t                    db,
+                       eosio::vm::span<const char> key,
+                       uint32_t                    matchKeySize)
    {
-      auto& n      = native();
-      auto  result = native().kvLessThan(db, key, matchKeySize);
+      auto& n      = native(chain_index);
+      auto  result = n.kvLessThan(db, key, matchKeySize);
       setResult(n);
       return result;
    }
 
-   uint32_t kvMax(uint32_t db, eosio::vm::span<const char> key)
+   uint32_t kvMax(std::uint32_t chain_index, uint32_t db, eosio::vm::span<const char> key)
    {
-      auto& n      = native();
+      auto& n      = native(chain_index);
       auto  result = n.kvMax(db, key);
       setResult(n);
       return result;
    }
 
-   uint32_t kvGetTransactionUsage()
+   uint32_t kvGetTransactionUsage(std::uint32_t chain_index)
    {
-      auto& n      = native();
+      auto& n      = native(chain_index);
       auto  result = n.kvGetTransactionUsage();
       setResult(n);
       return result;
@@ -1286,28 +1279,25 @@ void backtrace()
 void register_callbacks()
 {
    // Psibase Intrinsics
-   rhf_t::add<&callbacks::abortMessage>("env", "abortMessage");
-   rhf_t::add<&callbacks::writeConsole>("env", "writeConsole");
-   rhf_t::add<&callbacks::getResult>("env", "getResult");
-   rhf_t::add<&callbacks::getKey>("env", "getKey");
-   rhf_t::add<&callbacks::kvGet>("env", "kvGet");
-   rhf_t::add<&callbacks::getSequential>("env", "getSequential");
-   rhf_t::add<&callbacks::kvGreaterEqual>("env", "kvGreaterEqual");
-   rhf_t::add<&callbacks::kvLessThan>("env", "kvLessThan");
-   rhf_t::add<&callbacks::kvMax>("env", "kvMax");
-   rhf_t::add<&callbacks::kvGetTransactionUsage>("env", "kvGetTransactionUsage");
+   rhf_t::add<&callbacks::abortMessage>("psibase", "abortMessage");
+   rhf_t::add<&callbacks::getResult>("psibase", "getResult");
+   rhf_t::add<&callbacks::getKey>("psibase", "getKey");
+   rhf_t::add<&callbacks::kvGet>("psibase", "kvGet");
+   rhf_t::add<&callbacks::getSequential>("psibase", "getSequential");
+   rhf_t::add<&callbacks::kvGreaterEqual>("psibase", "kvGreaterEqual");
+   rhf_t::add<&callbacks::kvLessThan>("psibase", "kvLessThan");
+   rhf_t::add<&callbacks::kvMax>("psibase", "kvMax");
+   rhf_t::add<&callbacks::kvGetTransactionUsage>("psibase", "kvGetTransactionUsage");
 
    // Tester Intrinsics
-   rhf_t::add<&callbacks::testerAbort>("env", "testerAbort");
-   rhf_t::add<&callbacks::testerCreateChain>("env", "testerCreateChain");
-   rhf_t::add<&callbacks::testerDestroyChain>("env", "testerDestroyChain");
-   rhf_t::add<&callbacks::testerShutdownChain>("env", "testerShutdownChain");
-   rhf_t::add<&callbacks::testerGetChainPath>("env", "testerGetChainPath");
-   rhf_t::add<&callbacks::testerStartBlock>("env", "testerStartBlock");
-   rhf_t::add<&callbacks::testerFinishBlock>("env", "testerFinishBlock");
-   rhf_t::add<&callbacks::testerPushTransaction>("env", "testerPushTransaction");
-   rhf_t::add<&callbacks::testerHttpRequest>("env", "testerHttpRequest");
-   rhf_t::add<&callbacks::testerSelectChainForDb>("env", "testerSelectChainForDb");
+   rhf_t::add<&callbacks::testerCreateChain>("psibase", "createChain");
+   rhf_t::add<&callbacks::testerDestroyChain>("psibase", "destroyChain");
+   rhf_t::add<&callbacks::testerShutdownChain>("psibase", "shutdownChain");
+   rhf_t::add<&callbacks::testerGetChainPath>("psibase", "getChainPath");
+   rhf_t::add<&callbacks::testerStartBlock>("psibase", "startBlock");
+   rhf_t::add<&callbacks::testerFinishBlock>("psibase", "finishBlock");
+   rhf_t::add<&callbacks::testerPushTransaction>("psibase", "pushTransaction");
+   rhf_t::add<&callbacks::testerHttpRequest>("psibase", "httpRequest");
    rhf_t::add<&callbacks::testerExecute>("env", "testerExecute");
 
    // WASI functions

--- a/rust/psibase/src/tester_raw.rs
+++ b/rust/psibase/src/tester_raw.rs
@@ -19,10 +19,6 @@ extern "C" {
 extern "C" {
     /// Create a new chain and make it active for database native functions.
     ///
-    /// `max_objects` is the maximum number of objects the database can hold.
-    /// The remaining arguments are log-base-2 of file sizes for the database's
-    /// various files. e.g. `32` is 4 GB.
-    ///
     /// Returns a chain handle
     pub fn createChain(hot_bytes: u64, warm_bytes: u64, cool_bytes: u64, cold_bytes: u64) -> u32;
 
@@ -51,37 +47,20 @@ extern "C" {
     /// `chain_handle` identifies the chain to push to. `transaction/transaction_size`
     /// contains a fracpacked [`SignedTransaction`](crate::SignedTransaction).
     ///
-    /// The callback `cb_alloc` must allocate `size` bytes and return a pointer to it.
-    /// If it can't allocate the memory, then it must abort, either by `panic`,
-    /// [`raw::abortMessage`](crate::native_raw::abortMessage), or the `unreachable` instruction.
-    /// `testerPushTransaction` does not hold onto the pointer; it fills it with a
-    /// packed [`TransactionTrace`](crate::TransactionTrace) then returns.
-    /// `testerPushTransaction` passes `alloc_context` to `cb_alloc`.
+    /// Stores the transaction trace into result and returns the result size
     pub fn pushTransaction(
         chain_handle: u32,
         transaction: *const u8,
         transaction_size: usize,
     ) -> u32;
 
-    /// Select chain for database native functions
-    ///
-    /// After you call `testerSelectChainForDb`, the following functions will use
-    /// this chain's database:
-    ///
-    /// * [`raw::kvGet`](crate::native_raw::kvGet)
-    /// * [`raw::getSequential`](crate::native_raw::getSequential)
-    /// * [`raw::kvGreaterEqual`](crate::native_raw::kvGreaterEqual)
-    /// * [`raw::kvLessThan`](crate::native_raw::kvLessThan)
-    /// * [`raw::kvMax`](crate::native_raw::kvMax)
-    pub fn testerSelectChainForDb(chain_handle: u32);
-
     /// Shutdown chain without deleting database
     ///
     /// This shuts down a chain, but doesn't destroy it or remove the
     /// database. `chain_handle` still exists, but isn't usable except
-    /// with [`testerGetChainPath`] and [`testerDestroyChain`].
+    /// with [`getChainPath`] and [`destroyChain`].
     ///
-    /// TODO: `testerShutdownChain` probably isn't useful anymore; it might go away.
+    /// TODO: `shutdownChain` probably isn't useful anymore; it might go away.
     pub fn shutdownChain(chain_handle: u32);
 
     /// Start a new block
@@ -134,6 +113,16 @@ pub fn get_selected_chain() -> u32 {
     SELECTED_CHAIN.with(|c| c.get().unwrap())
 }
 
+/// Select chain for database native functions
+///
+/// After you call `tester_select_chain_for_db`, the following functions will use
+/// this chain's database:
+///
+/// * [`raw::kvGet`](crate::native_raw::kvGet)
+/// * [`raw::getSequential`](crate::native_raw::getSequential)
+/// * [`raw::kvGreaterEqual`](crate::native_raw::kvGreaterEqual)
+/// * [`raw::kvLessThan`](crate::native_raw::kvLessThan)
+/// * [`raw::kvMax`](crate::native_raw::kvMax)
 pub fn tester_select_chain_for_db(chain_handle: u32) {
     SELECTED_CHAIN.with(|c| c.set(Some(chain_handle)));
 }


### PR DESCRIPTION
The chain handle is explicitly passed to all the host functions that require it. This requires extra polyfills in the tester.

Also,
- Replace tester's `writeConsole` with `write` to STDOUT.
- Put tester host functions in the `psibase` module.
