### PR TITLE
Supervisor: requestId fallback for non-secure contexts

### DIFF
--- a/services/user/CommonApi/common/packages/common-lib/src/messaging/FunctionCallRequest.ts
+++ b/services/user/CommonApi/common/packages/common-lib/src/messaging/FunctionCallRequest.ts
@@ -1,5 +1,3 @@
-import type { UUID } from "crypto";
-
 import { FUNCTION_CALL_REQUEST } from "./index";
 
 export interface FunctionCallArgs {
@@ -55,7 +53,7 @@ export function toString(item: FunctionCallArgs): string {
 
 export interface FunctionCallRequest {
     type: typeof FUNCTION_CALL_REQUEST;
-    id: UUID;
+    id: string;
     args: QualifiedFunctionCallArgs;
 }
 

--- a/services/user/CommonApi/common/packages/common-lib/src/messaging/FunctionCallResponse.ts
+++ b/services/user/CommonApi/common/packages/common-lib/src/messaging/FunctionCallResponse.ts
@@ -1,11 +1,9 @@
-import type { UUID } from "crypto";
-
 import { FUNCTION_CALL_RESPONSE } from "./index";
 import { FunctionCallArgs } from "./index";
 
 export interface FunctionCallResponse {
     type: typeof FUNCTION_CALL_RESPONSE;
-    id: UUID;
+    id: string;
     call: FunctionCallArgs;
     result: any;
 }
@@ -17,7 +15,7 @@ export const isFunctionCallResponse = (
 };
 
 export const buildFunctionCallResponse = (
-    id: UUID,
+    id: string,
     call: FunctionCallArgs,
     result: any,
 ): FunctionCallResponse => {

--- a/services/user/CommonApi/common/packages/common-lib/src/supervisor.ts
+++ b/services/user/CommonApi/common/packages/common-lib/src/supervisor.ts
@@ -1,5 +1,3 @@
-import { type UUID } from "crypto";
-
 import { siblingUrl } from "./rpc";
 import {
     QualifiedFunctionCallArgs,
@@ -50,13 +48,13 @@ export class Supervisor {
     private supervisorSrc: string;
 
     private pendingRequests: {
-        id: UUID;
+        id: string;
         call: FunctionCallArgs;
         resolve: (result: unknown) => void;
         reject: (result: unknown) => void;
     }[] = [];
 
-    private removePendingRequestById(id: UUID) {
+    private removePendingRequestById(id: string) {
         this.pendingRequests = this.pendingRequests.filter(
             (req) => req.id !== id,
         );
@@ -179,7 +177,8 @@ export class Supervisor {
         };
 
         return new Promise((resolve, reject) => {
-            const requestId = window.crypto.randomUUID() as UUID;
+            const requestId: string =
+                window.crypto.randomUUID?.() ?? Math.random().toString(); // if insecure context and randomUUID is unavailable, use Math.random
             this.pendingRequests.push({
                 id: requestId,
                 call: args,

--- a/services/user/Supervisor/ui/src/supervisor.ts
+++ b/services/user/Supervisor/ui/src/supervisor.ts
@@ -1,5 +1,3 @@
-import type { UUID } from "crypto";
-
 import {
     QualifiedPluginId,
     QualifiedFunctionCallArgs,
@@ -141,7 +139,7 @@ export class Supervisor implements AppInterface {
         return Promise.all([pluginsReady, this.loadPlugins(dependencies)]);
     }
 
-    private replyToParent(id: UUID, call: FunctionCallArgs, result: any) {
+    private replyToParent(id: string, call: FunctionCallArgs, result: any) {
         assertTruthy(this.parentOrigination, "Unknown reply target");
         window.parent.postMessage(
             buildFunctionCallResponse(id, call, result),
@@ -268,11 +266,11 @@ export class Supervisor implements AppInterface {
     // This is an entrypoint for apps to call into plugins.
     async entry(
         callerOrigin: string,
-        id: UUID,
+        id: string,
         args: QualifiedFunctionCallArgs,
     ): Promise<any> {
         try {
-            // Wait to load the full plugin tree (a plugin and all it's dependencies, recursively).
+            // Wait to load the full plugin tree (a plugin and all its dependencies, recursively).
             // This is the time-intensive step. It includes: downloading, parsing, generating import fills,
             //   transpiling the component, bundling with rollup, and importing & instantiating the es module
             //   in memory.


### PR DESCRIPTION
`window.crypto.randomUUID()` is not available in non-secure contexts (_i.e._, HTTP). While UUIDs are best for this, there's no harm falling back to `Math.random`, as this has little to do with security. This is implemented for the benefit of developers running test chains on HTTP.