### PR TITLE
Prevent TokenUsers from automatically deploying on dev chain boot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,7 +766,7 @@ psibase_package(
     DESCRIPTION "All development services"
     PACKAGE_DEPENDS Accounts AuthAny AuthSig AuthDelegate Chainmail ClientData CommonApi CpuLimit 
                     Docs Events Explorer Fractal Invite Nft Packages Producers HttpServer
-                    Sites SetCode Supervisor Symbol TokenUsers Tokens Transact Homepage
+                    Sites SetCode Supervisor Symbol Tokens Transact Homepage
 )
 
 psibase_package(


### PR DESCRIPTION
`alice` and `bob` accounts are created by default when booting the dev chain via the `TokenUsers` package. But they are not auth-any, as they previously were.

The auth system is still under heavy development. `getAvailableAccounts` still simply returns `alice` and `bob`, independent of whatever accounts actually exist on the chain.

Applications, such as Chain Mail, are also under development. They currently use those two accounts in auth-any mode.

Removing their default creation by `TokenUsers` (which creates them without auth-any) means that we can create those accounts manually after the chain boots so that Chain Mail can still use them while we continue building everything out.