### PR TITLE
Default deploy chainmail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ set(JS_DIRS
     services/user/Supervisor/ui:Supervisor_js
     services/user/Explorer/ui:Explorer_js
     services/user/Tokens/ui:Tokens_js
+    services/user/Webmail/ui:Webmail_js
 )
 set(ADMIN_DIR services/user/XAdmin/ui:XAdmin_js)
 set(COMMON_LIB_DIR services/user/CommonApi/common/packages/common-lib/:CommonApiCommonLib_js)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,7 +732,7 @@ psibase_package(
     NAME DevDefault
     VERSION ${PSIBASE_VERSION}
     DESCRIPTION "All development services"
-    PACKAGE_DEPENDS Accounts AuthAny AuthSig AuthDelegate ClientData CommonApi CpuLimit 
+    PACKAGE_DEPENDS Accounts AuthAny AuthSig AuthDelegate Chainmail ClientData CommonApi CpuLimit 
                     Docs Events Explorer Fractal Invite Nft Packages Producers HttpServer
                     Sites SetCode Supervisor Symbol TokenUsers Tokens Transact Homepage
 )
@@ -742,7 +742,7 @@ psibase_package(
     NAME ProdDefault
     VERSION ${PSIBASE_VERSION}
     DESCRIPTION "All production services"
-    PACKAGE_DEPENDS Accounts AuthAny AuthSig AuthDelegate ClientData CommonApi CpuLimit 
+    PACKAGE_DEPENDS Accounts AuthAny AuthSig AuthDelegate Chainmail ClientData CommonApi CpuLimit 
                     Docs Events Explorer Fractal Invite Nft Packages Producers HttpServer
                     Sites SetCode Supervisor Symbol Tokens Transact Homepage
 )
@@ -771,7 +771,7 @@ function(write_package_index target dir)
 endfunction()
 
 write_package_index(package-index ${SERVICE_DIR}
-    Accounts AuthAny AuthSig ClientData CommonApi CpuLimit DevDefault ProdDefault
+    Accounts AuthAny AuthSig Chainmail ClientData CommonApi CpuLimit DevDefault ProdDefault
     Docs Events Explorer Fractal Invite Nft Nop Minimal Packages Producers HttpServer
     Sites SetCode Supervisor Symbol TokenUsers Tokens Transact Homepage)
 
