### PR TITLE
Show the error message even if there are no action traces.

### DIFF
--- a/rust/psibase/src/trace.rs
+++ b/rust/psibase/src/trace.rs
@@ -208,10 +208,10 @@ fn format_transaction_error_stack<T: std::fmt::Write>(
 ) -> fmt::Result {
     for a in &ttrace.action_traces {
         format_error_stack(a, f)?;
-        if let Some(message) = &ttrace.error {
-            writeln!(f, "{}", message)?;
-        }
         break;
+    }
+    if let Some(message) = &ttrace.error {
+        writeln!(f, "{}", message)?;
     }
     Ok(())
 }


### PR DESCRIPTION
```
Error: Failed to boot

Caused by:
```