### PR TITLE
Build the root of each package

### DIFF
--- a/rust/cargo-psibase/src/main.rs
+++ b/rust/cargo-psibase/src/main.rs
@@ -392,6 +392,29 @@ async fn build_plugin(
     Ok(files?)
 }
 
+async fn build_package_root(args: &Args, package: &str) -> Result<(), Error> {
+    let mut command = tokio::process::Command::new(get_cargo())
+        .arg("rustc")
+        .args(&["-p", package])
+        .arg("--release")
+        .arg("--lib")
+        .arg("--target=wasm32-wasi")
+        .args(get_manifest_path(args))
+        .args(get_target_dir(args))
+        .arg("--color=always")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+
+    let status = command.wait().await?;
+
+    if !status.success() {
+        exit(status.code().unwrap());
+    }
+
+    Ok(())
+}
+
 fn is_wasm32_wasi(dep: &DepKindInfo) -> bool {
     if let Some(platform) = &dep.target {
         if platform.matches("wasm32-wasip1", &[]) {

--- a/services/user/Chainmail/src/lib.rs
+++ b/services/user/Chainmail/src/lib.rs
@@ -1,2 +1,1 @@
 pub use chainmail;
-pub use plugin;


### PR DESCRIPTION
This serves two purposes
- It detects errors that could otherwise be missed when the package root isn't actually compiled
- It runs the build scripts for the package and its dependencies