@@ -781,6 +781,7 @@ install(
           ${SERVICE_DIR}/AuthAny.psi
           ${SERVICE_DIR}/AuthDelegate.psi
           ${SERVICE_DIR}/AuthSig.psi
+          ${SERVICE_DIR}/Chainmail.psi
           ${SERVICE_DIR}/ClientData.psi
           ${SERVICE_DIR}/CommonApi.psi
           ${SERVICE_DIR}/DevDefault.psi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ set(JS_DIRS
     services/user/Supervisor/ui:Supervisor_js
     services/user/Explorer/ui:Explorer_js
     services/user/Tokens/ui:Tokens_js
-    services/user/Webmail/ui:Webmail_js
+    services/user/Chainmail/ui:Chainmail_js
 )
 set(ADMIN_DIR services/user/XAdmin/ui:XAdmin_js)
 set(COMMON_LIB_DIR services/user/CommonApi/common/packages/common-lib/:CommonApiCommonLib_js)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,12 @@ psibase_package(
     DEPENDS ${ClientDataPlugin_DEP}
 )
 
+cargo_psibase_package(
+    OUTPUT ${SERVICE_DIR}/Webmail.psi
+    PATH services/user/Webmail
+    # DEPENDS ${Webmail_js_DEP}
+)
+
 psibase_package(
     OUTPUT ${SERVICE_DIR}/AuthSig.psi
     NAME AuthSig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,9 +408,9 @@ psibase_package(
 )
 
 cargo_psibase_package(
-    OUTPUT ${SERVICE_DIR}/Webmail.psi
-    PATH services/user/Webmail
-    # DEPENDS ${Webmail_js_DEP}
+    OUTPUT ${SERVICE_DIR}/Chainmail.psi
+    PATH services/user/Chainmail
+    # DEPENDS ${Chainmail_js_DEP}
 )
 
 psibase_package(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.20)
 cmake_policy(VERSION 3.16.3...3.25.1)
 project(psibase)
 include(ExternalProject)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16.3)
 cmake_policy(VERSION 3.16.3...3.25.1)
 project(psibase)
 include(ExternalProject)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ psibase_package(
 cargo_psibase_package(
     OUTPUT ${SERVICE_DIR}/Chainmail.psi
     PATH services/user/Chainmail
-    # DEPENDS ${Chainmail_js_DEP}
+    DEPENDS ${Chainmail_js_DEP}
 )
 
 psibase_package(

--- a/doc/psidk/src/development/services/rust-service/package.md
+++ b/doc/psidk/src/development/services/rust-service/package.md
@@ -7,7 +7,6 @@ A [psibase package](../../../specifications/data-formats/package.md) may be comp
 The available fields are:
 
 - `package-name`: Must be present on the top-level crate for the package.
-- `description`: A description of the package.
 - `services`: A list of services to include in the psibase package.
 - `server`: May be present on any crate that builds a service. The value is a crate which will handle HTTP requests sent to this service. The other crate will be built and included in the current package.
 - `plugin`: May be present on any crate that builds a service. The value is a crate that should be built with `cargo component` and uploaded as `/plugin.wasm`
@@ -22,12 +21,11 @@ Example:
 [package]
 name = "example"
 version = "0.1.0"
+description = "An example package"
 
 [package.metadata.psibase]
 # Builds example.psi
 package-name = "example"
-# Description of the package
-description = "An example package"
 # Most services besides the core system services don't need extra flags.
 flags = []
 # This service handles its own HTTP requests

--- a/doc/psidk/src/development/services/rust-service/package.md
+++ b/doc/psidk/src/development/services/rust-service/package.md
@@ -7,6 +7,7 @@ A [psibase package](../../../specifications/data-formats/package.md) may be comp
 The available fields are:
 
 - `package-name`: Must be present on the top-level crate for the package.
+- `description`: A description of the package.
 - `services`: A list of services to include in the psibase package.
 - `server`: May be present on any crate that builds a service. The value is a crate which will handle HTTP requests sent to this service. The other crate will be built and included in the current package.
 - `plugin`: May be present on any crate that builds a service. The value is a crate that should be built with `cargo component` and uploaded as `/plugin.wasm`
@@ -25,6 +26,8 @@ version = "0.1.0"
 [package.metadata.psibase]
 # Builds example.psi
 package-name = "example"
+# Description of the package
+description = "An example package"
 # Most services besides the core system services don't need extra flags.
 flags = []
 # This service handles its own HTTP requests

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -337,15 +337,10 @@ function(cargo_psibase_package)
     )
 
     add_custom_command(
-        OUTPUT ${PACKAGE_OUTPUT}
-        COMMAND ${CMAKE_COMMAND} -E true
-        DEPENDS ${TARGET_NAME}_ext
-    )
-
-    add_custom_command(
         OUTPUT ${ARG_OUTPUT}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PACKAGE_OUTPUT} ${ARG_OUTPUT}
         DEPENDS ${PACKAGE_OUTPUT}
+        DEPENDS ${TARGET_NAME}_ext
         VERBATIM
     )
     add_custom_target(${TARGET_NAME} ALL DEPENDS ${ARG_OUTPUT} cargo-psibase)

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -338,7 +338,7 @@ function(cargo_psibase_package)
     add_custom_command(
         OUTPUT ${ARG_OUTPUT}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PACKAGE_OUTPUT} ${ARG_OUTPUT}
-        DEPENDS ${TARGET_NAME}
+        DEPENDS ${PACKAGE_OUTPUT}
         VERBATIM
     )
     add_custom_target(${TARGET_NAME}_output ALL DEPENDS ${ARG_OUTPUT})

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -311,10 +311,8 @@ endfunction()
 #                             built/managed by cargo-psibase, as opposed to packages built entirely using CMake.
 # OUTPUT <filename>         - [Required] The package file.
 # PATH <filepath>           - [Required] The path to the cargo workspace (e.g. `services/user/Branding`).
