### PR TITLE
Branding plugin not loading

### DIFF
--- a/services/user/Branding/Cargo.lock
+++ b/services/user/Branding/Cargo.lock
@@ -355,7 +355,7 @@ name = "branding"
 version = "0.14.0"
 dependencies = [
  "async-graphql",
- "branding_package",
+ "branding-pkg",
  "psibase",
  "psibase_macros",
  "serde",
@@ -363,8 +363,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "branding_package"
-version = "0.0.0"
+name = "branding-pkg"
+version = "0.14.0"
 dependencies = [
  "branding",
  "plugin",
@@ -1529,7 +1529,7 @@ name = "plugin"
 version = "0.14.0"
 dependencies = [
  "branding",
- "branding_package",
+ "branding-pkg",
  "psibase",
  "serde",
  "serde_json",

--- a/services/user/Branding/Cargo.toml
+++ b/services/user/Branding/Cargo.toml
@@ -11,7 +11,12 @@ repository = "https://github.com/gofractally/psibase"
 homepage = "https://psibase.io"
 
 [package]
-name = "branding_package"
+name = "branding-pkg"
+description = "Allow operators to rebrand their network easily"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [profile.release]
 codegen-units = 1
@@ -22,7 +27,6 @@ lto = true
 
 [package.metadata.psibase]
 package-name = "Branding"
-description = "Allow operators to rebrand their network easily"
 services = ["branding"]
 
 [package.metadata.psibase.dependencies]
@@ -33,5 +37,5 @@ Sites = "0.14.0"
 crate-type = ["rlib"]
 
 [dependencies]
-branding = { path = "service" }
-plugin = { path = "plugin" }
+branding = { path = "service", version = "0.14.0" }
+plugin = { path = "plugin", version = "0.14.0" }

--- a/services/user/Branding/plugin/Cargo.toml
+++ b/services/user/Branding/plugin/Cargo.toml
@@ -8,25 +8,24 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-psibase = { path = "../../../../rust/psibase/" }
+psibase = { path = "../../../../rust/psibase/", version = "0.14.0" }
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 wit-bindgen-rt = { version = "0.30.0", features = ["bitflags"] }
-branding = { path = "../service/" }
+branding = { path = "../service/", version = "0.14.0" }
 
 [lib]
 crate-type = ["cdylib"]
 
 [package.metadata.component]
-package = "branding:psibase-plugin"
+package = "branding:plugin"
 
 [package.metadata.component.dependencies]
 
 [package.metadata.component.target.dependencies]
-# Something's wrong with transact that it needs host:common added as a dep in a project like this
 "host:common" = { path = "../../CommonApi/common/packages/wit/host-common.wit" }
 "transact:plugin" = { path = "../../../system/Transact/plugin/wit/world.wit" }
 "sites:plugin" = { path = "../../Sites/plugin/wit/world.wit" }
 
 [dev-dependencies]
-branding_package = { path = ".." }
+branding-pkg = { path = "..", version = "0.14.0" }

--- a/services/user/Branding/service/Cargo.toml
+++ b/services/user/Branding/service/Cargo.toml
@@ -13,11 +13,11 @@ plugin = "plugin"
 data = [{ src = "../ui/dist", dst = "/" }]
 
 [dependencies]
-psibase = { path = "../../../../rust/psibase" }
-psibase_macros = { path = "../../../../rust/psibase_macros" }
+psibase = { path = "../../../../rust/psibase", version = "0.14.0" }
+psibase_macros = { path = "../../../../rust/psibase_macros", version = "0.14.0" }
 async-graphql = "7.0.7"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.120"
 
 [dev-dependencies]
-branding_package = { path = ".." }
+branding-pkg = { path = "..", version = "0.14.0" }

--- a/services/user/Branding/src/lib.rs
+++ b/services/user/Branding/src/lib.rs
@@ -1,2 +1,1 @@
 pub use branding;
-pub use branding-plugin;

--- a/services/user/Sites/src/Sites.cpp
+++ b/services/user/Sites/src/Sites.cpp
@@ -262,10 +262,6 @@ namespace SystemService
       }
 
       auto account = getTargetService(request);
-      if (account == Sites::service)
-      {
-         return serveSitesApp(request);
-      }
 
       if (request.method == "GET" || request.method == "HEAD")
       {
@@ -402,6 +398,11 @@ namespace SystemService
 
             return reply;
          }
+      }
+
+      if (account == Sites::service)
+      {
+         return serveSitesApp(request);
       }
 
       return std::nullopt;


### PR DESCRIPTION
I noticed the branding app was failing by not being able to download the branding plugin.

I thought it was something to do with the branding package so I matched the syntax in the package config with the conventions established in the package-template. But it still didn't work.

Culprit ended up being the sites service implementation, which the branding plugin was dependent on.