### PR TITLE
better changelog categories

### DIFF
--- a/.github/workflows/changelog-template.json
+++ b/.github/workflows/changelog-template.json
@@ -1,0 +1,90 @@
+{
+    "template": "# Changelog\n#{{CHANGELOG}}## 📦 Uncategorized\n\n#{{UNCATEGORIZED}}\n\n# Associated docker images\n\nDocker images for this release of the psinode and psibase tools are available in GitHub container registry.\n  * [psinode](https://github.com/orgs/gofractally/packages/container/package/psinode)\n  * [psibase](https://github.com/orgs/gofractally/packages/container/package/psibase)\n\n# Contributors\n\n#{{CONTRIBUTORS}}",
+    "pr_template": "- [(PR ##{{NUMBER}})](#{{URL}})  |  #{{TITLE}}",
+    "ignore_labels": [
+        "no-log"
+    ],
+    "categories": [
+        {
+            "title": "## 🚀 Applications",
+            "labels": [
+                "System app"
+            ],
+            "consume": true,
+            "categories": [
+                {
+                    "title": "### 🐛 Bugfixes",
+                    "labels": [
+                        "bug"
+                    ]
+                },
+                {
+                    "title": "### 📚 Documentation",
+                    "labels": [
+                        "documentation"
+                    ]
+                },
+                {
+                    "title": "### 🔧 Refactoring",
+                    "labels": [
+                        "refactoring"
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "## 💻 Development experience",
+            "labels": [
+                "Dev Experience"
+            ],
+            "consume": true,
+            "categories": [
+                {
+                    "title": "### 🐛 Bugfixes",
+                    "labels": [
+                        "bug"
+                    ]
+                },
+                {
+                    "title": "### 📚 Documentation",
+                    "labels": [
+                        "documentation"
+                    ]
+                },
+                {
+                    "title": "### 🔧 Refactoring",
+                    "labels": [
+                        "refactoring"
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "## 🏗️ Infrastructure Providers",
+            "labels": [
+                "Node infra"
+            ],
+            "consume": true,
+            "categories": [
+                {
+                    "title": "### 🐛 Bugfixes",
+                    "labels": [
+                        "bug"
+                    ]
+                },
+                {
+                    "title": "### 📚 Documentation",
+                    "labels": [
+                        "documentation"
+                    ]
+                },
+                {
+                    "title": "### 🔧 Refactoring",
+                    "labels": [
+                        "refactoring"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -24,100 +24,23 @@ on:
         description: "The generated changelog"
         value: ${{ jobs.auto-generate-changelog.outputs.changelog }}
 
-env:
-  CONFIG_JSON: |
-            {
-              "template": "# Changelog\n#{{CHANGELOG}}\n\n## 📦 Uncategorized\n\n#{{UNCATEGORIZED}}\n\n",
-              "pr_template": "- [(PR ##{{NUMBER}})](#{{URL}})  |  #{{TITLE}}",
-              "ignore_labels": ["no-log"],
-              "categories": [
-                {
-                    "title": "## 💻 Development experience",
-                    "labels": ["Dev Experience", "Plugin Infra"],
-                    "exclude_labels": ["documentation", "bug"]
-                },
-                {
-                    "title": "### Bugfixes",
-                    "labels": ["Dev Experience", "bug"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "### Plugin bugfixes",
-                    "labels": ["Plugin Infra", "bug"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "### Docs",
-                    "labels": ["Dev Experience", "documentation"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "### Plugin-related docs",
-                    "labels": ["Plugin Infra", "documentation"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "## 🚀 Default apps",
-                    "labels": ["System app"],
-                    "exclude_labels": ["documentation", "bug"]
-                },
-                {
-                    "title": "### Bugfixes",
-                    "labels": ["System app", "bug"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "### Docs",
-                    "labels": ["System app", "documentation"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "## ⚖️ Governance",
-                    "labels": ["Governance"],
-                    "exclude_labels": ["documentation", "bug"]
-                },
-                {
-                    "title": "### Bugfixes",
-                    "labels": ["Governance", "bug"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "### Docs",
-                    "labels": ["Governance", "documentation"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "## 🏗️ Infrastructure Providers",
-                    "labels": ["Node infra"],
-                    "exclude_labels": ["documentation", "bug"]
-                },
-                {
-                    "title": "### Bugfixes",
-                    "labels": ["Node infra", "bug"],
-                    "exhaustive": true
-                },
-                {
-                    "title": "### Docs",
-                    "labels": ["Node infra", "documentation"],
-                    "exhaustive": true
-                }
-              ]
-            }
-
 jobs:
   generate-custom-changelog:
     if: github.event_name == 'workflow_dispatch'
     name: Gen notes ${{ github.event.inputs.starttag }} - ${{ github.event.inputs.endtag }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - id: read_config
+        run: echo "config=$(jq -c . .github/workflows/changelog-template.json)" >> $GITHUB_OUTPUT
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@v5.1.0
         with:
           failOnError: true
           fromTag: ${{ github.event.inputs.starttag }}
           toTag: ${{ github.event.inputs.endtag }}
-          configurationJson: ${{ env.CONFIG_JSON }}
+          configurationJson: ${{ steps.read_config.outputs.config }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Write to file
@@ -130,7 +53,6 @@ jobs:
           name: changelog.md
           path: changelog.md
 
-
   auto-generate-changelog:
     if: ${{ inputs.externalCall }}
     name: Gen ${{ inputs.endtag }} notes
@@ -138,13 +60,16 @@ jobs:
     outputs:
       changelog: ${{ steps.build_changelog.outputs.changelog }}
     steps:
+      - uses: actions/checkout@v4
+      - id: read_config
+        run: echo "config=$(jq -c . .github/workflows/changelog-template.json)" >> $GITHUB_OUTPUT
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@v5.1.0
         with:
           failOnError: true
           toTag: ${{ github.event.inputs.endtag }}
-          configurationJson: ${{ env.CONFIG_JSON }}
+          configurationJson: ${{ steps.read_config.outputs.config }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Write to file


### PR DESCRIPTION
Updates changelog generator version, should produce better/more consistent changelogs.
The action finally supports [nested categories](https://github.com/mikepenz/release-changelog-builder-action/pull/1308).

Also adds a contributors section to the changelog