### PR TITLE
Fix failed transactions that emit events

### DIFF
--- a/libraries/psibase/native/include/psibase/BlockContext.hpp
+++ b/libraries/psibase/native/include/psibase/BlockContext.hpp
@@ -15,7 +15,6 @@ namespace psibase
       WriterPtr         writer;
       Database::Session session;
       Block             current;
-      DatabaseStatusRow databaseStatus;
       bool              isProducing       = false;
       bool              isReadOnly        = false;
       bool              isGenesisBlock    = false;

--- a/libraries/psibase/native/src/NativeFunctions.cpp
+++ b/libraries/psibase/native/src/NativeFunctions.cpp
@@ -579,17 +579,20 @@ namespace psibase
                       "value of putSequential must have service account as its first member");
              }
 
-             auto&    dbStatus = transactionContext.blockContext.databaseStatus;
+             auto dbStatus =
+                 database.kvGet<DatabaseStatusRow>(DatabaseStatusRow::db, databaseStatusKey());
+             check(!!dbStatus, "databaseStatus not set");
+
              uint64_t indexNumber;
              if (db == uint32_t(DbId::historyEvent))
-                indexNumber = dbStatus.nextHistoryEventNumber++;
+                indexNumber = dbStatus->nextHistoryEventNumber++;
              else if (db == uint32_t(DbId::uiEvent))
-                indexNumber = dbStatus.nextUIEventNumber++;
+                indexNumber = dbStatus->nextUIEventNumber++;
              else if (db == uint32_t(DbId::merkleEvent))
-                indexNumber = dbStatus.nextMerkleEventNumber++;
+                indexNumber = dbStatus->nextMerkleEventNumber++;
              else
                 check(false, "putSequential: unsupported db");
-             database.kvPut(DatabaseStatusRow::db, dbStatus.key(), dbStatus);
+             database.kvPut(DatabaseStatusRow::db, dbStatus->key(), *dbStatus);
 
              database.kvPutRaw(m, psio::convert_to_key(indexNumber), {value.data(), value.size()});
              return indexNumber;

--- a/services/psibase_tests/event-service.cpp
+++ b/services/psibase_tests/event-service.cpp
@@ -14,4 +14,10 @@ psibase::EventNumber EventService::emitMerkle(std::string s)
    return emit().merkle().m(s);
 }
 
+psibase::EventNumber EventService::emitFail(std::string s, int i)
+{
+   emit().history().e(s, i);
+   abortMessage("die");
+}
+
 PSIBASE_DISPATCH(EventService)

--- a/services/psibase_tests/event-service.hpp
+++ b/services/psibase_tests/event-service.hpp
@@ -22,9 +22,10 @@ struct EventService : psibase::Service
    };
    psibase::EventNumber foo(std::string s, int i);
    psibase::EventNumber emitMerkle(std::string);
+   psibase::EventNumber emitFail(std::string s, int i);
 };
 
-PSIO_REFLECT(EventService, method(foo, s, i), method(emitMerkle, s))
+PSIO_REFLECT(EventService, method(foo, s, i), method(emitMerkle, s), method(emitFail, s, i))
 PSIBASE_REFLECT_EVENTS(EventService)
 
 PSIBASE_REFLECT_HISTORY_EVENTS(EventService, method(e, s, i))

--- a/services/psibase_tests/test_event.cpp
+++ b/services/psibase_tests/test_event.cpp
@@ -77,3 +77,17 @@ TEST_CASE("test merkle events")
       CHECK(expected_root == actual_root);
    }
 }
+
+TEST_CASE("test event in failed transaction")
+{
+   DefaultTestChain t;
+
+   auto event_service =
+       t.from(t.addService("event-service"_a, "event-service.wasm")).to<EventService>();
+
+   auto id1 = event_service.foo("a", 1).returnVal();
+   auto id2 = event_service.foo("b", 2).returnVal();
+   CHECK(event_service.emitFail("c", 3).failed("die"));
+   auto id3 = event_service.foo("d", 4).returnVal();
+   CHECK(id2 - id1 == id3 - id2);
+}


### PR DESCRIPTION
This would brick the chain because `putSequential` used a cached member variable which was not rolled back when the transaction aborted. Remove `BlockContext::databaseStatus` and just look it up as needed.