### PR TITLE
Improve cpp graphql support

### DIFF
--- a/libraries/psio/include/psio/graphql.hpp
+++ b/libraries/psio/include/psio/graphql.hpp
@@ -524,6 +524,7 @@ namespace psio
                   }
                   break;
                case '"':
+                  // String parsing follows the GraphQL spec at: https://spec.graphql.org/October2021/#sec-String-Value
                   parse_string();
                   return;
                default:;
@@ -893,6 +894,12 @@ namespace psio
                {
                   return;
                }
+            }
+            else if (ch == '\n' || ch == '\r')
+            {
+               // Literal line terminators can only be used in block strings
+               current_type = error;
+               return;
             }
             else
             {

--- a/libraries/psio/include/psio/graphql.hpp
+++ b/libraries/psio/include/psio/graphql.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
+#include <rapidjson/encodings.h>
 #include <cctype>
 #include <charconv>
 #include <chrono>
+#include <numeric>
 #include <psio/from_json.hpp>
 #include <psio/reflect.hpp>
 #include <psio/shared_view_ptr.hpp>
 #include <psio/stream.hpp>
 #include <psio/to_json.hpp>
+#include <ranges>
 #include <set>
 #include <typeindex>
 #include <variant>
@@ -423,6 +426,14 @@ namespace psio
       fill_gql_schema_impl((T*)nullptr, stream, defined_types, is_input, is_query_root);
    }
 
+   // Adaptor for RapidJSON UTF8 encoding output
+   struct utf8_output_adaptor
+   {
+      utf8_output_adaptor(std::string& out) : out(out) {}
+      void         Put(char ch) { out.push_back(ch); }
+      std::string& out;
+   };
+
    struct gql_stream
    {
       enum token_type
@@ -441,6 +452,7 @@ namespace psio
       token_type       current_type = unstarted;
       std::string_view current_value;
       char             current_punctuator = 0;
+      std::string      processed_string;
 
       gql_stream(input_stream input) : input{input} { skip(); }
       gql_stream(const gql_stream&)            = default;
@@ -512,34 +524,7 @@ namespace psio
                   }
                   break;
                case '"':
-                  // Notes:
-                  // * Block strings (""") not currently supported and escape processing not
-                  //   currently done; we may have to revisit this if we add either mutation
-                  //   support or searches through text fields, or if clients or client
-                  //   libraries end up using them unnecessarily
-                  // * Doesn't detect and reject unescaped code points that the GraphQL
-                  //   spec prohibits
-                  if (input.remaining() >= 3 && input.pos[1] == '"' && input.pos[2] == '"')
-                  {
-                     current_type = error;
-                     return;
-                  }
-                  ++input.pos;
-                  while (input.remaining() && input.pos[0] != '"')
-                  {
-                     auto ch = *input.pos++;
-                     if (ch == '\\')
-                     {
-                        if (!input.remaining())
-                           return;
-                        ++input.pos;
-                     }
-                  }
-                  if (!input.remaining())
-                     return;
-                  ++input.pos;
-                  current_value = {begin + 1, size_t(input.pos - begin - 2)};
-                  current_type  = string;
+                  parse_string();
                   return;
                default:;
             }  // switch (input.pos[0])
@@ -613,6 +598,310 @@ namespace psio
             }
          }  // while (true)
       }  // skip()
