### PR TITLE
Allow SPAs with registered http server to serve rest endpoints

### DIFF
--- a/services/system/HttpServer/src/HttpServer.cpp
+++ b/services/system/HttpServer/src/HttpServer.cpp
@@ -220,19 +220,27 @@ namespace SystemService
       // TODO: use a view
       auto [sock, req] = psio::from_frac<std::tuple<std::int32_t, HttpRequest>>(act.rawData);
 
-      // First we check the `sites` server
-      auto server    = "sites"_a;
-      currentRequest = {.socket = sock, .owner = server};
-      auto result    = iface(server).serveSys(req, std::optional{sock});
-
-      // If not found, we check the registered server
-      if (!result && currentRequest)
+      // First we check the registered server
+      auto service    = getTargetService(req);
+      auto registered = getServer(service);
+      std::optional<HttpReply> result;
+      psibase::AccountNumber server;
+      if (!registered)
       {
-         auto service    = getTargetService(req);
-         auto registered = getServer(service);
-         if (registered)
+         // Check sites
+         server    = "sites"_a;
+         currentRequest = {.socket = sock, .owner = server};
+         result         = iface(server).serveSys(req, std::optional{sock});
+      } else {
+         // Check registered server, then sites if nothing found
+         server    = registered->server;
+         currentRequest = {.socket = sock, .owner = server};
+         result    = iface(server).serveSys(req, std::optional{sock});
+
+         // If not found, we check the `sites` server
+         if (!result && currentRequest)
          {
-            server         = registered->server;
+            server    = "sites"_a;
             currentRequest = {.socket = sock, .owner = server};
             result         = iface(server).serveSys(req, std::optional{sock});
          }


### PR DESCRIPTION
Shortcoming with the http server impl was discovered specifically when dealing with SPAs:

For example:
Chainmail is registered as an SPA, so any request that doesn't specify an extension (which would imply a request for a static asset e.g. `style.css`) it assumes is a client route and returns the root document. But that means that API requests like `/messages/sender=alice` are just returning the root document.

This PR reverses the order in which the servers are checked, checking the registered server first. Only check sites iff the registered server returns `None`.

