### PR TITLE
Auth sig support staged tx

### DIFF
--- a/libraries/psibase/tester/src/DefaultTestChain.cpp
+++ b/libraries/psibase/tester/src/DefaultTestChain.cpp
@@ -175,7 +175,7 @@ std::vector<std::string> DefaultTestChain::defaultPackages()
 {
    return {"Accounts", "AuthAny", "AuthDelegate", "AuthSig", "CommonApi", "CpuLimit",  "Events",
            "Explorer", "Fractal", "Invite",       "Nft",     "Packages",  "Producers", "HttpServer",
-           "Sites",    "SetCode", "Symbol",       "Tokens",  "Transact"};
+           "Sites",    "SetCode", "StagedTx",     "Symbol",  "Tokens",    "Transact"};
 }
 
 DefaultTestChain::DefaultTestChain() : TestChain(defaultChainInstance(), true)

--- a/services/system/AuthSig/CMakeLists.txt
+++ b/services/system/AuthSig/CMakeLists.txt
@@ -20,4 +20,6 @@ function(add suffix)
 
 endfunction(add)
 
+add_subdirectory(test)
+
 conditional_add()

--- a/services/system/AuthSig/include/services/system/AuthSig.hpp
+++ b/services/system/AuthSig/include/services/system/AuthSig.hpp
@@ -70,13 +70,27 @@ namespace SystemService
          /// submits a transaction.
          void setKey(SubjectPublicKeyInfo key);
 
+         /// Handle notification related to the acceptance of a staged transaction
+         ///
+         /// Auth-sig will execute the staged transaction if the sender of the call to `accept`
+         /// is the same as the sender of the staged transaction.
+         void stagedAccept(uint32_t staged_tx_id, psibase::AccountNumber actor);
+
+         /// Handle notification related to the rejection of a staged transaction
+         ///
+         /// Auth-sig will reject the staged transaction if the sender of the call to `reject` is
+         /// the same as the sender of the staged transaction.
+         void stagedReject(uint32_t staged_tx_id, psibase::AccountNumber actor);
+
         private:
          Tables db{psibase::getReceiver()};
       };
       PSIO_REFLECT(AuthSig,  //
                    method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),
                    method(canAuthUserSys, user),
-                   method(setKey, key)
+                   method(setKey, key),
+                   method(stagedAccept, staged_tx_id, actor),
+                   method(stagedReject, staged_tx_id, actor)
                    //
       )
    }  // namespace AuthSig

--- a/services/system/AuthSig/test/CMakeLists.txt
+++ b/services/system/AuthSig/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_system_test(AuthSig src/AuthSig-test.cpp)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)

--- a/services/system/AuthSig/test/src/AuthSig-test.cpp
+++ b/services/system/AuthSig/test/src/AuthSig-test.cpp
@@ -86,23 +86,6 @@ size_t getNrNfts(DefaultTestChain& chain, AccountNumber user)
    return response_root.data.userNfts.edges.size();
 }
 
-// Checksum256 calc_txid(DefaultTestChain& chain, uint32_t id, std::vector<Action> actions)
-// {
-//    // auto query =
-//    //     GraphQLBody{"query GetStagedTx { getStagedTx(id: " + std::to_string(id) + ") { id, proposeBlock, txid } }"};
-
-//    auto query = GraphQLBody{
-//        "query GetAllStaged { getAllStaged { edges { node { id, txid, proposeBlock, "
-//        "proposer } } } }"};
-
-//    auto res  = chain.post(StagedTxService::service, "/graphql", query);
-//    auto body = std::string(res.body.begin(), res.body.end());
-//    psibase::writeConsole(body);
-//    psibase::writeConsole("\n");
-
-//    return {};
-// }
-
 // Tx can be staged on behalf of an account using auth-sig
 // Tx is executed once the staged tx sender accepts it
 // Tx is deleted without execution once tx sender rejects it

