### PR TITLE
Enable new account creation

### DIFF
--- a/services/system/Accounts/src/Accounts.cpp
+++ b/services/system/Accounts/src/Accounts.cpp
@@ -54,9 +54,6 @@ namespace SystemService
       auto status = statusIndex.get(std::tuple{});
       check(status.has_value(), "not started");
 
-      auto sender = getSender();
-      check(sender == service || sender == inviteService, "unauthorized account creation");
-
       std::string strName = name.str();
       if (enable_print)
       {
@@ -68,7 +65,7 @@ namespace SystemService
 
       check(name.value, "invalid account name");
       check(strName.back() != '-', "account name must not end in a hyphen");
-      if (sender != service)
+      if (getSender() != service)
       {
          check(!strName.starts_with("x-"),
                "The 'x-' account prefix is reserved for infrastructure providers");

--- a/services/system/AuthSig/include/services/system/AuthSig.hpp
+++ b/services/system/AuthSig/include/services/system/AuthSig.hpp
@@ -94,6 +94,9 @@ namespace SystemService
          bool isRejectSys(psibase::AccountNumber              sender,
                           std::vector<psibase::AccountNumber> rejecters);
 
+         /// Create a new account using this auth service configured with the specified public key.
+         void newAccount(psibase::AccountNumber name, SubjectPublicKeyInfo key);
+
         private:
          Tables db{psibase::getReceiver()};
       };
@@ -102,7 +105,8 @@ namespace SystemService
                    method(canAuthUserSys, user),
                    method(setKey, key),
                    method(isAuthSys, sender, authorizers),
-                   method(isRejectSys, sender, rejecters)
+                   method(isRejectSys, sender, rejecters),
+                   method(newAccount, name, key)
                    //
       )
    }  // namespace AuthSig

--- a/services/system/AuthSig/src/AuthSig.cpp
+++ b/services/system/AuthSig/src/AuthSig.cpp
@@ -114,6 +114,7 @@ namespace SystemService
              .rawData = psio::convert_to_frac(std::make_tuple(AuthSig::AuthSig::service))  //
          };
 
+         auto _ = recurse();
          to<Transact>().runAs(std::move(setKey), std::vector<ServiceMethod>{});
          to<Transact>().runAs(std::move(setAuth), std::vector<ServiceMethod>{});
       }

--- a/services/user/Invite/src/Invite.cpp
+++ b/services/user/Invite/src/Invite.cpp
@@ -74,14 +74,14 @@ void Invite::createInvite(Spki inviteKey)
 
    if (settings.whitelist.size() > 0)
    {
-      bool whitelisted = find(settings.whitelist.begin(), settings.whitelist.end(), inviter) !=
-                         settings.whitelist.end();
+      bool whitelisted = find(settings.whitelist.begin(), settings.whitelist.end(), inviter)
+                         != settings.whitelist.end();
       check(whitelisted, onlyWhitelisted.data());
    }
    else if (settings.blacklist.size() > 0)
    {
-      bool blacklisted = find(settings.blacklist.begin(), settings.blacklist.end(), inviter) !=
-                         settings.blacklist.end();
+      bool blacklisted = find(settings.blacklist.begin(), settings.blacklist.end(), inviter)
+                         != settings.blacklist.end();
       check(not blacklisted, noBlacklisted.data());
    }
 
@@ -90,8 +90,8 @@ void Invite::createInvite(Spki inviteKey)
    InviteRecord newInvite{
        .pubkey  = inviteKey,
        .inviter = inviter,
-       .expiry  = std::chrono::time_point_cast<Seconds>(to<Transact>().currentBlock().time) +
-                 secondsInWeek,
+       .expiry  = std::chrono::time_point_cast<Seconds>(to<Transact>().currentBlock().time)
+                 + secondsInWeek,
        .newAccountToken = true,
        .state           = InviteStates::pending,
    };
@@ -147,19 +147,7 @@ void Invite::acceptCreate(Spki inviteKey, AccountNumber acceptedBy, Spki newAcco
    invite->newAccountToken = false;
 
    // Create new account, and set key & auth
-   to<Accounts>().newAccount(acceptedBy, AuthAny::service, true);
-   std::tuple<Spki> params{newAccountKey};
-   Action           setKey{.sender  = acceptedBy,
-                           .service = AuthSig::AuthSig::service,
-                           .method  = "setKey"_m,
-                           .rawData = psio::convert_to_frac(params)};
-   to<Transact>().runAs(std::move(setKey), vector<ServiceMethod>{});
-   std::tuple<AccountNumber> params2{AuthSig::AuthSig::service};
-   Action                    setAuth{.sender  = acceptedBy,
-                                     .service = Accounts::service,
-                                     .method  = "setAuthServ"_m,
-                                     .rawData = psio::convert_to_frac(params2)};
-   to<Transact>().runAs(std::move(setAuth), vector<ServiceMethod>{});
+   to<AuthSig::AuthSig>().newAccount(acceptedBy, newAccountKey);
 
    invite->state = InviteStates::accepted;
    invite->actor = acceptedBy;

--- a/services/user/Invite/test/src/Invite-test.cpp
+++ b/services/user/Invite/test/src/Invite-test.cpp
@@ -89,11 +89,6 @@ SCENARIO("Auth")
          auto newAcc = accounts.newAccount("bob", AuthAny::service, true);
          CHECK(newAcc.succeeded());
       }
-      THEN("A regular user cannot create a new account")
-      {
-         auto newAcc = a.newAccount("bob", AuthAny::service, true);
-         CHECK(newAcc.failed("unauthorized account creation"));
-      }
    }
 }
 


### PR DESCRIPTION
At some point we restricted the creation of new accounts to the invite service, this reverses that decision. 