### PR TITLE
Use transact instead of /native/push_transaction

### DIFF
--- a/libraries/net/test/fuzz.cpp
+++ b/libraries/net/test/fuzz.cpp
@@ -200,7 +200,11 @@ namespace
                                    true);
          blockContext.start(TimePointSec{}, genesisProducer, 0, 0);
          blockContext.callStartBlock();
-         boot(&blockContext, *init);
+         for (auto&& trx : makeBoot(*init))
+         {
+            TransactionTrace trace;
+            blockContext.pushTransaction(std::move(trx), trace, std::nullopt);
+         }
          auto [revision, id] = blockContext.writeRevision(prover, claim);
          systemContext->sharedDatabase.setHead(*writer, revision);
          initialHead  = revision;

--- a/libraries/net/test/test_bft_consensus.cpp
+++ b/libraries/net/test/test_bft_consensus.cpp
@@ -149,7 +149,7 @@ TEST_CASE("bft latency", "[bft]")
    auto                    producers = makeAccounts({"a", "b", "c", "d"});
    nodes.add(producers);
    nodes.partition(NetworkPartition::all(), latency);
-   boot<BftConsensus>(nodes.getBlockContext(), producers);
+   boot<BftConsensus>(nodes[0], producers);
 
    runFor(ctx, 5min);
 
@@ -188,7 +188,7 @@ TEST_CASE("commit before prepare", "[bft]")
    auto                    producers = makeAccounts({"a", "b", "c", "d"});
    nodes.add(makeAccounts({"a", "e"}));
    nodes.partition(NetworkPartition::all());
-   boot<BftConsensus>(nodes.getBlockContext(), producers);
+   boot<BftConsensus>(nodes[0], producers);
    runFor(ctx, 1s);
 
    auto send = [&](auto&& message)

--- a/libraries/net/test/test_consensus.cpp
+++ b/libraries/net/test/test_consensus.cpp
@@ -158,7 +158,7 @@ TEST_CASE("joint consensus", "[combined]")
    NodeSet<node_type>      nodes(ctx);
    add_producers(nodes, start);
    nodes.connect_all();
-   boot(nodes.getBlockContext(), start);
+   boot(nodes[0], start);
    runFor(ctx, 15s);
 
    add_producers(nodes, change);
@@ -191,7 +191,7 @@ TEST_CASE("joint consensus crash", "[combined]")
    NodeSet<node_type>      nodes(ctx);
    add_producers(nodes, start);
    nodes.connect_all();
-   boot(nodes.getBlockContext(), start);
+   boot(nodes[0], start);
    runFor(ctx, 15s);
 
    timer_type    timer(ctx);
