### PR TITLE
Fix doc-examples build

### DIFF
--- a/libraries/psibase/sdk/toolchain.cmake
+++ b/libraries/psibase/sdk/toolchain.cmake
@@ -65,6 +65,7 @@ if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/../../wasi-sysroot)
 elseif(EXISTS ${CMAKE_CURRENT_LIST_DIR}/wasm/deps)
     # Build directory
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+    set(psibase_ROOT ${CMAKE_CURRENT_LIST_DIR})
     set(CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_LIST_DIR})
     # Make sure that the replacement libc can be found
     set(CMAKE_EXE_LINKER_FLAGS -L${CMAKE_CURRENT_LIST_DIR}/wasm/libraries/psibase)


### PR DESCRIPTION
`psibase-config.cmake` isn't found reliably. CMake takes a shotgun approach to finding xxx-config.cmake, so it *sometimes* works depending on the environment. Explicitly setting `psibase_ROOT` should make it reliable.