### PR TITLE
Add auth-sig key import

### DIFF
--- a/services/system/AuthSig/include/services/system/AuthSig.hpp
+++ b/services/system/AuthSig/include/services/system/AuthSig.hpp
@@ -24,7 +24,7 @@ namespace SystemService
          /// The public key included in the claims for each transaction sent by this account.
          SubjectPublicKeyInfo pubkey;
 
-         auto byPubkey() const { return std::tuple{pubkey, account}; }
+         auto byPubkey() const { return std::tuple{keyFingerprint(pubkey), account}; }
       };
       PSIO_REFLECT(AuthRecord, account, pubkey)
 

--- a/services/system/AuthSig/plugin/src/lib.rs
+++ b/services/system/AuthSig/plugin/src/lib.rs
@@ -114,6 +114,12 @@ impl KeyVault for AuthSig {
             .map_err(|e| CryptoError(e.to_string()))?;
         Ok(signature.to_bytes().to_vec())
     }
+
+    fn import_key(private_key: Pem) -> Result<Pem, CommonTypes::Error> {
+        let public_key = AuthSig::pub_from_priv(private_key.clone())?;
+        ManagedKeys::add(&public_key, &AuthSig::to_der(private_key)?);
+        Ok(public_key)
+    }
 }
 
 impl Actions for AuthSig {

--- a/services/system/AuthSig/plugin/wit/world.wit
+++ b/services/system/AuthSig/plugin/wit/world.wit
@@ -36,6 +36,12 @@ interface keyvault {
 
     /// Signs a pre-hashed message with the specified DER-encoded private key
     sign: func(hashed-message: list<u8>, private-key: list<u8>) -> result<list<u8>, error>;
+
+    /// Imports a PEM-encoded private key into the keyvault.
+    /// This does not change the key of any account, it simply allows AuthSig to sign
+    ///   with the specified private key.
+    /// Returns the corresponding public key in PEM format.
+    import-key: func(private-key: pem) -> result<pem, error>;
 }
 
 interface actions {

--- a/services/system/AuthSig/src/RAuthSig.cpp
+++ b/services/system/AuthSig/src/RAuthSig.cpp
@@ -33,7 +33,7 @@ namespace SystemService
          {
             auto idx =
                 AuthSig::Tables{AuthSig::service}.open<AuthSig::AuthTable>().getIndex<1>().subindex(
-                    key);
+                    keyFingerprint(key));
 
             auto convert = [](const auto& opt)
             {
@@ -73,7 +73,7 @@ namespace SystemService
          return std::nullopt;
 
       }  // serveSys
-   }     // namespace AuthSig
+   }  // namespace AuthSig
 }  // namespace SystemService
 
 PSIBASE_DISPATCH(SystemService::AuthSig::RAuthSig)

--- a/services/system/AuthSig/src/RAuthSig.cpp
+++ b/services/system/AuthSig/src/RAuthSig.cpp
@@ -57,7 +57,7 @@ namespace SystemService
          }
       };
       PSIO_REFLECT(AuthQuery,
-                   method(accWithKey, key, gt, ge, lt, le, first, last, before, after),
+                   method(accWithKey, pubkeyPem, gt, ge, lt, le, first, last, before, after),
                    method(account, name)
                    //
       );

--- a/services/system/AuthSig/src/RAuthSig.cpp
+++ b/services/system/AuthSig/src/RAuthSig.cpp
@@ -21,7 +21,7 @@ namespace SystemService
    {
       struct AuthQuery
       {
-         auto accWithKey(SubjectPublicKeyInfo    key,
+         auto accWithKey(string                  pubkeyPem,
                          optional<AccountNumber> gt,
                          optional<AccountNumber> ge,
                          optional<AccountNumber> lt,
@@ -33,7 +33,7 @@ namespace SystemService
          {
             auto idx =
                 AuthSig::Tables{AuthSig::service}.open<AuthSig::AuthTable>().getIndex<1>().subindex(
-                    keyFingerprint(key));
+                    keyFingerprint(SubjectPublicKeyInfo{parseSubjectPublicKeyInfo(pubkeyPem)}));
 
             auto convert = [](const auto& opt)
             {


### PR DESCRIPTION
* Adds the capability to import external keypairs into auth-sig.
* Changes the secondary index for the key table in auth-sig to use the key fingerprint instead of the full public key. This is just to save space