### PR TITLE
Propagate graphql errors as errors instead of success response

### DIFF
--- a/services/user/Supervisor/ui/src/pluginHost.ts
+++ b/services/user/Supervisor/ui/src/pluginHost.ts
@@ -140,11 +140,11 @@ export class PluginHost implements HostInterface {
     ): Result<string, RecoverableErrorPayload> {
         const res = this.postGraphQL(`${this.self.origin}/graphql`, graphql);
         if ("body" in res) {
-            if (res.body.includes("errors")) { // works?
+            if (res.body.includes("errors")) {
                 const json = JSON.parse(res.body);
-                throw this.recoverableError(json.errors.message);
+                return this.recoverableError(json.errors.message);
             } else {
-                    return res.body;
+                return res.body;
             }
         }
         return res;

--- a/services/user/Supervisor/ui/src/pluginHost.ts
+++ b/services/user/Supervisor/ui/src/pluginHost.ts
@@ -140,7 +140,12 @@ export class PluginHost implements HostInterface {
     ): Result<string, RecoverableErrorPayload> {
         const res = this.postGraphQL(`${this.self.origin}/graphql`, graphql);
         if ("body" in res) {
-            return res.body;
+            if (res.body.includes("errors")) { // works?
+                const json = JSON.parse(res.body);
+                throw this.recoverableError(json.errors.message);
+            } else {
+                    return res.body;
+            }
         }
         return res;
     }

--- a/services/user/Supervisor/ui/src/pluginHost.ts
+++ b/services/user/Supervisor/ui/src/pluginHost.ts
@@ -140,9 +140,9 @@ export class PluginHost implements HostInterface {
     ): Result<string, RecoverableErrorPayload> {
         const res = this.postGraphQL(`${this.self.origin}/graphql`, graphql);
         if ("body" in res) {
-            if (res.body.includes("errors")) {
-                const json = JSON.parse(res.body);
-                return this.recoverableError(json.errors.message);
+            const json = JSON.parse(res.body);
+            if (json.errors?.length) {
+                throw this.recoverableError(JSON.stringify(json.errors));
             } else {
                 return res.body;
             }


### PR DESCRIPTION
Supervisor was returning graphql errors as successes, which caused unrelated downstream issues because everything downstream was expecting good results but getting body = "errors": { ...error stuff... }
Now graphql errors are thrown in the JS context