### PR TITLE
XAdmin boot form UX enhancements

### DIFF
--- a/services/user/XAdmin/ui/src/components/forms/block-producer.tsx
+++ b/services/user/XAdmin/ui/src/components/forms/block-producer.tsx
@@ -17,11 +17,12 @@ const BlockProducerSchema = z.object({
 
 interface Props {
     form: UseFormReturn<z.infer<typeof BlockProducerSchema>>;
+    next: () => Promise<void>;
 }
 
-export const BlockProducerForm = ({ form }: Props) => (
+export const BlockProducerForm = ({ form, next }: Props) => (
     <Form {...form}>
-        <form className="space-y-6">
+        <form className="space-y-6" onSubmit={form.handleSubmit(next)}>
             <FormField
                 control={form.control}
                 name="name"

--- a/services/user/XAdmin/ui/src/components/forms/block-producer.tsx
+++ b/services/user/XAdmin/ui/src/components/forms/block-producer.tsx
@@ -12,7 +12,7 @@ import {
 import { Input } from "../ui/input";
 
 const BlockProducerSchema = z.object({
-    name: z.string().min(2),
+    name: z.string().min(1),
 });
 
 interface Props {

--- a/services/user/XAdmin/ui/src/components/forms/chain-mode-form.tsx
+++ b/services/user/XAdmin/ui/src/components/forms/chain-mode-form.tsx
@@ -15,9 +15,10 @@ type ChainTypeShape = z.infer<typeof chainTypeSchema>;
 
 interface Props {
     form: UseFormReturn<ChainTypeShape>;
+    next: () => Promise<void>;
 }
 
-export const ChainTypeForm = ({ form }: Props) => (
+export const ChainTypeForm = ({ form, next }: Props) => (
     <Form {...form}>
         <form className="space-y-6">
             <FormField
@@ -30,6 +31,7 @@ export const ChainTypeForm = ({ form }: Props) => (
                                 onClick={(event) => {
                                     event.preventDefault();
                                     field.onChange("dev");
+                                    next();
                                 }}
                                 variant={
                                     field.value === "dev"
@@ -54,6 +56,7 @@ export const ChainTypeForm = ({ form }: Props) => (
                                 onClick={(event) => {
                                     event.preventDefault();
                                     field.onChange("prod");
+                                    next();
                                 }}
                                 variant={
                                     field.value === "prod"

--- a/services/user/XAdmin/ui/src/pages/create-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/create-page.tsx
@@ -45,7 +45,7 @@ import { PrevNextButtons } from "../components/PrevNextButtons";
 import { calculateIndex } from "../lib/calculateIndex";
 
 const BlockProducerSchema = z.object({
-    name: z.string().min(2),
+    name: z.string().min(1),
 });
 
 interface DependencyState {

--- a/services/user/XAdmin/ui/src/pages/create-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/create-page.tsx
@@ -238,7 +238,7 @@ export const CreatePage = () => {
                             <h1 className="mb-4 scroll-m-20 text-3xl font-extrabold tracking-tight lg:text-4xl">
                                 Boot template
                             </h1>{" "}
-                            <ChainTypeForm form={chainTypeForm} />
+                            <ChainTypeForm form={chainTypeForm} next={next} />
                         </div>
                     )}
                     {currentStep == 2 && (
@@ -246,7 +246,10 @@ export const CreatePage = () => {
                             <h1 className="mb-4 scroll-m-20 text-3xl font-extrabold tracking-tight lg:text-4xl">
                                 Name yourself
                             </h1>{" "}
-                            <BlockProducerForm form={blockProducerForm} />
+                            <BlockProducerForm
+                                form={blockProducerForm}
+                                next={next}
+                            />
                         </div>
                     )}
                     {currentStep == 3 && (


### PR DESCRIPTION
I always use this UI to boot my development chains. A couple things that always got me:

1. I click on Development or Production to make my choice. I get confused when nothing happens. Oh yeah, I have to click the next arrow at the bottom! I always forget that. So I make it proceed automatically to the next step when I make my selection.
2. I always press RETURN after I enter the name of my producer. And it triggers default form submission behavior attempting to redirect me to a non-existent submission route. Then I have to start all over. Not a big deal. But this makes it so that the RETURN/ENTER button moves me on to the next step instead.