-# POSTINSTALL <filename>    - [Optional] Additional actions that should be run at the end of installation (e.g. `services/user/Branding/postinstall.json`)
-# UI <service> <filepath>   - [Optional] A service to upload to, and a UI directory to build/upload. (e.g. `branding services/user/Branding/ui`)
 function(cargo_psibase_package)
-    cmake_parse_arguments(ARG "" "PATH;OUTPUT;POSTINSTALL" "UI" ${ARGN})
+    cmake_parse_arguments(ARG "" "PATH;OUTPUT" "" ${ARGN})
 
     if(NOT ARG_PATH OR NOT ARG_OUTPUT)
         message(FATAL_ERROR "Both PATH and OUTPUT must be specified for cargo_psibase_package")
@@ -323,48 +321,7 @@ function(cargo_psibase_package)
     # Set variables
     cmake_path(GET ARG_OUTPUT FILENAME PACKAGE_NAME)
     cmake_path(GET ARG_OUTPUT STEM TARGET_NAME)
-    set(PACKAGE_OUTPUT ${ARG_PATH}/target/wasm32-wasi/release/packages/${PACKAGE_NAME})
-    set(TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp_${TARGET_NAME})
-    set(OUTPUT_DEPENDS)
-    set(POSTINSTALL_COMMAND)
-    if(ARG_POSTINSTALL)
-        set(ARG_POSTINSTALL ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_POSTINSTALL})
-        list(APPEND POSTINSTALL_COMMAND 
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/script
-            COMMAND ${CMAKE_COMMAND} -E copy ${ARG_POSTINSTALL} ${TMP_DIR}/script/postinstall.json
-        )
-        list(APPEND OUTPUT_DEPENDS ${ARG_POSTINSTALL})
-    endif()
-    set(UI_COMMAND)
-    if (ARG_UI)
-        list(GET ARG_UI 0 SERVICE_NAME)
-        list(GET ARG_UI 1 UI_PATH)
-        set(UI_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${UI_PATH})
-        list(APPEND UI_COMMAND
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/data/${SERVICE_NAME}
-            COMMAND ${CMAKE_COMMAND} -E copy_directory ${UI_PATH}/dist ${TMP_DIR}/data/${SERVICE_NAME}
-        )
-        list(APPEND OUTPUT_DEPENDS ${TARGET_NAME}_UI_BUILT)
-    endif()
-    set(MERGE_COMMAND)
-    list(APPEND MERGE_COMMAND
-        COMMAND cd ${TMP_DIR} && zip -ur ${ARG_OUTPUT} . -x ${PACKAGE_NAME}
-    )
-
-    # Build the UI if needed
-    if (ARG_UI)
-        set(OUTPUT_PATH ${UI_PATH}/dist)
-        file(GLOB_RECURSE UI_SOURCES ${UI_PATH}/src/*)
-        list(APPEND UI_SOURCES ${UI_PATH}/package.json ${UI_PATH}/yarn.lock)
-        add_custom_command(
-            OUTPUT ${OUTPUT_PATH}/index.html
-            BYPRODUCTS ${OUTPUT_PATH}
-            DEPENDS ${UI_SOURCES}
-            COMMAND cd ${UI_PATH} && yarn --mutex network && yarn build
-            COMMENT "Building ${TARGET_NAME} UI"
-        )
-        add_custom_target(${TARGET_NAME}_UI_BUILT DEPENDS ${OUTPUT_PATH}/index.html)
-    endif()
+    set(PACKAGE_OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_PATH}/target/wasm32-wasi/release/packages/${PACKAGE_NAME})
 
     # Build the package if needed
     ExternalProject_Add(${TARGET_NAME}
@@ -376,16 +333,12 @@ function(cargo_psibase_package)
         INSTALL_COMMAND ""
         BUILD_ALWAYS 1
     )
-    list(APPEND OUTPUT_DEPENDS ${TARGET_NAME})
 
     # Make the final output
     add_custom_command(
         OUTPUT ${ARG_OUTPUT}
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/${PACKAGE_OUTPUT} ${ARG_OUTPUT}
-        ${POSTINSTALL_COMMAND}
-        ${UI_COMMAND}
-        ${MERGE_COMMAND}
-        DEPENDS ${OUTPUT_DEPENDS}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PACKAGE_OUTPUT} ${ARG_OUTPUT}
+        DEPENDS ${TARGET_NAME}
         VERBATIM
     )
     add_custom_target(${TARGET_NAME}_output ALL DEPENDS ${ARG_OUTPUT})

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -325,7 +325,7 @@ function(cargo_psibase_package)
     set(PACKAGE_OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_PATH}/target/wasm32-wasi/release/packages/${PACKAGE_NAME})
 
     # Build the package if needed
-    ExternalProject_Add(${TARGET_NAME}
+    ExternalProject_Add(${TARGET_NAME}_ext
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_PATH}
         BUILD_BYPRODUCTS ${PACKAGE_OUTPUT}
         CONFIGURE_COMMAND ""
@@ -343,5 +343,5 @@ function(cargo_psibase_package)
         DEPENDS ${PACKAGE_OUTPUT}
         VERBATIM
     )
-    add_custom_target(${TARGET_NAME}_output ALL DEPENDS ${ARG_OUTPUT})
+    add_custom_target(${TARGET_NAME} ALL DEPENDS ${ARG_OUTPUT})
 endfunction()

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -311,7 +311,7 @@ endfunction()
 #                             built/managed by cargo-psibase, as opposed to packages built entirely using CMake.
 # OUTPUT <filename>         - [Required] The package file.
 # PATH <filepath>           - [Required] The path to the cargo workspace (e.g. `services/user/Branding`).
-# DEPENDS <targets>...      - [Required] Targets that this target depends on
+# DEPENDS <targets>...      - Targets that this target depends on
 function(cargo_psibase_package)
     cmake_parse_arguments(ARG "" "PATH;OUTPUT;DEPENDS" "" ${ARGN})
 

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -320,8 +320,8 @@ function(cargo_psibase_package)
     endif()
 
     # Set variables
-    cmake_path(GET ARG_OUTPUT FILENAME PACKAGE_NAME)
-    cmake_path(GET ARG_OUTPUT STEM TARGET_NAME)
+    get_filename_component(PACKAGE_NAME ${ARG_OUTPUT} NAME)
+    get_filename_component(TARGET_NAME ${ARG_OUTPUT} NAME_WE)
     set(PACKAGE_OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_PATH}/target/wasm32-wasi/release/packages/${PACKAGE_NAME})
 
     # Build the package if needed

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -336,10 +336,14 @@ function(cargo_psibase_package)
         DEPENDS ${ARG_DEPENDS} cargo-psibase
     )
 
+    # Adding this target tells cmake how to build package_output, which is needed because the 
+    #   below custom command depends on it.
+    add_custom_target(${TARGET_NAME}_package DEPENDS ${PACKAGE_OUTPUT})
+    add_dependencies(${TARGET_NAME}_package ${TARGET_NAME}_ext)
     add_custom_command(
         OUTPUT ${ARG_OUTPUT}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PACKAGE_OUTPUT} ${ARG_OUTPUT}
-        DEPENDS ${TARGET_NAME}_ext
+        DEPENDS ${PACKAGE_OUTPUT}
         VERBATIM
     )
     add_custom_target(${TARGET_NAME} ALL DEPENDS ${ARG_OUTPUT})

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -336,15 +336,17 @@ function(cargo_psibase_package)
         DEPENDS ${ARG_DEPENDS} cargo-psibase
     )
 
-    # Adding this target tells cmake how to build package_output, which is needed because the 
-    #   below custom command depends on it.
-    add_custom_target(${TARGET_NAME}_package DEPENDS ${PACKAGE_OUTPUT})
-    add_dependencies(${TARGET_NAME}_package ${TARGET_NAME}_ext)
+    add_custom_command(
+        OUTPUT ${PACKAGE_OUTPUT}
+        COMMAND ${CMAKE_COMMAND} -E true
+        DEPENDS ${TARGET_NAME}_ext
+    )
+
     add_custom_command(
         OUTPUT ${ARG_OUTPUT}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PACKAGE_OUTPUT} ${ARG_OUTPUT}
         DEPENDS ${PACKAGE_OUTPUT}
         VERBATIM
     )
-    add_custom_target(${TARGET_NAME} ALL DEPENDS ${ARG_OUTPUT})
+    add_custom_target(${TARGET_NAME} ALL DEPENDS ${ARG_OUTPUT} cargo-psibase)
 endfunction()

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -311,8 +311,9 @@ endfunction()
 #                             built/managed by cargo-psibase, as opposed to packages built entirely using CMake.
 # OUTPUT <filename>         - [Required] The package file.
 # PATH <filepath>           - [Required] The path to the cargo workspace (e.g. `services/user/Branding`).
+# DEPENDS <targets>...      - [Required] Targets that this target depends on
 function(cargo_psibase_package)
-    cmake_parse_arguments(ARG "" "PATH;OUTPUT" "" ${ARGN})
+    cmake_parse_arguments(ARG "" "PATH;OUTPUT;DEPENDS" "" ${ARGN})
 
     if(NOT ARG_PATH OR NOT ARG_OUTPUT)
         message(FATAL_ERROR "Both PATH and OUTPUT must be specified for cargo_psibase_package")
@@ -332,6 +333,7 @@ function(cargo_psibase_package)
             --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_PATH}/Cargo.toml
         INSTALL_COMMAND ""
         BUILD_ALWAYS 1
+        DEPENDS ${ARG_DEPENDS}
     )
 
     # Make the final output

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -333,7 +333,7 @@ function(cargo_psibase_package)
             --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_PATH}/Cargo.toml
         INSTALL_COMMAND ""
         BUILD_ALWAYS 1
-        DEPENDS ${ARG_DEPENDS}
+        DEPENDS ${ARG_DEPENDS} cargo-psibase
     )
 
     # Make the final output

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -336,11 +336,10 @@ function(cargo_psibase_package)
         DEPENDS ${ARG_DEPENDS} cargo-psibase
     )
 
-    # Make the final output
     add_custom_command(
         OUTPUT ${ARG_OUTPUT}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PACKAGE_OUTPUT} ${ARG_OUTPUT}
-        DEPENDS ${PACKAGE_OUTPUT}
+        DEPENDS ${TARGET_NAME}_ext
         VERBATIM
     )
     add_custom_target(${TARGET_NAME} ALL DEPENDS ${ARG_OUTPUT})

--- a/rust/cargo-psibase/src/package.rs
+++ b/rust/cargo-psibase/src/package.rs
@@ -326,13 +326,14 @@ pub async fn build_package(
         }
     };
 
-    let meta = Meta {
+    let mut meta = Meta {
         name: package_name.to_string(),
         version: package_version.to_string(),
         description: package_description.unwrap_or_else(|| package_name.to_string()),
         depends,
         accounts,
     };
+    meta.depends.sort_by(|a, b| a.name.cmp(&b.name));
 
     let mut service_wasms = Vec::new();
     for (service, info, id) in services {

--- a/rust/psibase/src/services/events.rs
+++ b/rust/psibase/src/services/events.rs
@@ -1,19 +1,15 @@
 #[crate::service(name = "events", dispatch = false, psibase_mod = "crate")]
 #[allow(non_snake_case, unused_variables)]
 mod service {
+    use crate::{AccountNumber, DbId, MethodNumber, Schema};
 
     #[action]
-    fn setSchema(schema: crate::Schema) {
+    fn setSchema(schema: Schema) {
         unimplemented!()
     }
 
     #[action]
-    fn addIndex(
-        db_id: crate::DbId,
-        service: crate::AccountNumber,
-        event: crate::MethodNumber,
-        column: u8,
-    ) {
+    fn addIndex(db_id: DbId, service: AccountNumber, event: MethodNumber, column: u8) {
         unimplemented!()
     }
 }

--- a/rust/test_package/Cargo.toml
+++ b/rust/test_package/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "test_package"
+description = "Test for package building"
 version.workspace = true
 rust-version.workspace = true
 repository.workspace = true
@@ -9,7 +10,6 @@ publish = false
 
 [package.metadata.psibase]
 package-name = "TestPackage"
-description = "Test for package building"
 services = ["tpack"]
 
 [lib]

--- a/services/user/Chainmail/Cargo.lock
+++ b/services/user/Chainmail/Cargo.lock
@@ -364,7 +364,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chainmail"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "async-graphql",
  "chainmail_package",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "chainmail_package"
-version = "0.0.0"
+version = "0.12.0"
 dependencies = [
  "chainmail",
  "plugin",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "plugin"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "chainmail",
  "chainmail_package",

--- a/services/user/Chainmail/Cargo.toml
+++ b/services/user/Chainmail/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["service", "plugin"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.12.0"
 rust-version = "1.64"
 edition = "2021"
 repository = "https://github.com/gofractally/psibase"
@@ -12,6 +12,17 @@ publish = false
 
 [package]
 name = "chainmail_package"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+
+[package.metadata.psibase]
+package-name = "Chainmail"
+description = "Message-sending application"
+services = ["chainmail"]
 
 [profile.release]
 codegen-units = 1
@@ -20,14 +31,9 @@ debug = false
 strip = true
 lto = true
 
-[package.metadata.psibase]
-package-name = "Chainmail"
-description = "Basic email app"
-services = ["chainmail"]
-
 [lib]
 crate-type = ["rlib"]
 
 [dependencies]
-chainmail = { path = "service" }
-plugin = { path = "plugin" }
+chainmail = { path = "service", version = "0.12.0" }
+plugin = { path = "plugin", version = "0.12.0" }

--- a/services/user/Chainmail/Cargo.toml
+++ b/services/user/Chainmail/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 
 [package]
 name = "chainmail_package"
+description = "Message-sending application"
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
@@ -21,7 +22,6 @@ publish.workspace = true
 
 [package.metadata.psibase]
 package-name = "Chainmail"
-description = "Message-sending application"
 services = ["chainmail"]
 
 [profile.release]

--- a/services/user/Chainmail/plugin/Cargo.toml
+++ b/services/user/Chainmail/plugin/Cargo.toml
@@ -26,4 +26,4 @@ world = "impl"
 "transact:plugin" = { path = "../../../system/Transact/plugin/wit/world.wit" }
 
 [dev-dependencies]
-chainmail_package = { path = ".." }
+chainmail_package = { path = "..", version = "0.12.0" }

--- a/services/user/Chainmail/service/Cargo.toml
+++ b/services/user/Chainmail/service/Cargo.toml
@@ -10,9 +10,18 @@ publish = false
 [package.metadata.psibase]
 server = "chainmail"
 plugin = "plugin"
+data = [{ src = "../ui/dist/", dst = "/" }]
 postinstall = [
     { sender = "chainmail", service = "chainmail", method = "init", rawData = "0000" },
 ]
+
+[package.metadata.psibase.dependencies]
+Accounts = "0.12.0"
+CommonApi = "0.12.0"
+SetCode = "0.12.0"
+HttpServer = "0.12.0"
+Supervisor = "0.12.0"
+Events = "0.12.0"
 
 [dependencies]
 psibase = { path = "../../../../rust/psibase/" }
@@ -20,4 +29,4 @@ async-graphql = "7.0.7"
 serde = { version = "1.0.209", features = ["derive"] }
 
 [dev-dependencies]
-chainmail_package = { path = ".." }
+chainmail_package = { path = "..", version = "0.12.0" }

--- a/services/user/Chainmail/service/Cargo.toml
+++ b/services/user/Chainmail/service/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 [package.metadata.psibase]
 server = "chainmail"
 plugin = "plugin"
+postinstall = [
+    { sender = "chainmail", service = "chainmail", method = "init", rawData = "0000" },
+]
 
 [dependencies]
 psibase = { path = "../../../../rust/psibase/" }

--- a/services/user/Chainmail/service/src/lib.rs
+++ b/services/user/Chainmail/service/src/lib.rs
@@ -99,9 +99,10 @@ fn serve_rest_api(request: &HttpRequest) -> Option<HttpReply> {
 
 #[psibase::service]
 mod service {
-    use psibase::services::accounts::Wrapper as AccountsSvc;
     use psibase::*;
     use serde::{Deserialize, Serialize};
+    use services::accounts::Wrapper as AccountsSvc;
+    use services::events::Wrapper as EventsSvc;
 
     use crate::serve_rest_api;
 
@@ -125,11 +126,9 @@ mod service {
         );
         table.put(&InitRow {}).unwrap();
 
-        // TODO: Depends on #845
-        // use services::events::Wrapper as EventsSvc;
-        // EventsSvc::call().setSchema(&create_schema());
-        // EventsSvc::call().addIndex(DbId::HistoryEvent, SERVICE, MethodNumber::from("sent"), 0);
-        // EventsSvc::call().addIndex(DbId::HistoryEvent, SERVICE, MethodNumber::from("sent"), 1);
+        EventsSvc::call().setSchema(create_schema::<Wrapper>());
+        EventsSvc::call().addIndex(DbId::HistoryEvent, SERVICE, MethodNumber::from("sent"), 0);
+        EventsSvc::call().addIndex(DbId::HistoryEvent, SERVICE, MethodNumber::from("sent"), 1);
     }
 
     #[action]

--- a/services/user/Chainmail/service/src/lib.rs
+++ b/services/user/Chainmail/service/src/lib.rs
@@ -100,15 +100,37 @@ fn serve_rest_api(request: &HttpRequest) -> Option<HttpReply> {
 #[psibase::service]
 mod service {
     use psibase::services::accounts::Wrapper as AccountsSvc;
-    use psibase::{
-        anyhow, check, get_sender, get_service, serve_content, serve_simple_ui, store_content,
-        AccountNumber, HexBytes, HttpReply, HttpRequest, Table, WebContentRow,
-    };
+    use psibase::*;
+    use serde::{Deserialize, Serialize};
 
     use crate::serve_rest_api;
 
     #[table(record = "WebContentRow")]
     struct WebContentTable;
+
+    #[table(name = "InitTable", index = 1)]
+    #[derive(Serialize, Deserialize, ToSchema, Fracpack)]
+    struct InitRow {}
+    impl InitRow {
+        #[primary_key]
+        fn pk(&self) {}
+    }
+
+    #[action]
+    fn init() {
+        let table = InitTable::new();
+        check(
+            table.get_index_pk().get(&()).is_none(),
+            "Service already initialized",
+        );
+        table.put(&InitRow {}).unwrap();
+
+        // TODO: Depends on #845
+        // use services::events::Wrapper as EventsSvc;
+        // EventsSvc::call().setSchema(&create_schema());
+        // EventsSvc::call().addIndex(DbId::HistoryEvent, SERVICE, MethodNumber::from("sent"), 0);
+        // EventsSvc::call().addIndex(DbId::HistoryEvent, SERVICE, MethodNumber::from("sent"), 1);
+    }
 
     #[action]
     fn send(receiver: AccountNumber, subject: String, body: String) {


### PR DESCRIPTION
This PR ensures that the ChainMail app is deployed to the chain by default.

To accomplish this, the [new functionality](https://github.com/gofractally/psibase/pull/840) in `cargo-psibase` that allows for UI and postinstall scripts to be specified is leveraged in chainmail.

Also, this PR introduces a new CMake function `cargo_psibase_package` that allows psibase devs to tell CMake about packages that are built using `cargo-psibase package` rather than using the CMake `psibase_package` function. Therefore cargo-psibase-managed packages can be integrated into the regular build system just like the other packages.

