### PR TITLE
Build rs-tests in release mode to reduce total size

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -12,7 +12,7 @@ add_test(
 
 add_test(
     NAME rs-tests
-    COMMAND cargo test --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml --target-dir ${CMAKE_CURRENT_BINARY_DIR} -p test_fracpack -p psibase -p cargo-psibase
+    COMMAND cargo test -r --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml --target-dir ${CMAKE_CURRENT_BINARY_DIR} -p test_fracpack -p psibase -p cargo-psibase
 )
 
 include(ProcessorCount)


### PR DESCRIPTION
The extra debug build takes a while and generates ~5GiB of build artifacts. This seems to be the main reason why CICD has started failing.