### PR TITLE
Use localhost instead of sslip

### DIFF
--- a/doc/psidk/src/run-infrastructure/cli/psinode.md
+++ b/doc/psidk/src/run-infrastructure/cli/psinode.md
@@ -36,7 +36,7 @@ psinode - The psibase blockchain server
 
 - `-o` *hostname*, `--host` *hostname*
 
-  Enable the service http interface. Its argument is a domain name which supports virtual hosting. e.g. if it's running on your local machine, use `psibase.127.0.0.1.sslip.io`. This argument allows on-chain services to handle HTTP requests and also allows the node to accept transactions.
+  Enable the service http interface. Its argument is a domain name which supports virtual hosting. e.g. if it's running on your local machine, use `psibase.localhost`. This argument allows on-chain services to handle HTTP requests. It can be specified multiple times. Arguments passed on the command line override those in the config file. HTTP requests that do not match any host will be redirected to the first host.
 
 - `-k` *private-key*, `--key` *private-key*
 

--- a/libraries/psibase_http/handle_request.cpp
+++ b/libraries/psibase_http/handle_request.cpp
@@ -677,14 +677,19 @@ namespace psibase::http
                }
             }
 
-            auto root_host_pos = std::ranges::find_if(
-                server.http_config->hosts,
-                [&](const auto& name)
-                {
-                   return host.ends_with(name) && (host.size() == name.size() ||
-                                                   host[host.size() - name.size() - 1] == '.');
-                });
-            if (root_host_pos == server.http_config->hosts.end())
+            std::string_view root_host;
+            for (const auto& name : server.http_config->hosts)
+            {
+               if (host.ends_with(name) &&
+                   (host.size() == name.size() || host[host.size() - name.size() - 1] == '.'))
+               {
+                  if (name.size() > root_host.size())
+                  {
+                     root_host = name;
+                  }
+               }
+            }
+            if (root_host.empty())
             {
                if (server.http_config->hosts.empty())
                   return send(not_found(req.target()));
@@ -737,7 +742,7 @@ namespace psibase::http
                return send(
                    method_not_allowed(req.target(), req.method_string(), "GET, POST, OPTIONS"));
             data.host        = {host.begin(), host.size()};
-            data.rootHost    = *root_host_pos;
+            data.rootHost    = root_host;
             data.target      = std::string(req_target);
             data.contentType = (std::string)req[bhttp::field::content_type];
             data.body        = std::move(req.body());

--- a/libraries/psibase_http/http_session_base.hpp
+++ b/libraries/psibase_http/http_session_base.hpp
@@ -102,6 +102,8 @@ namespace psibase::http
       virtual void post(std::function<void()>)                                             = 0;
       virtual void close_impl(boost::beast::error_code& ec)                                = 0;
       virtual void shutdown_impl()                                                         = 0;
+
+      virtual bool is_secure() const { return false; }
    };
 
 }  // namespace psibase::http

--- a/libraries/psibase_http/include/psibase/http.hpp
+++ b/libraries/psibase_http/include/psibase/http.hpp
@@ -299,7 +299,7 @@ namespace psibase::http
       std::atomic<int64_t>     idle_timeout_us  = {};
       std::string              allow_origin     = {};
       std::vector<listen_spec> listen           = {};
-      std::string              host             = {};
+      std::vector<std::string> hosts            = {};
 #ifdef PSIBASE_ENABLE_SSL
       tls_context_ptr tls_context = {};
 #endif

--- a/libraries/psibase_http/tls_http_session.hpp
+++ b/libraries/psibase_http/tls_http_session.hpp
@@ -23,6 +23,8 @@ namespace psibase::http
          return stream.next_layer().socket().remote_endpoint().address() == addr.address;
       }
 
+      virtual bool is_secure() const override { return true; }
+
       void shutdown_impl();
       void close_impl(boost::beast::error_code& ec);
 

