### PR TITLE
Align graphql and json timepointusec serialization

### DIFF
--- a/rust/psibase/src/time.rs
+++ b/rust/psibase/src/time.rs
@@ -1,4 +1,5 @@
 use crate::{Pack, ToKey, ToSchema, Unpack};
+use async_graphql::ScalarType;
 use async_graphql::{InputObject, SimpleObject};
 use chrono::{DateTime, FixedOffset, Utc};
 use serde::{
@@ -72,20 +73,7 @@ impl<'de> Deserialize<'de> for TimePointSec {
 }
 
 #[derive(
-    Debug,
-    Copy,
-    Clone,
-    Default,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Pack,
-    Unpack,
-    ToKey,
-    ToSchema,
-    SimpleObject,
-    InputObject,
+    Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Pack, Unpack, ToKey, ToSchema,
 )]
 #[fracpack(
     definition_will_not_change,
@@ -93,9 +81,38 @@ impl<'de> Deserialize<'de> for TimePointSec {
     custom = "TimePointUSec"
 )]
 #[to_key(psibase_mod = "crate")]
-#[graphql(input_name = "TimePointUSecInput")]
 pub struct TimePointUSec {
     pub microseconds: i64,
+}
+
+impl TryFrom<String> for TimePointUSec {
+    type Error = String;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        DateTime::<FixedOffset>::parse_from_rfc3339(&s)
+            .map(|dt| dt.to_utc().into())
+            .map_err(|e| e.to_string())
+    }
+}
+
+impl ToString for TimePointUSec {
+    fn to_string(&self) -> String {
+        DateTime::<Utc>::from(*self).to_rfc3339()
+    }
+}
+
+#[async_graphql::Scalar]
+impl ScalarType for TimePointUSec {
+    fn parse(value: async_graphql::Value) -> async_graphql::InputValueResult<Self> {
+        if let async_graphql::Value::String(s) = value {
+            Self::try_from(s).map_err(async_graphql::InputValueError::custom)
+        } else {
+            Err(async_graphql::InputValueError::expected_type(value))
+        }
+    }
+
+    fn to_value(&self) -> async_graphql::Value {
+        async_graphql::Value::String(self.to_string())
+    }
 }
 
 impl TimePointUSec {
@@ -128,17 +145,14 @@ impl From<TimePointUSec> for DateTime<Utc> {
 
 impl Serialize for TimePointUSec {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&DateTime::<Utc>::from(*self).to_rfc3339())
+        serializer.serialize_str(&self.to_string())
     }
 }
 
 impl<'de> Deserialize<'de> for TimePointUSec {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = <&str>::deserialize(deserializer)?;
-        Ok(DateTime::<FixedOffset>::parse_from_rfc3339(s)
-            .map_err(|e| D::Error::custom(e.to_string()))?
-            .to_utc()
-            .into())
+        let s = <String>::deserialize(deserializer)?;
+        Self::try_from(s).map_err(D::Error::custom)
     }
 }
 

--- a/rust/psibase/src/time.rs
+++ b/rust/psibase/src/time.rs
@@ -138,8 +138,8 @@ impl Serialize for TimePointUSec {
 
 impl<'de> Deserialize<'de> for TimePointUSec {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = <String>::deserialize(deserializer)?;
-        Self::from_str(&s).map_err(D::Error::custom)
+        let s = <&str>::deserialize(deserializer)?;
+        Self::from_str(s).map_err(D::Error::custom)
     }
 }
 

--- a/services/user/Registry/plugin/src/queries.rs
+++ b/services/user/Registry/plugin/src/queries.rs
@@ -86,9 +86,7 @@ pub fn query_app_metadata(
                     status,
                     redirectUris,
                     owners,
-                    createdAt {{
-                        seconds
-                    }}
+                    createdAt
                 }}
                 tags {{
                     id,

--- a/services/user/Registry/service/src/lib.rs
+++ b/services/user/Registry/service/src/lib.rs
@@ -554,13 +554,13 @@ pub mod service {
 mod tests {
     use super::*;
     use crate::service::{AppMetadata, AppStatus, AppStatusU32, TagRecord, MAX_APP_NAME_LENGTH};
-    use psibase::{account, AccountNumber, ChainEmptyResult, TimePointSec};
+    use psibase::{account, AccountNumber, ChainEmptyResult, TimePointUSec};
 
     fn default_metadata() -> AppMetadata {
         AppMetadata {
             account_id: AccountNumber::new(0),
             status: AppStatus::Draft as AppStatusU32,
-            created_at: TimePointSec::from(0),
+            created_at: TimePointUSec::from(0),
             redirect_uris: vec!["http://localhost:3000/callback".to_string()],
             owners: vec![account!("alice"), account!("bob")],
             name: "Super Cooking App".to_string(),


### PR DESCRIPTION
Otherwise graphql returns a timepointusec in a form that serde is unable to deserialize into a rich object