--- a/services/system/AuthSig/test/src/AuthSig-test.cpp
+++ b/services/system/AuthSig/test/src/AuthSig-test.cpp
@@ -1,0 +1,164 @@
+#define CATCH_CONFIG_MAIN
+
+#include <psibase/DefaultTestChain.hpp>
+#include <services/system/Accounts.hpp>
+#include <services/system/AuthAny.hpp>
+#include <services/system/AuthSig.hpp>
+#include <services/system/PrivateKeyInfo.hpp>
+#include <services/system/Spki.hpp>
+#include <services/system/StagedTx.hpp>
+#include <services/system/VerifySig.hpp>
+#include <services/user/Nft.hpp>
+
+using namespace SystemService;
+using namespace UserService;
+using namespace psibase;
+
+namespace
+{
+   auto pubFromPem = [](std::string param) {  //
+      return AuthSig::SubjectPublicKeyInfo{AuthSig::parseSubjectPublicKeyInfo(param)};
+   };
+
+   auto privFromPem = [](std::string param) {  //
+      return AuthSig::PrivateKeyInfo{AuthSig::parsePrivateKeyInfo(param)};
+   };
+
+   auto pub = pubFromPem(
+       "-----BEGIN PUBLIC KEY-----\n"
+       "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWdALpn+cGuD1klsSRXTdapYlG5mu\n"
+       "WgoALofZYufL838GRUo43UuoGzxu/mW5T6r9Ix4/qc4gH2B+Zc6VYw/pKQ==\n"
+       "-----END PUBLIC KEY-----\n");
+   auto priv = privFromPem(
+       "-----BEGIN PRIVATE KEY-----\n"
+       "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg9h35bFuOZyB8i+GT\n"
+       "HEfwKktshavRCyzHq3X55sdfgs6hRANCAARZ0Aumf5wa4PWSWxJFdN1qliUbma5a\n"
+       "CgAuh9li58vzfwZFSjjdS6gbPG7+ZblPqv0jHj+pziAfYH5lzpVjD+kp\n"
+       "-----END PRIVATE KEY-----\n");
+
+   //{"data": {"userNfts":{"edges":[{"node":{"id":2,"issuer":"alice","owner":"alice"}}]}}}
+   struct Node
+   {
+      uint32_t      id;
+      AccountNumber issuer;
+      AccountNumber owner;
+   };
+   PSIO_REFLECT(Node, id, issuer, owner);
+
+   struct Edge
+   {
+      Node node;
+   };
+   PSIO_REFLECT(Edge, node);
+
+   struct UserNfts
+   {
+      std::vector<Edge> edges;
+   };
+   PSIO_REFLECT(UserNfts, edges);
+
+   struct Data
+   {
+      UserNfts userNfts;
+   };
+   PSIO_REFLECT(Data, userNfts);
+
+   struct QueryRoot
+   {
+      Data data;
+   };
+   PSIO_REFLECT(QueryRoot, data);
+
+}  // namespace
+
+size_t getNrNfts(DefaultTestChain& chain, AccountNumber user)
+{
+   auto query = GraphQLBody{
+       "query UserNfts { userNfts( user: \"alice\" ) { edges { node { id issuer owner } } } }"};
+
+   auto res = chain.post(Nft::service, "/graphql", query);
+
+   auto body          = std::string(res.body.begin(), res.body.end());
+   auto response_root = psio::convert_from_json<QueryRoot>(body);
+
+   //psibase::writeConsole(psio::format_json(response_root));
+
+   return response_root.data.userNfts.edges.size();
+}
+
+// Checksum256 calc_txid(DefaultTestChain& chain, uint32_t id, std::vector<Action> actions)
+// {
+//    // auto query =
+//    //     GraphQLBody{"query GetStagedTx { getStagedTx(id: " + std::to_string(id) + ") { id, proposeBlock, txid } }"};
+
+//    auto query = GraphQLBody{
+//        "query GetAllStaged { getAllStaged { edges { node { id, txid, proposeBlock, "
+//        "proposer } } } }"};
+
+//    auto res  = chain.post(StagedTxService::service, "/graphql", query);
+//    auto body = std::string(res.body.begin(), res.body.end());
+//    psibase::writeConsole(body);
+//    psibase::writeConsole("\n");
+
+//    return {};
+// }
+
+// Tx can be staged on behalf of an account using auth-sig
+// Tx is executed once the staged tx sender accepts it
+// Tx is deleted without execution once tx sender rejects it
+SCENARIO("AuthSig")
+{
+   GIVEN("Regular chain")
+   {
+      DefaultTestChain t;
+
+      KeyList keys  = {{pub, priv}};
+      auto    alice = t.from(t.addAccount("alice"_a)).with(keys);
+      t.setAuth<AuthSig::AuthSig>(alice.id, pub);
+      auto bob = t.from(t.addAccount("bob"_a));
+
+      auto mintAction = Action{.sender  = alice.id,
+                               .service = Nft::service,
+                               .method  = "mint"_m,
+                               .rawData = psio::to_frac(std::tuple())
+
+      };
+      auto proposed   = std::vector<Action>{mintAction};
+
+      THEN("Alice has not minted any NFTs")
+      {
+         CHECK(getNrNfts(t, alice.id) == 0);
+      }
+      THEN("Alice can self-stage a tx, which auto-executes")
+      {
+         auto propose = alice.to<StagedTxService>().propose(proposed);
+         REQUIRE(propose.succeeded());
+         REQUIRE(getNrNfts(t, alice.id) == 1);
+      }
+      THEN("Bob can stage a tx for alice, which does not auto-execute")
+      {
+         auto propose = bob.to<StagedTxService>().propose(proposed);
+         REQUIRE(propose.succeeded());
+         REQUIRE(getNrNfts(t, alice.id) == 0);
+      }
+      WHEN("Bob stages a tx for alice")
+      {
+         auto id   = bob.to<StagedTxService>().propose(proposed).returnVal();
+         auto txid = bob.to<StagedTxService>().get_staged_tx(id).returnVal().txid;
+
+         THEN("Alice can accept it, executing it")
+         {
+            auto accept = alice.to<StagedTxService>().accept(id, txid);
+            REQUIRE(accept.succeeded());
+            REQUIRE(getNrNfts(t, alice.id) == 1);
+         }
+         THEN("Alice can reject it, deleting it")
+         {
+            auto reject = alice.to<StagedTxService>().reject(id, txid);
+            REQUIRE(reject.succeeded());
+            REQUIRE(getNrNfts(t, alice.id) == 0);
+            REQUIRE(alice.to<StagedTxService>().get_staged_tx(id).failed("Unknown staged tx"));
+         }
+      }
+   }
+}

