### PR TITLE
Avoid throwing in WASM builds even when exceptions are "enabled"

### DIFF
--- a/libraries/psio/include/psio/check.hpp
+++ b/libraries/psio/include/psio/check.hpp
@@ -17,7 +17,7 @@ namespace psio
    template <typename T>
    [[noreturn]] void abort_error(const T& msg)
    {
-#ifdef __cpp_exceptions
+#ifndef COMPILING_WASM
       throw std::runtime_error((std::string)error_to_str(msg));
 #else
       psibase::abortMessage(error_to_str(msg));

--- a/libraries/psio/include/psio/view.hpp
+++ b/libraries/psio/include/psio/view.hpp
@@ -221,7 +221,7 @@ namespace psio
          (void)unpack_numeric<false>(&offset, this->data, pos, 4);
          if (offset == 1)
          {
-#ifdef COMPILING_WASM
+#ifndef COMPILING_WASM
             throw std::bad_optional_access{};
 #else
             abort_error("bad optional access");
@@ -340,7 +340,7 @@ namespace psio
       }
       else
       {
-#ifdef COMPILING_WASM
+#ifndef COMPILING_WASM
          throw std::bad_variant_access{};
 #else
          abort_error("bad variant access");
@@ -358,7 +358,7 @@ namespace psio
       }
       else
       {
-#ifdef COMPILING_WASM
+#ifndef COMPILING_WASM
          throw std::bad_variant_access{};
 #else
          abort_error("bad variant access");
@@ -556,7 +556,7 @@ namespace psio
          }
          else
          {
-#ifdef COMPILING_WASM
+#ifndef COMPILING_WASM
             throw std::out_of_range("view<vector> our of range");
 #else
             abort_error("view<vector> our of range");
@@ -625,7 +625,7 @@ namespace psio
          }
          else
          {
-#ifdef COMPILING_WASM
+#ifndef COMPILING_WASM
             throw std::out_of_range("view<string> out of range");
 #else
             abort_error("view<string> out of range");

--- a/libraries/psio/include/psio/view.hpp
+++ b/libraries/psio/include/psio/view.hpp
@@ -221,7 +221,7 @@ namespace psio
          (void)unpack_numeric<false>(&offset, this->data, pos, 4);
          if (offset == 1)
          {
-#ifdef __cpp_exceptions
+#ifdef COMPILING_WASM
             throw std::bad_optional_access{};
 #else
             abort_error("bad optional access");
@@ -340,7 +340,7 @@ namespace psio
       }
       else
       {
-#ifdef __cpp_exceptions
+#ifdef COMPILING_WASM
          throw std::bad_variant_access{};
 #else
          abort_error("bad variant access");
@@ -358,7 +358,7 @@ namespace psio
       }
       else
       {
-#ifdef __cpp_exceptions
+#ifdef COMPILING_WASM
          throw std::bad_variant_access{};
 #else
          abort_error("bad variant access");
@@ -556,7 +556,7 @@ namespace psio
          }
          else
          {
-#ifdef __cpp_exceptions
+#ifdef COMPILING_WASM
             throw std::out_of_range("view<vector> our of range");
 #else
             abort_error("view<vector> our of range");
@@ -625,7 +625,7 @@ namespace psio
          }
          else
          {
-#ifdef __cpp_exceptions
+#ifdef COMPILING_WASM
             throw std::out_of_range("view<string> out of range");
 #else
             abort_error("view<string> out of range");


### PR DESCRIPTION
It's currently stubbed to abort and the message from a direct call to abortMessage is better.
It also violates the ODR when mixing translation units compiled with exceptions enabled/disabled.
