### PR TITLE
Fix supervisor onLoaded race condition and reduce burden on apps

### DIFF
--- a/services/user/CommonApi/common/packages/common-lib/src/supervisor.ts
+++ b/services/user/CommonApi/common/packages/common-lib/src/supervisor.ts
@@ -69,13 +69,13 @@ export class Supervisor {
         setupSupervisorIFrame(this.supervisorSrc);
     }
 
-    listenToRawMessages() {
+    private listenToRawMessages() {
         window.addEventListener("message", (event) =>
             this.handleRawEvent(event),
         );
     }
 
-    handleRawEvent(messageEvent: MessageEvent) {
+    private handleRawEvent(messageEvent: MessageEvent) {
         if (
             messageEvent.origin !== myOrigin &&
             messageEvent.origin !== this.supervisorSrc
@@ -106,12 +106,12 @@ export class Supervisor {
         }
     }
 
-    onSupervisorInitialized() {
+    private onSupervisorInitialized() {
         this.isSupervisorInitialized = true;
         this.onLoadPromiseResolvers.forEach((resolver) => resolver());
     }
 
-    onFunctionCallResponse(response: FunctionCallResponse) {
+    private onFunctionCallResponse(response: FunctionCallResponse) {
         const pendingRequest = this.pendingRequests.find(
             (req) => req.id === response.id,
         );
@@ -169,7 +169,7 @@ export class Supervisor {
         return iframe;
     }
 
-    async functionCall(args: FunctionCallArgs) {
+    public async functionCall(args: FunctionCallArgs) {
         await this.onLoaded();
         const iframe = this.getSupervisorIframe();
 
@@ -200,14 +200,15 @@ export class Supervisor {
         });
     }
 
-    async onLoaded() {
+    public async onLoaded() {
         if (this.isSupervisorInitialized) return;
         return new Promise((resolve) => {
             this.onLoadPromiseResolvers.push(resolve);
         });
     }
 
-    preLoadPlugins(plugins: PluginId[]) {
+    public async preLoadPlugins(plugins: PluginId[]) {
+        await this.onLoaded();
         // Fully qualify any plugins with default values
         const fqPlugins: QualifiedPluginId[] = plugins.map((plugin) => ({
             ...plugin,


### PR DESCRIPTION
@Velua discovered a race condition in the supervisor `onLoaded()` function. We patched that. Additionally, instead of forcing apps to call `onLoaded()` prior to making `functionCall()`s to supervisor, we call `this.onLoaded()` inline in the `functionCall()` method itself. This reduces a lot of app boilerplate and simplifies supervisor instantiation and consumption.