### PR TITLE
update ci/cd builder image

### DIFF
--- a/.github/workflows/ubuntu-builder.yml
+++ b/.github/workflows/ubuntu-builder.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2004:15928717e8222c50eab8bc3c880ae51bc1bd8a1e"
+          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2004:7581315f13f1edaff283a2e6ef0cad74aebbd45d"
             ubuntu-version: "2004"
-          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2204:15928717e8222c50eab8bc3c880ae51bc1bd8a1e"
+          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2204:7581315f13f1edaff283a2e6ef0cad74aebbd45d"
             ubuntu-version: "2204"
-          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2404:15928717e8222c50eab8bc3c880ae51bc1bd8a1e"
+          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2404:7581315f13f1edaff283a2e6ef0cad74aebbd45d"
             ubuntu-version: "2404"
     steps:
       - name: Timestamp


### PR DESCRIPTION
Updates the builder image for ci/cd. Changes:
* https://github.com/gofractally/image-builders/pull/44
* https://github.com/gofractally/image-builders/pull/45