### PR TITLE
Supervisor: Handle multiple requests simultaneously

### DIFF
--- a/services/user/Chainmail/service/src/lib.rs
+++ b/services/user/Chainmail/service/src/lib.rs
@@ -185,6 +185,5 @@ mod service {
     #[allow(non_snake_case)]
     fn serveSys(request: HttpRequest) -> Option<HttpReply> {
         None.or_else(|| serve_rest_api(&request))
-            .or_else(|| serve_simple_ui::<Wrapper>(&request))
     }
 }

--- a/services/user/Chainmail/ui/src/components/mail-display.tsx
+++ b/services/user/Chainmail/ui/src/components/mail-display.tsx
@@ -7,6 +7,7 @@ import { format } from "date-fns";
 import { Archive, ArchiveRestore, Pin, Trash2 } from "lucide-react";
 import { replaceAll } from "@milkdown/utils";
 import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@shadcn/avatar";
 import { Button } from "@shadcn/button";
@@ -24,6 +25,7 @@ import {
 } from "@components";
 import { Message, useDraftMessages, useIncomingMessages } from "@hooks";
 import { getSupervisor } from "@lib/supervisor";
+import { wait } from "@lib/utils";
 
 export function MailDisplay({
     message,
@@ -85,6 +87,7 @@ const ActionBar = ({
     mailbox: Mailbox;
     message: Message;
 }) => {
+    const queryClient = useQueryClient();
     const { setSelectedMessageId: setInboxMessageId } = useIncomingMessages();
     const {
         selectedMessage: selectedDraftMessage,
@@ -111,6 +114,10 @@ const ActionBar = ({
         });
         setInboxMessageId("");
         toast.success("Your message has been archived");
+        await wait(3000);
+        queryClient.invalidateQueries({
+            queryKey: ["incoming"],
+        });
     };
 
     const onUnArchive = (itemId: string) => {

--- a/services/user/Chainmail/ui/src/lib/utils.ts
+++ b/services/user/Chainmail/ui/src/lib/utils.ts
@@ -25,3 +25,5 @@ export function debounce<T extends (...args: any[]) => any>(
     };
     return <T>(<any>callable);
 }
+
+export const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));

--- a/services/user/CommonApi/common/packages/common-lib/src/messaging/FunctionCallRequest.ts
+++ b/services/user/CommonApi/common/packages/common-lib/src/messaging/FunctionCallRequest.ts
@@ -1,3 +1,5 @@
+import type { UUID } from "crypto";
+
 import { FUNCTION_CALL_REQUEST } from "./index";
 
 export interface FunctionCallArgs {
@@ -53,6 +55,7 @@ export function toString(item: FunctionCallArgs): string {
 
 export interface FunctionCallRequest {
     type: typeof FUNCTION_CALL_REQUEST;
+    id: UUID;
     args: QualifiedFunctionCallArgs;
 }
 

--- a/services/user/CommonApi/common/packages/common-lib/src/messaging/FunctionCallResponse.ts
+++ b/services/user/CommonApi/common/packages/common-lib/src/messaging/FunctionCallResponse.ts
@@ -1,8 +1,11 @@
+import type { UUID } from "crypto";
+
 import { FUNCTION_CALL_RESPONSE } from "./index";
 import { FunctionCallArgs } from "./index";
 
 export interface FunctionCallResponse {
     type: typeof FUNCTION_CALL_RESPONSE;
+    id: UUID;
     call: FunctionCallArgs;
     result: any;
 }
@@ -14,11 +17,13 @@ export const isFunctionCallResponse = (
 };
 
 export const buildFunctionCallResponse = (
+    id: UUID,
     call: FunctionCallArgs,
     result: any,
 ): FunctionCallResponse => {
     return {
         type: FUNCTION_CALL_RESPONSE,
+        id,
         call,
         result,
     };

--- a/services/user/CommonApi/common/packages/common-lib/src/supervisor.ts
+++ b/services/user/CommonApi/common/packages/common-lib/src/supervisor.ts
@@ -1,4 +1,4 @@
-import { randomUUID, type UUID } from "crypto";
+import { type UUID } from "crypto";
 
 import { siblingUrl } from "./rpc";
 import {
@@ -179,7 +179,7 @@ export class Supervisor {
         };
 
         return new Promise((resolve, reject) => {
-            const requestId = randomUUID();
+            const requestId = window.crypto.randomUUID() as UUID;
             this.pendingRequests.push({
                 id: requestId,
                 call: args,

--- a/services/user/Supervisor/ui/src/appInterace.ts
+++ b/services/user/Supervisor/ui/src/appInterace.ts
@@ -1,3 +1,5 @@
+import type { UUID } from "crypto";
+
 import {
     QualifiedFunctionCallArgs,
     QualifiedPluginId,
@@ -10,5 +12,5 @@ export interface AppInterface {
         plugins: QualifiedPluginId[],
     ) => void;
 
-    entry: (callerOrigin: string, args: QualifiedFunctionCallArgs) => void;
+    entry: (callerOrigin: string, id: UUID, args: QualifiedFunctionCallArgs) => void;
 }

--- a/services/user/Supervisor/ui/src/main.ts
+++ b/services/user/Supervisor/ui/src/main.ts
@@ -35,7 +35,7 @@ const shouldHandleMessage = (message: MessageEvent) => {
 // When the supervisor is first loaded, all it does is register some handlers for
 //   calls from the parent window, and also tells the parent window that it's ready.
 addCallHandler(callHandlers, isFunctionCallRequest, (msg) =>
-    supervisor.entry(msg.origin, msg.data.args),
+    supervisor.entry(msg.origin, msg.data.id, msg.data.args),
 );
 addCallHandler(callHandlers, isPreLoadPluginsRequest, (msg) =>
     supervisor.preloadPlugins(msg.origin, msg.data.payload.plugins),

--- a/services/user/Supervisor/ui/src/supervisor.ts
+++ b/services/user/Supervisor/ui/src/supervisor.ts
@@ -1,3 +1,5 @@
+import type { UUID } from "crypto";
+
 import {
     QualifiedPluginId,
     QualifiedFunctionCallArgs,
@@ -139,10 +141,10 @@ export class Supervisor implements AppInterface {
         return Promise.all([pluginsReady, this.loadPlugins(dependencies)]);
     }
 
-    private replyToParent(call: FunctionCallArgs, result: any) {
+    private replyToParent(id: UUID, call: FunctionCallArgs, result: any) {
         assertTruthy(this.parentOrigination, "Unknown reply target");
         window.parent.postMessage(
-            buildFunctionCallResponse(call, result),
+            buildFunctionCallResponse(id, call, result),
             this.parentOrigination.origin,
         );
     }
@@ -266,6 +268,7 @@ export class Supervisor implements AppInterface {
     // This is an entrypoint for apps to call into plugins.
     async entry(
         callerOrigin: string,
+        id: UUID,
         args: QualifiedFunctionCallArgs,
     ): Promise<any> {
         try {
@@ -310,7 +313,7 @@ export class Supervisor implements AppInterface {
             assert(this.context.stack.isEmpty(), "Callstack should be empty");
 
             // Send plugin result to parent window
-            this.replyToParent(args, result);
+            this.replyToParent(id, args, result);
 
             this.context = undefined;
         } catch (e) {
@@ -319,11 +322,12 @@ export class Supervisor implements AppInterface {
                 // Since it is the final return value, it is no longer recoverable and is
                 //   converted to a PluginError to be handled by the client.
                 this.replyToParent(
+                    id,
                     args,
                     new PluginError(e.payload.producer, e.payload.message),
                 );
             } else {
-                this.replyToParent(args, e);
+                this.replyToParent(id, args, e);
             }
 
             this.context = undefined;


### PR DESCRIPTION
This implements a promise queue. Now supervisor can handle multiple requests simultaneously instead of just one.