### PR TITLE
Fix unreliable test

### DIFF
--- a/programs/psinode/CMakeLists.txt
+++ b/programs/psinode/CMakeLists.txt
@@ -71,7 +71,7 @@ if(Python_Interpreter_FOUND)
         COMMAND ${Python_EXECUTABLE} test_query.py --psinode=$<TARGET_FILE:psinode>
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
     add_test(
-        NAME psinode_test_exeption_exit
+        NAME psinode_test_exception_exit
         COMMAND ${Python_EXECUTABLE} test_exception_exit.py --psinode=$<TARGET_FILE:psinode>
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
     add_test(

--- a/programs/psinode/tests/test_exception_exit.py
+++ b/programs/psinode/tests/test_exception_exit.py
@@ -26,7 +26,10 @@ class TestExceptionExit(unittest.TestCase):
 
         t = Thread(target=long_query, args=(a.new_api(),))
         t.start()
-        a.push_action('transact', 'setcode', 'setcode', {"service":"transact","vmType":0, "vmVersion":0, "code": "DEADBEEF"})
+        try:
+            a.push_action('transact', 'setcode', 'setcode', {"service":"transact","vmType":0, "vmVersion":0, "code": "DEADBEEF"})
+        except ConnectionError:
+            pass
         t.join()
 
         code = a.child.wait(timeout=10)


### PR DESCRIPTION
`push_transaction` might not return a response before the node shuts down.