### PR TITLE
Handle percent encoded URLs

### DIFF
--- a/libraries/psibase/CMakeLists.txt
+++ b/libraries/psibase/CMakeLists.txt
@@ -11,6 +11,7 @@ function(add suffix)
         common/src/crypto.cpp
         common/src/KvMerkle.cpp
         common/src/nativeTables.cpp
+        common/src/Rpc.cpp
         common/src/schema.cpp
         common/src/trace.cpp
     )

--- a/libraries/psibase/common/src/Rpc.cpp
+++ b/libraries/psibase/common/src/Rpc.cpp
@@ -1,0 +1,67 @@
+#include <psibase/Rpc.hpp>
+
+namespace
+{
+   template <typename Iter>
+   char read_pct(Iter& iter, Iter end)
+   {
+      auto read_digit = [&]
+      {
+         ++iter;
+         if (iter != end)
+         {
+            if (*iter >= '0' && *iter <= '9')
+               return *iter - '0';
+            else if (*iter >= 'a' && *iter <= 'f')
+               return *iter - 'a' + 10;
+            else if (*iter >= 'A' && *iter <= 'F')
+               return *iter - 'A' + 10;
+         }
+         psibase::abortMessage("Invalid pct-encoded");
+      };
+      auto upper = read_digit();
+      auto lower = read_digit();
+      return (upper << 4) | lower;
+   }
+
+   std::string decode_pct(std::string_view s)
+   {
+      std::string result;
+      for (auto iter = s.begin(), end = s.end(); iter != end; ++iter)
+      {
+         if (*iter == '%')
+            result += read_pct(iter, end);
+         else
+            result += *iter;
+      }
+      return result;
+   }
+}  // namespace
+
+namespace psibase
+{
+
+   std::pair<std::string, std::string> HttpRequest::readQueryItem(std::string_view& query)
+   {
+      auto end   = query.find('&');
+      auto split = query.substr(0, end).find('=');
+
+      auto key   = query.substr(0, split);
+      auto value = split > end ? std::string_view{} : query.substr(split + 1, end - split - 1);
+
+      if (end == std::string_view::npos)
+      {
+         query.remove_prefix(query.size());
+      }
+      else
+      {
+         query.remove_prefix(end + 1);
+      }
+      return {decode_pct(key), decode_pct(value)};
+   }
+
+   std::string HttpRequest::path() const
+   {
+      return decode_pct(std::string_view(target).substr(0, target.find('?')));
+   }
+}  // namespace psibase

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2514,6 +2514,7 @@ dependencies = [
  "custom_error",
  "der",
  "flate2",
+ "form_urlencoded",
  "fracpack",
  "futures",
  "getrandom",

--- a/rust/psibase/Cargo.toml
+++ b/rust/psibase/Cargo.toml
@@ -20,6 +20,7 @@ brotli = "7.0.0"
 chrono = "0.4"
 const_format = "0.2"
 custom_error = "1.9"
+form_urlencoded = "1.2.1"
 fracpack = { version = "0.13.0", path = "../fracpack" }
 flate2 = "1.0"
 futures = "0.3"

--- a/services/Cargo.lock
+++ b/services/Cargo.lock
@@ -1872,6 +1872,7 @@ dependencies = [
  "custom_error",
  "der",
  "flate2",
+ "form_urlencoded",
  "fracpack",
  "futures",
  "getrandom",

--- a/services/user/Branding/Cargo.lock
+++ b/services/user/Branding/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "custom_error",
  "der",
  "flate2",
+ "form_urlencoded",
  "fracpack",
  "futures",
  "getrandom",

--- a/services/user/Brotli/Cargo.lock
+++ b/services/user/Brotli/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
  "custom_error",
  "der",
  "flate2",
+ "form_urlencoded",
  "fracpack",
  "futures",
  "getrandom",

--- a/services/user/Chainmail/Cargo.lock
+++ b/services/user/Chainmail/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "custom_error",
  "der",
  "flate2",
+ "form_urlencoded",
  "fracpack",
  "futures",
  "getrandom",

--- a/services/user/Registry/Cargo.lock
+++ b/services/user/Registry/Cargo.lock
@@ -1568,6 +1568,7 @@ dependencies = [
  "custom_error",
  "der",
  "flate2",
+ "form_urlencoded",
  "fracpack",
  "futures",
  "getrandom",

--- a/services/user/Sites/src/Sites.cpp
+++ b/services/user/Sites/src/Sites.cpp
@@ -270,7 +270,7 @@ namespace SystemService
       if (request.method == "GET" || request.method == "HEAD")
       {
          Tables tables{};
-         auto   target = normalizeTarget(request.target);
+         auto   target = request.path();
 
          std::optional<SitesContentRow> content;
          auto                           isSpa = useSpa(account);


### PR DESCRIPTION
- Add utility functions to HttpRequest to decode the path and query
- Sites (the main service that is likely to need encoded URLs) uses request.path() to decode the path
- Chainmail and Packages use request.query() to parse the query.

Fixes #257