### PR TITLE
change pagination page size on x-admin

### DIFF
--- a/services/user/XAdmin/ui/src/components/forms/confirmation-form.tsx
+++ b/services/user/XAdmin/ui/src/components/forms/confirmation-form.tsx
@@ -114,7 +114,7 @@ export function ConfirmationForm({
             sorting,
             columnFilters,
             pagination: {
-                pageSize: 30,
+                pageSize: 999,
                 pageIndex: 0,
             },
             columnVisibility,


### PR DESCRIPTION
Previously was set to 30 and we're just going over that amount in `.psi` packages. Expanding to `999` for now, can look into pagination later if we want.

This is purely a UI change. 