+
+      uint16_t parse_hex_code_unit()
+      {
+         if (input.remaining() < 4)
+         {
+            current_type = error;
+            return 0;
+         }
+
+         std::string_view hex{input.pos, 4};
+         if (!std::ranges::all_of(
+                 hex, [](char c) { return std::isxdigit(static_cast<unsigned char>(c)); }))
+         {
+            current_type = error;
+            return 0;
+         }
+
+         uint16_t code_unit;
+         auto [ptr, ec] = std::from_chars(hex.data(), hex.data() + hex.size(), code_unit, 16);
+         if (ec != std::errc{})
+         {
+            current_type = error;
+            return 0;
+         }
+
+         input.pos += 4;
+         return code_unit;
+      }
+
+      void adapt_code_point_for_surrogate_pair(uint16_t code_unit, uint32_t& code_point)
+      {
+         // https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf
+         constexpr uint16_t HIGH_SURROGATE_START = 0xD800;
+         constexpr uint16_t HIGH_SURROGATE_END   = 0xDBFF;
+         constexpr uint16_t LOW_SURROGATE_START  = 0xDC00;
+         constexpr uint16_t LOW_SURROGATE_END    = 0xDFFF;
+         constexpr uint32_t SURROGATE_OFFSET     = 0x10000;
+
+         if (code_unit >= HIGH_SURROGATE_START && code_unit <= HIGH_SURROGATE_END)
+         {
+            // Need a low surrogate to follow
+            if (input.remaining() < 2 || input.pos[0] != '\\' || input.pos[1] != 'u')
+            {
+               current_type = error;
+               return;
+            }
+            input.pos += 2;
+
+            uint16_t low_surrogate = parse_hex_code_unit();
+            if (current_type == error)
+               return;
+
+            if (low_surrogate < LOW_SURROGATE_START || low_surrogate > LOW_SURROGATE_END)
+            {
+               current_type = error;
+               return;
+            }
+
+            // Combine into single code point
+            code_point = SURROGATE_OFFSET + ((code_unit - HIGH_SURROGATE_START) << 10) +
+                         (low_surrogate - LOW_SURROGATE_START);
+         }
+         else if (code_unit >= LOW_SURROGATE_START && code_unit <= LOW_SURROGATE_END)
+         {
+            // Unpaired low surrogate
+            current_type = error;
+            return;
+         }
+      }
+
+      void parse_unicode_escape_sequence(std::string& result)
+      {
+         uint16_t code_unit = parse_hex_code_unit();
+         if (current_type == error)
+            return;
+
+         uint32_t code_point = code_unit;
+         adapt_code_point_for_surrogate_pair(code_unit, code_point);
+         if (current_type == error)
+            return;
+
+         utf8_output_adaptor out(result);
+         rapidjson::UTF8<>::Encode(out, code_point);
+      }
+
+      void interpret_escape_sequence(std::string& result, char escape_char)
+      {
+         if (escape_char == 'u')
+         {
+            parse_unicode_escape_sequence(result);
+            return;
+         }
+
+         switch (escape_char)
+         {
+            case '"':
+               result.push_back('"');
+               break;
+            case '\\':
+               result.push_back('\\');
+               break;
+            case '/':
+               result.push_back('/');
+               break;
+            case 'b':
+               result.push_back('\b');
+               break;
+            case 'f':
+               result.push_back('\f');
+               break;
+            case 'n':
+               result.push_back('\n');
+               break;
+            case 'r':
+               result.push_back('\r');
+               break;
+            case 't':
+               result.push_back('\t');
+               break;
+            default:
+               current_type = error;
+               return;
+         }
+      }
+
+      static std::vector<std::string_view> split_into_lines(std::string_view input)
+      {
+         std::vector<std::string_view> lines;
+         size_t                        pos = 0;
+         while (pos < input.size())
+         {
+            size_t end = input.find_first_of("\r\n", pos);
+            if (end == std::string_view::npos)
+            {
+               lines.push_back(input.substr(pos));
+               break;
+            }
+
+            lines.push_back(input.substr(pos, end - pos));
+            pos = end + 1;
+
+            // Handle crlf
+            if (input[end] == '\r' && pos < input.size() && input[pos] == '\n')
+               ++pos;
+         }
+         return lines;
+      }
+
+      static bool is_whitespace_line(std::string_view line)
+      {
+         return line.find_first_not_of(" \t") == std::string_view::npos;
+      }
+
+      static std::optional<size_t> find_common_indent(const std::vector<std::string_view>& lines)
+      {
+         std::optional<size_t> common_indent;
+
+         for (size_t i = 1; i < lines.size(); ++i)
+         {
+            const auto& line = lines[i];
+            if (is_whitespace_line(line) || line.empty())
+               continue;
+
+            auto indent = line.find_first_not_of(" \t");
+            if (indent != std::string_view::npos && (!common_indent || indent < *common_indent))
+               common_indent = indent;
+         }
+
+         return common_indent;
+      }
+
+      static std::vector<std::string> process_lines(const std::vector<std::string_view>& lines,
+                                                    std::optional<size_t> common_indent)
+      {
+         auto process_line = [&](std::string_view line)
+         {
+            if (is_whitespace_line(line))
+               return std::string_view{};
+            if (common_indent && !line.empty())
+               line.remove_prefix(*common_indent);
+            return line;
+         };
+
+         std::vector<std::string> processed_lines;
+         processed_lines.reserve(lines.size());
+
+         for (auto line : lines | std::views::transform(process_line))
+         {
+            processed_lines.push_back(std::string{line});
+         }
+
+         return processed_lines;
+      }
+
+      static std::string join_lines(const std::vector<std::string>& lines)
+      {
+         auto notEmpty = [](const std::string& s) { return !s.empty(); };
+
+         auto start = std::ranges::find_if(lines, notEmpty);
+         if (start == lines.end())
+            return {};
+
+         auto end = std::ranges::find_if(lines.rbegin(), lines.rend(), notEmpty).base();
+
+         std::string result = *start;
+         for (auto it = std::next(start); it != end; ++it)
+         {
+            result += '\n';
+            result += *it;
+         }
+         return result;
+      }
+
+      std::string process_block_string_value(std::string_view raw_value)
+      {
+         auto lines           = split_into_lines(raw_value);
+         auto common_indent   = find_common_indent(lines);
+         auto processed_lines = process_lines(lines, common_indent);
+         return join_lines(processed_lines);
+      }
+
+      void parse_block_string()
+      {
+         input.pos += 3;  // Skip opening """
+         std::string raw_storage;
+
+         while (input.remaining())
+         {
+            if (input.remaining() >= 4 && input.pos[0] == '\\' && input.pos[1] == '"' &&
+                input.pos[2] == '"' && input.pos[3] == '"')
+            {
+               // Escaped triple quote
+               raw_storage += "\"\"\"";
+               input.pos += 4;
+            }
+            else if (input.remaining() >= 3 && input.pos[0] == '"' && input.pos[1] == '"' &&
+                     input.pos[2] == '"')
+            {
+               // Closing triple quote
+               input.pos += 3;
+               processed_string = process_block_string_value(raw_storage);
+               current_value    = processed_string;
+               current_type     = string;
+               return;
+            }
+            else if (input.pos[0] == '\r')
+            {
+               // New line
+               raw_storage += '\n';
+               ++input.pos;
+
+               if (input.remaining() && input.pos[0] == '\n')  // Handle crlf
+                  ++input.pos;
+            }
+            else
+            {
+               raw_storage += *input.pos++;
+            }
+         }
+         current_type = error;
+      }
+
+      void parse_string()
+      {
+         if (input.remaining() >= 3 && input.pos[1] == '"' && input.pos[2] == '"')
+         {
+            parse_block_string();
+            return;
+         }
+
+         std::string result;
+         ++input.pos;
+         while (input.remaining() && input.pos[0] != '"')
+         {
+            auto ch = *input.pos++;
+            if (ch == '\\')
+            {
+               if (!input.remaining())
+               {
+                  current_type = error;
+                  return;
+               }
+               interpret_escape_sequence(result, *input.pos++);
+               if (current_type == error)
+               {
+                  return;
+               }
+            }
+            else
+            {
+               result.push_back(ch);
+            }
+         }
+         if (!input.remaining())
+         {
+            current_type = error;
+            return;
+         }
+         ++input.pos;  // (Closing quote)
+
+         processed_string = std::move(result);
+         current_value    = processed_string;
+         current_type     = string;
+      }
    };  // gql_stream
 
    template <typename E>