@@ -227,12 +227,14 @@ TEST_CASE("joint consensus crash", "[combined]")
 
 TEST_CASE("fork at commit consensus change", "[combined]")
 {
+   TEST_START(logger);
+
    boost::asio::io_context ctx;
    NodeSet<node_type>      nodes(ctx);
    auto                    producers = makeAccounts({"a", "b", "c", "d"});
    nodes.add(makeAccounts({"a", "h"}));
    nodes.partition(NetworkPartition::all());
-   boot<BftConsensus>(nodes.getBlockContext(), producers);
+   boot<BftConsensus>(nodes[0], producers);
    runFor(ctx, 1s);
 
    auto send = [&](auto&& message)

--- a/libraries/net/test/test_signatures.cpp
+++ b/libraries/net/test/test_signatures.cpp
@@ -23,7 +23,7 @@ TEST_CASE("block signature")
    prover->add(ecc);
    nodes.add(AccountNumber{"prod"}, prover);
    nodes.add(AccountNumber{"client"});
-   boot(nodes.getBlockContext(), ConsensusData{CftConsensus{{Producer{prod, ecc->get()}}}}, true);
+   boot(nodes[0], ConsensusData{CftConsensus{{Producer{prod, ecc->get()}}}}, true);
    runFor(ctx, 5s);
    nodes.connect_all();
    runFor(ctx, 1s);
@@ -48,8 +48,7 @@ TEST_CASE("load signature state")
       node_type               node{ctx, system.get(), prover};
       node.set_producer_id(prod);
       node.load_producers();
-      boot(node.chain().getBlockContext(),
-           ConsensusData{CftConsensus{{Producer{prod, prover->get()}}}}, true);
+      boot(node, ConsensusData{CftConsensus{{Producer{prod, prover->get()}}}}, true);
       runFor(ctx, 5s);
    }
    {

--- a/libraries/net/test/test_util.cpp
+++ b/libraries/net/test/test_util.cpp
@@ -75,37 +75,38 @@ std::vector<psibase::AccountNumber> makeAccounts(
    return result;
 }
 
-void boot(BlockContext* ctx, const ConsensusData& producers, bool ec)
+auto makeBoot(const ConsensusData& producers, bool ec) -> std::vector<SignedTransaction>
 {
-   std::vector<GenesisService> services = {{
-                                               .service = Transact::service,
-                                               .flags   = Transact::serviceFlags,
-                                               .code    = readWholeFile("Transact.wasm"),
+   std::vector<SignedTransaction> result;
+   std::vector<GenesisService>    services = {{
+                                                  .service = Transact::service,
+                                                  .flags   = Transact::serviceFlags,
+                                                  .code    = readWholeFile("Transact.wasm"),
                                            },
-                                           {
-                                               .service = RTransact::service,
-                                               .flags   = 0,
-                                               .code    = readWholeFile("RTransact.wasm"),
+                                              {
+                                                  .service = RTransact::service,
+                                                  .flags   = 0,
+                                                  .code    = readWholeFile("RTransact.wasm"),
                                            },
-                                           {
-                                               .service = CpuLimit::service,
-                                               .flags   = CpuLimit::serviceFlags,
-                                               .code    = readWholeFile("MockCpuLimit.wasm"),
+                                              {
+                                                  .service = CpuLimit::service,
+                                                  .flags   = CpuLimit::serviceFlags,
+                                                  .code    = readWholeFile("MockCpuLimit.wasm"),
                                            },
-                                           {
-                                               .service = Accounts::service,
-                                               .flags   = 0,
-                                               .code    = readWholeFile("Accounts.wasm"),
+                                              {
+                                                  .service = Accounts::service,
+                                                  .flags   = 0,
+                                                  .code    = readWholeFile("Accounts.wasm"),
                                            },
-                                           {
-                                               .service = Producers::service,
-                                               .flags   = Producers::serviceFlags,
-                                               .code    = readWholeFile("Producers.wasm"),
+                                              {
+                                                  .service = Producers::service,
+                                                  .flags   = Producers::serviceFlags,
+                                                  .code    = readWholeFile("Producers.wasm"),
                                            },
-                                           {
-                                               .service = AuthAny::service,
-                                               .flags   = 0,
-                                               .code    = readWholeFile("AuthAny.wasm"),
+                                              {
+                                                  .service = AuthAny::service,
+                                                  .flags   = 0,
+                                                  .code    = readWholeFile("AuthAny.wasm"),
                                            }};
    if (ec)
    {
@@ -116,34 +117,32 @@ void boot(BlockContext* ctx, const ConsensusData& producers, bool ec)
       });
    }
    // Transact + Producers + AuthAny + Accounts
-   pushTransaction(ctx,
-                   Transaction{                                                         //
-                               .actions = {                                             //
-                                           Action{.sender  = AccountNumber{"psibase"},  // ignored
-                                                  .service = AccountNumber{"psibase"},  // ignored
-                                                  .method  = MethodNumber{"boot"},
-                                                  .rawData = psio::convert_to_frac(
-                                                      GenesisActionData{.services = services})}}});
+   result.push_back({Transaction{
+       //
+       .actions = {
+           //
+           Action{.sender  = AccountNumber{"psibase"},  // ignored
+                  .service = AccountNumber{"psibase"},  // ignored
+                  .method  = MethodNumber{"boot"},
+                  .rawData = psio::convert_to_frac(GenesisActionData{.services = services})}}}});
 
-   pushTransaction(
-       ctx,
-       Transaction{
-           .tapos = {.expiration = std::chrono::time_point_cast<Seconds>(ctx->current.header.time) +
-                                   Seconds(1)},
-           .actions = {Action{.sender  = Transact::service,
-                              .service = Transact::service,
-                              .method  = MethodNumber{"startBoot"},
-                              .rawData = psio::to_frac(std::tuple(std::vector<Checksum256>()))},
-                       Action{.sender  = Accounts::service,
-                              .service = Accounts::service,
-                              .method  = MethodNumber{"init"},
-                              .rawData = psio::to_frac(std::tuple())},
-                       transactor<Producers>(Producers::service, Producers::service)
-                           .setConsensus(producers),
-                       Action{.sender  = Transact::service,
-                              .service = Transact::service,
-                              .method  = MethodNumber{"finishBoot"},
-                              .rawData = psio::to_frac(std::tuple())}}});
+   result.push_back({Transaction{
+       .tapos   = {.expiration = TimePointSec{Seconds(2)}},
+       .actions = {
+           Action{.sender  = Transact::service,
+                  .service = Transact::service,
+                  .method  = MethodNumber{"startBoot"},
+                  .rawData = psio::to_frac(std::tuple(std::vector<Checksum256>()))},
+           Action{.sender  = Accounts::service,
+                  .service = Accounts::service,
+                  .method  = MethodNumber{"init"},
+                  .rawData = psio::to_frac(std::tuple())},
+           transactor<Producers>(Producers::service, Producers::service).setConsensus(producers),
+           Action{.sender  = Transact::service,
+                  .service = Transact::service,
+                  .method  = MethodNumber{"finishBoot"},
+                  .rawData = psio::to_frac(std::tuple())}}}});
+   return result;
 }
 
 static Tapos getTapos(const BlockInfo& info)

--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -588,73 +588,6 @@ struct transaction_queue
 #define CATCH_IGNORE \
    catch (...) {}
 
-bool push_boot(BlockContext& bc, transaction_queue::entry& entry)
-{
-   bool result = false;
-   try
-   {
-      // TODO: verify no extra data
-      // TODO: view
-      auto transactions = psio::from_frac<std::vector<SignedTransaction>>(entry.packed_signed_trx);
-      TransactionTrace trace;
-
-      try
-      {
-         if (!bc.needGenesisAction)
-         {
-            trace.error = "chain is already booted";
-         }
-         else
-         {
-            for (auto& trx : transactions)
-            {
-               if (!trx.proofs.empty())
-                  // Proofs execute as of the state at the beginning of a block.
-                  // That state is empty, so there are no proof services installed.
-                  trace.error = "Transactions in boot block may not have proofs";
-               else
-                  bc.pushTransaction(std::move(trx), trace, std::nullopt);
-            }
-         }
-         result = true;
-      }
-      RETHROW_BAD_ALLOC
-      catch (...)
-      {
-         // Don't give a false positive
-         if (!trace.error)
-            throw;
-      }
-
-      try
-      {
-         entry.boot_callback(std::move(trace));
-      }
-      RETHROW_BAD_ALLOC
-      CATCH_IGNORE
-   }
-   RETHROW_BAD_ALLOC
-   catch (std::exception& e)
-   {
-      try
-      {
-         entry.boot_callback(e.what());
-      }
-      RETHROW_BAD_ALLOC
-      CATCH_IGNORE
-   }
-   catch (...)
-   {
-      try
-      {
-         entry.boot_callback("unknown error");
-      }
-      RETHROW_BAD_ALLOC
-      CATCH_IGNORE
-   }
-   return result;
-}  // push_boot
-
 template <typename Timer, typename F>
 void loop(Timer& timer, F&& f)
 {
@@ -1724,18 +1657,28 @@ void run(const std::string&              db_path,
       http_config->admin_authz = admin_authz;
 
       // TODO: speculative execution on non-producers
-      http_config->push_boot_async = [queue, &transactionStats, &transactionStatsMutex](
-                                         std::vector<char>               packed_signed_transactions,
-                                         http::push_transaction_callback callback)
+      http_config->push_boot_async =
+          [&chainContext, &node](std::vector<char>               packed_signed_transactions,
+                                 http::push_transaction_callback callback)
       {
-         {
-            std::lock_guard l{transactionStatsMutex};
-            ++transactionStats.total;
-            ++transactionStats.unprocessed;
-         }
-         std::scoped_lock lock{queue->mutex};
-         queue->entries.push_back(
-             {true, std::move(packed_signed_transactions), std::move(callback), {}});
+         boost::asio::post(chainContext,
+                           [&node, callback = std::move(callback),
+                            transactions = psio::from_frac<std::vector<SignedTransaction>>(
+                                packed_signed_transactions)] mutable
+                           {
+                              TransactionTrace trace;
+                              try
+                              {
+                                 node.push_boot(std::move(transactions), trace);
+                              }
+                              RETHROW_BAD_ALLOC
+                              catch (std::exception& e)
+                              {
+                                 callback(e.what());
+                                 return;
+                              }
+                              callback(std::move(trace));
+                           });
       };
 
       http_config->push_transaction_async =
@@ -2324,37 +2267,15 @@ void run(const std::string&              db_path,
       else if (auto bc = node.chain().getBlockContext())
       {
          std::vector<transaction_queue::entry> entries;
-         if (bc->needGenesisAction)
-         {
-            // Only process up to the genesis transaction
-            std::scoped_lock lock{queue->mutex};
-            auto             pos = std::ranges::find_if(queue->entries,
-                                                        [](const auto& entry) { return entry.is_boot; });
-            if (pos != queue->entries.end())
-               ++pos;
-            std::ranges::move(queue->entries.begin(), pos, std::back_inserter(entries));
-            queue->entries.erase(queue->entries.begin(), pos);
-         }
-         else if (bc->current.header.previous != Checksum256{})
          {
             std::scoped_lock lock{queue->mutex};
             std::swap(entries, queue->entries);
          }
-         else
-         {
-            // The genesis transaction has already been executed, but we're still
-            // building the genesis block. Wait for the next block before pushing
-            // any transactions.
-         }
          auto revisionAtBlockStart = node.chain().getHeadRevision();
          for (auto& entry : entries)
          {
-            bool res;
-            if (entry.is_boot)
-               res = push_boot(*bc, entry);
-            else
-               res = pushTransaction(*sharedState, revisionAtBlockStart, *bc, *proofSystem, entry,
-                                     std::chrono::microseconds(leeway_us));
+            bool res = pushTransaction(*sharedState, revisionAtBlockStart, *bc, *proofSystem, entry,
+                                       std::chrono::microseconds(leeway_us));
             {
                std::lock_guard lock{transactionStatsMutex};
                --transactionStats.unprocessed;

--- a/services/system/Transact/include/services/system/RTransact.hpp
+++ b/services/system/Transact/include/services/system/RTransact.hpp
@@ -70,12 +70,19 @@ namespace SystemService
    using ReversibleBlocksTable =
        psibase::Table<ReversibleBlocksRow, &ReversibleBlocksRow::blockNum>;
 
+   struct TraceClientInfo
+   {
+      std::int32_t socket;
+      bool         json = true;
+      PSIO_REFLECT(TraceClientInfo, socket, json)
+   };
+
    struct TraceClientRow
    {
-      psibase::Checksum256      id;
-      std::vector<std::int32_t> sockets;
+      psibase::Checksum256         id;
+      std::vector<TraceClientInfo> clients;
    };
-   PSIO_REFLECT(TraceClientRow, id, sockets)
+   PSIO_REFLECT(TraceClientRow, id, clients)
 
    using TraceClientTable = psibase::Table<TraceClientRow, &TraceClientRow::id>;
 

--- a/services/system/Transact/include/services/system/Transact.hpp
+++ b/services/system/Transact/include/services/system/Transact.hpp
@@ -262,8 +262,10 @@ namespace SystemService
       ///
       /// Subjective callbacks are run by native and must have no sender.
       ///
-      /// TODO: Generalize implementation. Currently the only supported
-      /// combinations are objective+transaction and subjective+block.
+      /// Callbacks are unique. `addCallback` will have no effect if an
+      /// identical callback is already registered.
+      ///
+      /// The order in which callbacks are executed is unspecified.
       void addCallback(CallbackType type, bool objective, psibase::Action act);
       /// Removes an existing callback
       void removeCallback(CallbackType type, bool objective, psibase::Action act);

--- a/services/system/Transact/src/RTransact.cpp
+++ b/services/system/Transact/src/RTransact.cpp
@@ -313,7 +313,10 @@ namespace
       AcceptParser parser;
       for (const auto& header : headers)
       {
-         parseHeader(header.value, parser);
+         if (header.name == "accept")
+         {
+            parseHeader(header.value, parser);
+         }
       }
       return parser.isJson();
    }

--- a/services/system/Transact/src/RTransact.cpp
+++ b/services/system/Transact/src/RTransact.cpp
@@ -189,7 +189,7 @@ namespace
       if (low == std::string::npos)
          return {};
       else
-         return s.substr(low, high + 1);
+         return s.substr(low, high - low + 1);
    }
 
    template <typename F>
@@ -253,7 +253,7 @@ namespace
          int  specificness = -1;
          bool json         = false;
          bool bin          = false;
-         for (auto&& part : value | std::views::split(','))
+         for (auto&& part : value | std::views::split(';'))
          {
             auto param = trim(std::string_view(part.begin(), part.end()));
             if (first)

--- a/services/system/Transact/src/RTransact.cpp
+++ b/services/system/Transact/src/RTransact.cpp
@@ -45,19 +45,43 @@ void RTransact::onTrx(const Checksum256& id, const TransactionTrace& trace)
    check(getSender() == AccountNumber{}, "Wrong sender");
    auto                          clients = Subjective{}.open<TraceClientTable>();
    std::optional<TraceClientRow> row;
+   bool                          json;
+   bool                          bin;
    PSIBASE_SUBJECTIVE_TX
    {
-      row = clients.get(id);
+      json = false;
+      bin  = false;
+      row  = clients.get(id);
       if (row)
+      {
          clients.remove(*row);
+         for (auto client : row->clients)
+         {
+            if (client.json)
+               json = true;
+            else
+               bin = true;
+            to<HttpServer>().claimReply(client.socket);
+         }
+      }
    }
-   if (row)
+   if (json)
    {
       HttpReply           reply{.contentType = "application/json"};
       psio::vector_stream stream{reply.body};
       to_json(trace, stream);
-      for (std::int32_t sock : row->sockets)
-         to<HttpServer>().sendReply(sock, reply);
+      for (auto client : row->clients)
+         if (client.json)
+            to<HttpServer>().sendReply(client.socket, reply);
+   }
+   if (bin)
+   {
+      HttpReply           reply{.contentType = "application/octet-stream"};
+      psio::vector_stream stream{reply.body};
+      to_frac(trace, stream);
+      for (auto client : row->clients)
+         if (!client.json)
+            to<HttpServer>().sendReply(client.socket, reply);
    }
 }
 
@@ -104,14 +128,21 @@ void RTransact::onBlock()
    // Send responses to everyone waiting for a transaction that expired
    if (!ids.empty())
    {
-      TransactionTrace    trace{.error = "Transaction expired"};
-      HttpReply           reply{.contentType = "application/json"};
-      psio::vector_stream stream{reply.body};
-      to_json(trace, stream);
+      TransactionTrace trace{.error = "Transaction expired"};
+      HttpReply        json{.contentType = "application/json"};
+      {
+         psio::vector_stream stream{json.body};
+         to_json(trace, stream);
+      }
+      HttpReply bin{.contentType = "application/octet-stream"};
+      {
+         psio::vector_stream stream{bin.body};
+         to_frac(trace, stream);
+      }
       for (auto row : ids)
       {
-         for (auto sock : row.sockets)
-            to<HttpServer>().sendReply(sock, reply);
+         for (auto client : row.clients)
+            to<HttpServer>().sendReply(client.socket, client.json ? json : bin);
       }
    }
 }
@@ -148,6 +179,145 @@ namespace
       to<HttpServer>().sendProds(
           transactor<RTransact>(HttpServer::service, RTransact::service).recv(trx));
    }
+
+   constexpr auto ws = " \t";  // (SP / HTAB)
+
+   std::string_view trim(std::string_view s)
+   {
+      auto low  = s.find_first_not_of(ws);
+      auto high = s.find_last_not_of(ws);
+      if (low == std::string::npos)
+         return {};
+      else
+         return s.substr(low, high + 1);
+   }
+
+   template <typename F>
+   void parseHeader(std::string_view value, F&& f)
+   {
+      for (auto&& part : value | std::views::split(','))
+      {
+         f(trim(std::string_view(part.begin(), part.end())));
+      }
+   }
+
+   std::optional<int> parseQ(std::string_view param)
+   {
+      if (param.starts_with("q="))
+      {
+         int q;
+         param.remove_prefix(2);
+         if (param.starts_with('0'))
+            q = 0;
+         else if (param.starts_with('1'))
+            q = 1000;
+         else
+            return {};
+         if (param.size() > 1)
+         {
+            if (param[1] != '.')
+               return {};
+            param.remove_prefix(2);
+            if (param.size() > 3)
+               return {};
+            for (std::size_t i = 0; i < 3; ++i)
+            {
+               int digit = 0;
+               if (i < param.size())
+               {
+                  auto ch = param[i];
+                  if (ch < '0' || ch > '9')
+                     return {};
+                  digit = ch - '0';
+               }
+               q = q * 10 + digit;
+            }
+            if (q > 1000)
+               return {};
+         }
+         return q;
+      }
+      return {};
+   }
+
+   struct AcceptParser
+   {
+      int  bestJson = -1;
+      int  bestBin  = -1;
+      int  jsonQ    = 0;
+      int  binQ     = 0;
+      void operator()(std::string_view value)
+      {
+         bool first        = true;
+         int  q            = 1000;
+         int  specificness = -1;
+         bool json         = false;
+         bool bin          = false;
+         for (auto&& part : value | std::views::split(','))
+         {
+            auto param = trim(std::string_view(part.begin(), part.end()));
+            if (first)
+            {
+               first = false;
+               if (param == "application/json")
+               {
+                  json         = true;
+                  specificness = 2;
+               }
+               else if (param == "application/octet-stream")
+               {
+                  bin          = true;
+                  specificness = 2;
+               }
+               else if (param == "application/*")
+               {
+                  json         = true;
+                  bin          = true;
+                  specificness = 1;
+               }
+               else if (param == "*/*")
+               {
+                  json         = true;
+                  bin          = true;
+                  specificness = 0;
+               }
+               else
+               {
+                  return;
+               }
+            }
+            else
+            {
+               if (auto newQ = parseQ(param))
+               {
+                  q = *newQ;
+               }
+            }
+         }
+         if (json && specificness > bestJson)
+         {
+            bestJson = specificness;
+            jsonQ    = q;
+         }
+         if (bin && specificness > bestBin)
+         {
+            bestBin = specificness;
+            binQ    = q;
+         }
+      }
+      bool isJson() { return jsonQ >= binQ; }
+   };
+
+   bool acceptJson(const auto& headers)
+   {
+      AcceptParser parser;
+      for (const auto& header : headers)
+      {
+         parseHeader(header.value, parser);
+      }
+      return parser.isJson();
+   }
+
 }  // namespace
 
 void RTransact::recv(const SignedTransaction& trx)
@@ -167,13 +337,14 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest& request
    {
       if (request.contentType != "application/octet-stream")
          abortMessage("Expected fracpack encoded signed transaction (application/octet-stream)");
-      auto trx = psio::from_frac<SignedTransaction>(request.body);
-      auto id  = psibase::sha256(trx.transaction.data(), trx.transaction.size());
+      auto trx  = psio::from_frac<SignedTransaction>(request.body);
+      auto id   = psibase::sha256(trx.transaction.data(), trx.transaction.size());
+      bool json = acceptJson(request.headers);
       PSIBASE_SUBJECTIVE_TX
       {
          auto clients = Subjective{}.open<TraceClientTable>();
          auto row     = clients.get(id).value_or(TraceClientRow{.id = id});
-         row.sockets.push_back(*socket);
+         row.clients.push_back({*socket, json});
          clients.put(row);
          to<HttpServer>().deferReply(*socket);
       }

--- a/services/system/Transact/src/Transact.cpp
+++ b/services/system/Transact/src/Transact.cpp
@@ -176,8 +176,11 @@ namespace SystemService
          {
             value = Callbacks{.type = type};
          }
-         value->actions.push_back(std::move(act));
-         table.put(*value);
+         if (!std::ranges::contains(value->actions, act))
+         {
+            value->actions.push_back(std::move(act));
+            table.put(*value);
+         }
       }
       else
       {
@@ -189,8 +192,11 @@ namespace SystemService
          {
             value = NotifyRow{.type = ntype};
          }
-         value->actions.push_back(std::move(act));
-         kvPut(NotifyRow::db, key, *value);
+         if (!std::ranges::contains(value->actions, act))
+         {
+            value->actions.push_back(std::move(act));
+            kvPut(NotifyRow::db, key, *value);
+         }
       }
    }
 


### PR DESCRIPTION
- `push_transaction` can return a packed trace (`application/octet-stream`) instead of JSON to avoid exceeding the service memory limit.