--- a/services/system/CMakeLists.txt
+++ b/services/system/CMakeLists.txt
@@ -5,6 +5,34 @@ function(add_system_service suffix name)
     set_target_properties(${name}${suffix} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
 endfunction()
 
+function(add_system_test_impl suffix name)
+    set(TARGET ${name}-test${suffix})
+    add_executable(${TARGET} ${ARGN})
+    target_include_directories(${TARGET} PUBLIC
+      ../include
+     ${CMAKE_CURRENT_LIST_DIR})
+    target_link_libraries(${TARGET} services_system${suffix} psitestlib${suffix})
+    set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
+endfunction()
+
+function(add_system_test_release name)
+    if(BUILD_RELEASE_WASM)
+        add_system_test_impl("" ${name} ${ARGN})
+        add_wasm_test(${name}-test)
+    endif()
+endfunction()
+
+function(add_system_test_debug name)
+    if(BUILD_DEBUG_WASM)
+        add_system_test_impl("-debug" ${name} ${ARGN})
+    endif()
+endfunction()
+
+function(add_system_test name)
+    add_system_test_release(${name} ${ARGN})
+    add_system_test_debug(${name} ${ARGN})
+endfunction()
+
 function(add suffix)
     add_library(services_system${suffix} INTERFACE)
     target_mapped_include_directories(services_system${suffix} INTERFACE

--- a/services/system/StagedTx/service/cpp/include/services/system/StagedTx.hpp
+++ b/services/system/StagedTx/service/cpp/include/services/system/StagedTx.hpp
@@ -15,11 +15,12 @@ namespace SystemService
    {
       uint32_t               id;
       psibase::Checksum256   txid;
+      uint32_t               propose_block;
       psibase::TimePointUSec propose_date;
       psibase::AccountNumber proposer;
       ActionList             action_list;
    };
-   PSIO_REFLECT(StagedTx, id, txid, propose_date, proposer, action_list)
+   PSIO_REFLECT(StagedTx, id, txid, propose_block, propose_date, proposer, action_list)
 
    struct Response
    {
@@ -49,10 +50,12 @@ namespace SystemService
       void init();
 
       /// Proposes a new staged transaction containing the specified actions.
+      /// Returns the ID of the database record containing the staged transaction.
+      ///
       /// All actions must have the same sender.
       ///
       /// * `actions` - The actions to be staged
-      void propose(const std::vector<psibase::Action>& actions);
+      uint32_t propose(const std::vector<psibase::Action>& actions);
 
       /// Indicates that the caller accepts the specified staged transaction
       ///
@@ -71,8 +74,8 @@ namespace SystemService
 
       /// Removes (deletes) a staged transaction
       ///
-      /// A staged transaction can only be removed by the proposer or the auth service of
-      /// the staged tx sender.
+      /// A staged transaction can only be removed by the proposer, the staged tx
+      /// first sender, or the first sender's auth service.
       ///
       /// * `id`: The ID of the database record containing the staged transaction
       /// * `txid`: The unique txid of the staged transaction


### PR DESCRIPTION
Adds staged-tx support to auth sig.

The strategy is simply to allow anyone to add a staged tx on behalf of the account, anyone can also accept or reject the transaction, but it doesn't do anything unless the actor is the sender of the staged tx, in which case:
* accept -> execute
* reject -> remove