--- a/libraries/psio/include/psio/graphql.hpp
+++ b/libraries/psio/include/psio/graphql.hpp
@@ -854,6 +854,14 @@ namespace psio
             }
             else
             {
+               // From the spec: "If non-printable ASCII characters are needed in a string value,
+               //   a standard quoted string with appropriate escape sequences must be used instead of a block string."
+               unsigned char ch = *input.pos;
+               if (ch < 32 && ch != '\n' && ch != '\r' && ch != '\t')
+               {
+                  current_type = error;
+                  return;
+               }
                raw_storage += *input.pos++;
             }
          }

--- a/libraries/psio/tests/graphql.cpp
+++ b/libraries/psio/tests/graphql.cpp
@@ -334,7 +334,7 @@ TEST_CASE("graphql_block_strings", "[graphql]")
           World
         """, two: "" }) })",
                                   "");
-   REQUIRE(result7 == R"({"data": {"cat":"Hello\n\n  World"}})");
+   REQUIRE(result7 == R"({"data": {"cat":"Hello\n     \n  World"}})");
 
    // Test tab indentation
    auto result8 = psio::gql_query(r, R"({ cat(arg: { one: """
@@ -377,7 +377,7 @@ TEST_CASE("graphql_block_strings", "[graphql]")
         World
     """, two: "" }) })",
                                    "");
-   REQUIRE(result12 == R"({"data": {"cat":"Hello\n\n\nWorld"}})");
+   REQUIRE(result12 == R"({"data": {"cat":"Hello\n\n   \nWorld"}})");
 
    // Test lines with mixed tabs and spaces for indentation
    auto result13 = psio::gql_query(r, R"({ cat(arg: { one: """

