### PR TITLE
Add rust/psibase unit tests to ctest

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -1,12 +1,6 @@
 enable_testing()
 
 add_test(
-    NAME CargoPsibase-test
-    COMMAND cargo test --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/cargo-psibase/Cargo.toml
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cargo-psibase/
-)
-
-add_test(
     NAME rs-subjective-test
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/release/cargo-psibase test --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/test_subjective/Cargo.toml --target-dir ${CMAKE_CURRENT_BINARY_DIR} --psitest=${CMAKE_BINARY_DIR}/psitest
 )
@@ -18,5 +12,11 @@ add_test(
 
 add_test(
     NAME rs-tests
-    COMMAND cargo test --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml --target-dir ${CMAKE_CURRENT_BINARY_DIR} -p test_fracpack
+    COMMAND cargo test --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml --target-dir ${CMAKE_CURRENT_BINARY_DIR} -p test_fracpack -p psibase -p cargo-psibase
 )
+
+include(ProcessorCount)
+ProcessorCount(NPROC)
+if(NPROC)
+    set_tests_properties(rs-tests PROPERTIES PROCESSORS ${NPROC})
+endif()

--- a/rust/psibase/src/package.rs
+++ b/rust/psibase/src/package.rs
@@ -53,7 +53,7 @@ pub struct PackageRef {
     pub version: String,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Pack, Unpack, ToSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Pack, Unpack, ToSchema)]
 #[fracpack(fracpack_mod = "fracpack")]
 pub struct Meta {
     pub name: String,


### PR DESCRIPTION
- Combine rust unit tests into a single run of cargo
- Mark rs-tests as using all available cores, so ctest doesn't try to run other tests in parallel with it
- Clear assumptions so that optimizing non-requested packages doesn't just fail.
- Make depgraph tests compile again