### PR TITLE
Fix writing http-timeout to the config file

### DIFF
--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -282,18 +282,22 @@ void validate(boost::any& v, const std::vector<std::string>& values, Timeout*, i
 
 std::string to_string(const Timeout& timeout)
 {
-   auto ms = timeout.duration.count();
    if (timeout == Timeout::none())
    {
       return "inf";
    }
-   if (ms % 1000 == 0)
+   auto us = std::chrono::duration_cast<std::chrono::microseconds>(timeout.duration).count();
+   if (us % 1000000 == 0)
    {
-      return std::to_string(ms / 1000) + " s";
+      return std::to_string(us / 1000000) + " s";
+   }
+   else if (us % 1000 == 0)
+   {
+      return std::to_string(us / 1000) + " ms";
    }
    else
    {
-      return std::to_string(ms) + " ms";
+      return std::to_string(us) + " us";
    }
 }
 


### PR DESCRIPTION
I think at one point it was using milliseconds, and I missed to_string when I changed it to microseconds.