### PR TITLE
Ensure UI gets built and included when `cargo-psibase package` (or build)

### DIFF
--- a/package-templates/rust/build.rs
+++ b/package-templates/rust/build.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::io::Path;
+use std::io::Write;
+
+use std::process::Command;
+
+fn main() {
+    if !Path::new("./ui").exists() {
+        // no UI to build
+        return;
+    }
+    // Touch a marker file to ensure that cargo reruns this build script no matter what
+    // unless it may decide in appropriately that it doesn't need to run the script.
+    fs::File::create("./ui_build")
+        .unwrap()
+        .write_all(b"")
+        .unwrap();
+
+    Command::new("yarn")
+        .current_dir("./ui")
+        .status()
+        .expect("Failed to run `yarn`");
+    Command::new("yarn")
+        .args(&["build"])
+        .current_dir("./ui")
+        .status()
+        .expect("Failed to run build project");
+}

--- a/services/user/Branding/Cargo.lock
+++ b/services/user/Branding/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "branding_package"
-version = "0.0.0"
+version = "0.14.0"
 dependencies = [
  "branding",
  "plugin",

--- a/services/user/Branding/Cargo.toml
+++ b/services/user/Branding/Cargo.toml
@@ -12,6 +12,10 @@ homepage = "https://psibase.io"
 
 [package]
 name = "branding_package"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [profile.release]
 codegen-units = 1

--- a/services/user/Branding/build.rs
+++ b/services/user/Branding/build.rs
@@ -1,9 +1,14 @@
 use std::fs;
+use std::io::Path;
 use std::io::Write;
 
 use std::process::Command;
 
 fn main() {
+    if !Path::new("./ui").exists() {
+        // no UI to build
+        return;
+    }
     // Touch a marker file to ensure that cargo reruns this build script no matter what
     // unless it may decide in appropriately that it doesn't need to run the script.
     fs::File::create("./ui_build")

--- a/services/user/Branding/build.rs
+++ b/services/user/Branding/build.rs
@@ -1,0 +1,17 @@
+use std::process::Command;
+
+fn main() {
+    // Tell Cargo that if the given file changes, to rerun this build script.
+    // println!("cargo:rerun-if-changed=ui");
+    // Use the `cc` crate to build a C file and statically link it.
+    Command::new("yarn")
+        .current_dir("./ui")
+        .status()
+        .expect("Failed to run `yarn`");
+    Command::new("yarn")
+        .current_dir("./ui")
+        .args(&["build"])
+        .status()
+        .expect("Failed to run build project");
+    println!("UI built!");
+}

--- a/services/user/Branding/build.rs
+++ b/services/user/Branding/build.rs
@@ -1,17 +1,23 @@
+use std::fs;
+use std::io::Write;
+
 use std::process::Command;
 
 fn main() {
-    // Tell Cargo that if the given file changes, to rerun this build script.
-    // println!("cargo:rerun-if-changed=ui");
-    // Use the `cc` crate to build a C file and statically link it.
+    // Touch a marker file to ensure that cargo reruns this build script no matter what
+    // unless it may decide in appropriately that it doesn't need to run the script.
+    fs::File::create("./ui_build")
+        .unwrap()
+        .write_all(b"")
+        .unwrap();
+
     Command::new("yarn")
         .current_dir("./ui")
         .status()
         .expect("Failed to run `yarn`");
     Command::new("yarn")
-        .current_dir("./ui")
         .args(&["build"])
+        .current_dir("./ui")
         .status()
         .expect("Failed to run build project");
-    println!("UI built!");
 }

--- a/services/user/Branding/service/Cargo.toml
+++ b/services/user/Branding/service/Cargo.toml
@@ -20,4 +20,4 @@ serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.120"
 
 [dev-dependencies]
-branding_package = { path = ".." }
+branding_package = { path = "..", version = "0.14.0" }

--- a/services/user/Branding/src/lib.rs
+++ b/services/user/Branding/src/lib.rs
@@ -1,2 +1,1 @@
 pub use branding;
-pub use branding-plugin;


### PR DESCRIPTION
A build.rs script now runs before other build steps to ensure the UI is built