--- a/libraries/psio/tests/graphql.cpp
+++ b/libraries/psio/tests/graphql.cpp
@@ -167,7 +167,7 @@ struct InputArg
    std::string one;
    std::string two;
 };
-PSIO_REFLECT(InputArg, method(one), method(two))
+PSIO_REFLECT(InputArg, one, two)
 
 struct Account
 {
@@ -215,7 +215,7 @@ PSIO_REFLECT(Root,
              method(cat, arg),
              method(getAccounts, first, before, last, after))
 
-TEST_CASE("graphql")
+TEST_CASE("graphql", "[graphql]")
 {
    Root r{"hello", 42};
 
@@ -240,4 +240,151 @@ TEST_CASE("graphql")
        "{ accounts:getAccounts( last: 2 ) { pageInfo { hasPreviousPage, hasNextPage }, "
        "edges { node {firstName, lastName } } }  }",
        "");
+}
+
+TEST_CASE("graphql_escape_sequences", "[graphql]")
+{
+   Root r{"hello", 42};
+
+   // Test all escape sequences
+   auto result1 =
+       psio::gql_query(r, R"({ cat(arg: { one: "Hello\n\t\b\f\r\"\\\/", two: "World" }) })", "");
+   REQUIRE(result1 == R"({"data": {"cat":"Hello\n\t\b\f\r\"\\/World"}})");
+
+   // Test Unicode escape sequences
+   auto result2 = psio::gql_query(
+       r, R"({ cat(arg: { one: "\u0048\u0065\u006C\u006C\u006F", two: "World" }) })", "");
+   REQUIRE(result2 == R"({"data": {"cat":"HelloWorld"}})");
+
+   // Test that unknown escape sequences result in an error
+   auto result3 = psio::gql_query(r, R"({ cat(arg: { one: "Hello\x", two: "World" }) })", "");
+   REQUIRE(result3 == R"({"errors": {"message": "expected }"}})");
+
+   // Test empty string followed by quote (should be valid)
+   auto result4 = psio::gql_query(r, R"({ cat(arg: { one: "", two: "\"" }) })", "");
+   REQUIRE(result4 == R"({"data": {"cat":"\""}})");
+
+   // Test 2-byte Unicode character (ñ = U+00F1)
+   auto result5 = psio::gql_query(r, R"({ cat(arg: { one: "Ma\u00F1ana", two: "" }) })", "");
+   REQUIRE(result5 == R"({"data": {"cat":"Mañana"}})");
+
+   // Test 3-byte Unicode character (€ = U+20AC)
+   auto result6 = psio::gql_query(r, R"({ cat(arg: { one: "\u20AC100", two: "" }) })", "");
+   REQUIRE(result6 == R"({"data": {"cat":"€100"}})");
+
+   // Test 4-byte Unicode character using surrogate pair (🚀 = U+1F680)
+   auto result7 = psio::gql_query(r, R"({ cat(arg: { one: "Launch\uD83D\uDE80", two: "" }) })", "");
+   REQUIRE(result7 == R"({"data": {"cat":"Launch🚀"}})");
+
+   // Test invalid surrogate pair (high surrogate without low surrogate)
+   auto result8 = psio::gql_query(r, R"({ cat(arg: { one: "\uD83D", two: "" }) })", "");
+   REQUIRE(result8 == R"({"errors": {"message": "expected }"}})");
+
+   // Test invalid surrogate pair (low surrogate without high surrogate)
+   auto result9 = psio::gql_query(r, R"({ cat(arg: { one: "\uDE80", two: "" }) })", "");
+   REQUIRE(result9 == R"({"errors": {"message": "expected }"}})");
+}
+
+TEST_CASE("graphql_block_strings", "[graphql]")
+{
+   Root r{"hello", 42};
+
+   // Test basic block string with backslash and quotes (should be preserved verbatim)
+   auto result1 =
+       psio::gql_query(r, R"({ cat(arg: { one: """Hello \n "quoted" World!""", two: "" }) })", "");
+   REQUIRE(result1 == R"({"data": {"cat":"Hello \\n \"quoted\" World!"}})");
+
+   // Test common indentation removal
+   auto result2 = psio::gql_query(r, R"({ cat(arg: { one: """
+        Hello
+          World
+        Goodbye
+    """, two: "" }) })",
+                                  "");
+   REQUIRE(result2 == R"({"data": {"cat":"Hello\n  World\nGoodbye"}})");
+
+   // Test empty lines at start and end are removed
+   auto result3 = psio::gql_query(r, R"({ cat(arg: { one: """
+
+        Hello
+        World
+
+    """, two: "" }) })",
+                                  "");
+   REQUIRE(result3 == R"({"data": {"cat":"Hello\nWorld"}})");
+
+   // Test escaped triple quotes
+   auto result4 =
+       psio::gql_query(r, R"({ cat(arg: { one: """Hello \""" World""", two: "" }) })", "");
+   REQUIRE(result4 == R"({"data": {"cat":"Hello \"\"\" World"}})");
+
+   // Test mixed line endings (CRLF and LF)
+   auto result5 = psio::gql_query(
+       r, "{ cat(arg: { one: \"\"\"\r\nHello\rWorld\nGoodbye\r\n\"\"\", two: \"\" }) }", "");
+   REQUIRE(result5 == R"({"data": {"cat":"Hello\nWorld\nGoodbye"}})");
+
+   // Test empty block string
+   auto result6 = psio::gql_query(r, R"({ cat(arg: { one: """""", two: "" }) })", "");
+   REQUIRE(result6 == R"({"data": {"cat":""}})");
+
+   // Test whitespace-only lines don't affect common indentation
+   auto result7 = psio::gql_query(r, R"({ cat(arg: { one: """
+        Hello
+             
+          World
+        """, two: "" }) })",
+                                  "");
+   REQUIRE(result7 == R"({"data": {"cat":"Hello\n\n  World"}})");
+
+   // Test tab indentation
+   auto result8 = psio::gql_query(r, R"({ cat(arg: { one: """
+		Hello
+			World
+		Goodbye
+""", two: "" }) })",
+                                  "");
+   REQUIRE(result8 == R"({"data": {"cat":"Hello\n\tWorld\nGoodbye"}})");
+
+   // Test mixed space and tab indentation
+   auto result9 = psio::gql_query(r, R"({ cat(arg: { one: """
+	    Hello
+	      World
+	    Goodbye
+""", two: "" }) })",
+                                  "");
+   REQUIRE(result9 == R"({"data": {"cat":"Hello\n  World\nGoodbye"}})");
+
+   // Test non-printable ASCII characters are preserved
+   auto result10 =
+       psio::gql_query(r, R"({ cat(arg: { one: """Hello\u0007World""", two: "" }) })", "");
+   REQUIRE(result10 == R"({"data": {"cat":"Hello\\u0007World"}})");
+
+   // Test multiple consecutive empty lines in the middle
+   auto result11 = psio::gql_query(r, R"({ cat(arg: { one: """
+        Hello
+
+
+        World
+    """, two: "" }) })",
+                                   "");
+   REQUIRE(result11 == R"({"data": {"cat":"Hello\n\n\nWorld"}})");
+
+   // Test lines with only whitespace in the middle
+   auto result12 = psio::gql_query(r, R"({ cat(arg: { one: """
+        Hello
+        
+           
+        World
+    """, two: "" }) })",
+                                   "");
+   REQUIRE(result12 == R"({"data": {"cat":"Hello\n\n\nWorld"}})");
+
+   // Test lines with mixed tabs and spaces for indentation
+   auto result13 = psio::gql_query(r, R"({ cat(arg: { one: """
+        Hello
+	    	World
+        	Goodbye
+    """, two: "" }) })",
+                                   "");
+   REQUIRE(result13 == R"({"data": {"cat":"  Hello\nWorld\n  \tGoodbye"}})");
 }

--- a/services/user/Invite/plugin/src/lib.rs
+++ b/services/user/Invite/plugin/src/lib.rs
@@ -99,7 +99,7 @@ impl Invitee for InvitePlugin {
 
         let query = format!(
             r#"query {{
-                getInvite(pubkey: "{pubkey}") {{
+                getInvite(pubkey: """{pubkey}""") {{
                     inviter,
                     actor,
                     expiry,


### PR DESCRIPTION
Adds block string support, escape sequences, unicode escapes, and in general tries to better follow the [graphql spec](https://spec.graphql.org/October2021/#sec-String-Value) for string parsing.