--- a/programs/psinode/config.in
+++ b/programs/psinode/config.in
@@ -3,7 +3,7 @@
 p2p      = off
 # producer = psibase
 # key      = <private key>
-host     = localhost
+host     = psibase.localhost
 host     = psibase.127.0.0.1.sslip.io
 listen   = 8080
 # peer     = http://localhost:8080/

--- a/programs/psinode/config.in
+++ b/programs/psinode/config.in
@@ -3,12 +3,10 @@
 p2p      = off
 # producer = psibase
 # key      = <private key>
+host     = localhost
 host     = psibase.127.0.0.1.sslip.io
 listen   = 8080
 # peer     = http://localhost:8080/
-service  = localhost:$PSIBASE_DATADIR/services/x-admin
-service  = 127.0.0.1:$PSIBASE_DATADIR/services/x-admin
-service  = [::1]:$PSIBASE_DATADIR/services/x-admin
 service  = x-admin.:$PSIBASE_DATADIR/services/x-admin
 admin    = static:*
 

--- a/programs/psinode/tests/psinode.py
+++ b/programs/psinode/tests/psinode.py
@@ -479,10 +479,14 @@ class Node(API):
         Raise TimeoutError if the timeout expires first
         '''
         for i in range(timeout):
-            if cond(self):
-                return
+            try:
+                if cond(self):
+                    return
+            except:
+                pass
             time.sleep(1)
-        raise TimeoutError()
+        if not cond(self):
+            raise TimeoutError()
     def connect(self, other):
         '''Connect to a peer. other can be a URL or a Node object'''
         if isinstance(other, Node):

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2521,6 +2521,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hmac",
+ "hyper",
  "include_dir",
  "indexmap 2.2.6",
  "indicatif",

--- a/rust/psibase/Cargo.toml
+++ b/rust/psibase/Cargo.toml
@@ -54,6 +54,7 @@ toml = "0.8.19"
 clap = { version = "4.5", features = ["derive", "env", "string"] }
 
 hmac = "0.12"
+hyper = "0.14"
 indicatif = "0.17"
 jwt = "0.16"
 reqwest = { version = "0.11", default-features = false, features = [

--- a/services/Cargo.lock
+++ b/services/Cargo.lock
@@ -1877,6 +1877,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hmac",
+ "hyper",
  "include_dir",
  "indexmap",
  "indicatif",

--- a/services/system/StagedTx/Cargo.lock
+++ b/services/system/StagedTx/Cargo.lock
@@ -1695,6 +1695,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hmac",
+ "hyper",
  "include_dir",
  "indexmap",
  "indicatif",

--- a/services/user/Branding/Cargo.lock
+++ b/services/user/Branding/Cargo.lock
@@ -1605,6 +1605,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hmac",
+ "hyper",
  "include_dir",
  "indexmap",
  "indicatif",

--- a/services/user/Brotli/Cargo.lock
+++ b/services/user/Brotli/Cargo.lock
@@ -1604,6 +1604,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hmac",
+ "hyper",
  "include_dir",
  "indexmap",
  "indicatif",

--- a/services/user/Chainmail/Cargo.lock
+++ b/services/user/Chainmail/Cargo.lock
@@ -1605,6 +1605,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hmac",
+ "hyper",
  "include_dir",
  "indexmap",
  "indicatif",

--- a/services/user/Registry/Cargo.lock
+++ b/services/user/Registry/Cargo.lock
@@ -1586,6 +1586,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hmac",
+ "hyper",
  "include_dir",
  "indexmap",
  "indicatif",

--- a/services/user/XAdmin/ui/src/configuration/configuration-page.tsx
+++ b/services/user/XAdmin/ui/src/configuration/configuration-page.tsx
@@ -187,7 +187,7 @@ export const ConfigurationForm = ({
                                 </div>
                                 <div className="grid w-full items-center gap-1.5">
                                     <Label>Host</Label>
-                                    <Input {...configForm.register("host")} />
+                                    <Input {...configForm.register("hosts")} />
                                 </div>
                             </div>
                             <div>

--- a/services/user/XAdmin/ui/src/configuration/configuration-page.tsx
+++ b/services/user/XAdmin/ui/src/configuration/configuration-page.tsx
@@ -67,6 +67,11 @@ export const ConfigurationForm = ({
         name: "services",
     });
 
+    const hosts = useFieldArray({
+        control: configForm.control,
+        name: "hosts",
+    });
+
     const onConfig = async (input: PsinodeConfigUI) => {
         for (let service of input.services) {
             if (service.host == "") {
@@ -139,7 +144,11 @@ export const ConfigurationForm = ({
     const loggers = configForm.watch("loggers");
 
     const onAddNewListenerClick = () => {
-        listeners.append({ key: newId(), text: "", protocol: "http" });
+        listeners.append({ key: newId(), port: undefined, protocol: "http" });
+    };
+
+    const onAddNewHostClick = () => {
+        hosts.append({ key: newId(), host: "" });
     };
 
     return (
@@ -185,10 +194,54 @@ export const ConfigurationForm = ({
                                         {...configForm.register("producer")}
                                     />
                                 </div>
-                                <div className="grid w-full items-center gap-1.5">
-                                    <Label>Host</Label>
-                                    <Input {...configForm.register("hosts")} />
-                                </div>
+                            </div>
+                            <div>
+                                <h4 className="my-4 scroll-m-20 text-xl font-semibold tracking-tight">
+                                    Hosts
+                                </h4>
+
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th className="flex flex-row-reverse ">
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={(e) => {
+                                                        e.preventDefault();
+                                                        onAddNewHostClick();
+                                                    }}
+                                                >
+                                                    +
+                                                </Button>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {hosts.fields.map((h, idx: number) => (
+                                            <tr key={h.key}>
+                                                <td>
+                                                    <Input
+                                                        type="text"
+                                                        {...configForm.register(
+                                                            `hosts.${idx}.host`
+                                                        )}
+                                                    />
+                                                </td>
+                                                <td>
+                                                    <Button
+                                                        variant="secondary"
+                                                        onClick={() =>
+                                                            hosts.remove(idx)
+                                                        }
+                                                    >
+                                                        <Trash size={16} />
+                                                    </Button>
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
                             </div>
                             <div>
                                 <h4 className="my-4 scroll-m-20 text-xl font-semibold tracking-tight">

--- a/services/user/XAdmin/ui/src/configuration/interfaces.ts
+++ b/services/user/XAdmin/ui/src/configuration/interfaces.ts
@@ -18,11 +18,17 @@ export type ListenConfig = {
     text?: string;
 };
 
+export type HostConfig = {
+    host: string;
+    // auto-generated
+    key: string;
+};
+
 export type PsinodeConfigUI = {
     p2p: boolean;
     peers: string[];
     producer: string;
-    hosts: string[];
+    hosts: HostConfig[];
     port?: number;
     listen: ListenConfig[];
     services: ServiceConfig[];

--- a/services/user/XAdmin/ui/src/configuration/interfaces.ts
+++ b/services/user/XAdmin/ui/src/configuration/interfaces.ts
@@ -22,7 +22,7 @@ export type PsinodeConfigUI = {
     p2p: boolean;
     peers: string[];
     producer: string;
-    host: string;
+    hosts: string[];
     port?: number;
     listen: ListenConfig[];
     services: ServiceConfig[];
@@ -72,7 +72,7 @@ export const psinodeConfigSchema = z
             trustfiles: path.array(),
         }),
         producer: z.string(),
-        host: z.string(),
+        hosts: z.string().array(),
         port: z.number().optional(),
         admin_authz: z
             .object({

--- a/services/user/XAdmin/ui/src/configuration/utils.ts
+++ b/services/user/XAdmin/ui/src/configuration/utils.ts
@@ -6,17 +6,6 @@ import {
     PsinodeConfigUpdate,
 } from "./interfaces";
 
-export const initialConfigForm = (): PsinodeConfigUI => ({
-    p2p: false,
-    producer: "",
-    hosts: [],
-    peers: [],
-    listen: [],
-    services: [{ host: "", root: "", key: "x" }],
-    admin: "",
-    loggers: {},
-});
-
 export const emptyService = (s: ServiceConfig) => {
     return s.host == "" && s.root == "";
 };
@@ -255,7 +244,7 @@ function writeListen(listen: ListenConfig): any {
         return {
             protocol: listen.protocol,
             address: "0.0.0.0",
-            port: Number(listen.text),
+            port: Number(listen.port),
         };
     } else if (listen.protocol == "local") {
         return { protocol: listen.protocol, path: listen.text };
@@ -273,7 +262,7 @@ export const mergeConfig = (
         ...updated,
         p2p: mergeSimple(prev.p2p, updated.p2p, user.p2p),
         producer: mergeSimple(prev.producer, updated.producer, user.producer),
-        hosts: mergeSimple(prev.hosts, updated.hosts, user.hosts),
+        hosts: mergeList(prev.hosts, updated.hosts, user.hosts),
         listen: mergeList(prev.listen, updated.listen, user.listen),
         services: mergeList(
             prev.services.filter((item) => !emptyService(item)),
@@ -294,6 +283,7 @@ export const writeConfig = (input: PsinodeConfigUI): PsinodeConfigUpdate => ({
             host: s.host,
             root: s.root,
         })),
+    hosts: input.hosts.map((h) => h.host),
     admin: input.admin != "" ? input.admin : null,
     loggers: writeLoggers(input.loggers),
 });

--- a/services/user/XAdmin/ui/src/configuration/utils.ts
+++ b/services/user/XAdmin/ui/src/configuration/utils.ts
@@ -1,18 +1,15 @@
-import { UseFormReturn } from "react-hook-form";
 import { LogConfig } from "../log/interfaces";
-import { readLoggers } from "../log/utils";
 import {
     PsinodeConfigUI,
     ServiceConfig,
     ListenConfig,
-    PsinodeConfigSelect,
     PsinodeConfigUpdate,
 } from "./interfaces";
 
 export const initialConfigForm = (): PsinodeConfigUI => ({
     p2p: false,
     producer: "",
-    host: "",
+    hosts: [],
     peers: [],
     listen: [],
     services: [{ host: "", root: "", key: "x" }],
@@ -276,7 +273,7 @@ export const mergeConfig = (
         ...updated,
         p2p: mergeSimple(prev.p2p, updated.p2p, user.p2p),
         producer: mergeSimple(prev.producer, updated.producer, user.producer),
-        host: mergeSimple(prev.host, updated.host, user.host),
+        hosts: mergeSimple(prev.hosts, updated.hosts, user.hosts),
         listen: mergeList(prev.listen, updated.listen, user.listen),
         services: mergeList(
             prev.services.filter((item) => !emptyService(item)),

--- a/services/user/XAdmin/ui/src/hooks/useConfig.ts
+++ b/services/user/XAdmin/ui/src/hooks/useConfig.ts
@@ -18,6 +18,10 @@ const transformConfigServerToUI = (
             ...listen,
             key: listen.protocol + listen.address + listen.path + listen.port,
         })),
+        hosts: serverConfig.hosts.map((host, index) => ({
+            host,
+            key: host + index.toString(),
+        })),
         services: serverConfig.services.map((service, index) => ({
             ...service,
             key: service.host + service.root + index.toString(),


### PR DESCRIPTION
localhost is reserved as a top level domain and browsers consider it and its subdomains secure, even over HTTP.

- To allow localhost:8080 to reach boot, all requests redirect to x-admin when the chain is not booted.
- To avoid a disruptive transition, I added the ability to have multiple host names.

TODO:
- [x] Config read needs to parse changes to config format (hosts instead of host)
- [x] Config editor needs to allow multiple hosts
- [x] psibase should not depend on DNS to resolve *.localhost