### PR TITLE
Fix bug writing config file with duplicated hostname

### DIFF
--- a/libraries/psibase/native/src/ConfigFile.cpp
+++ b/libraries/psibase/native/src/ConfigFile.cpp
@@ -520,6 +520,12 @@ void ConfigFile::set(std::string_view                             section,
          {
             insertions[insertPoint] += editLine(opts, section, key, value);
          }
+         else if (lines[iter->second].empty())
+         {
+            // Multiple values for the same key. Make sure that they appear in order
+            insertPoint = iter->second + 1;
+            insertions[insertPoint] += editLine(opts, section, key, value);
+         }
          else
          {
             auto location = iter->second;


### PR DESCRIPTION
It caused this:
```
= localhost:
```

because we edit a line by deleting and reinserting it and then the second instance attempts to read the key name (`service`) from a line that has been cleared, which causes it to get a blank key.