### PR TITLE
View and manage security devices and keys in XAdmin UI

### DIFF
--- a/services/user/XAdmin/ui/src/components/EmptyBlock.tsx
+++ b/services/user/XAdmin/ui/src/components/EmptyBlock.tsx
@@ -1,4 +1,4 @@
-import { FilePlus2 } from "lucide-react";
+import { FilePlus2, type LucideProps } from "lucide-react";
 import { Button } from "./ui/button";
 
 interface Props {
@@ -6,6 +6,9 @@ interface Props {
     description?: string;
     buttonLabel: string;
     onClick: () => void;
+    ButtonIcon?: React.ForwardRefExoticComponent<
+        Omit<LucideProps, "ref"> & React.RefAttributes<SVGSVGElement>
+    >;
 }
 
 export const EmptyBlock = ({
@@ -13,11 +16,12 @@ export const EmptyBlock = ({
     title,
     onClick,
     buttonLabel,
+    ButtonIcon = FilePlus2,
 }: Props) => {
     return (
         <div className="flex h-[450px] shrink-0 items-center justify-center rounded-md border border-dashed">
             <div className="mx-auto flex max-w-[420px] flex-col items-center justify-center text-center">
-                <FilePlus2 className="h-12 w-12 " />
+                <ButtonIcon className="h-12 w-12 " />
                 <h3 className="mt-4 text-lg font-semibold">{title}</h3>
                 {description && (
                     <p className="mb-4 mt-2 text-sm text-muted-foreground">

--- a/services/user/XAdmin/ui/src/components/EmptyBlock.tsx
+++ b/services/user/XAdmin/ui/src/components/EmptyBlock.tsx
@@ -4,8 +4,8 @@ import { Button } from "./ui/button";
 interface Props {
     title: string;
     description?: string;
-    buttonLabel: string;
-    onClick: () => void;
+    buttonLabel?: string;
+    onClick?: () => void;
     ButtonIcon?: React.ForwardRefExoticComponent<
         Omit<LucideProps, "ref"> & React.RefAttributes<SVGSVGElement>
     >;
@@ -28,9 +28,11 @@ export const EmptyBlock = ({
                         {description}
                     </p>
                 )}
-                <Button size="sm" onClick={() => onClick()}>
-                    {buttonLabel}
-                </Button>
+                {buttonLabel && (
+                    <Button size="sm" onClick={() => onClick?.()}>
+                        {buttonLabel}
+                    </Button>
+                )}
             </div>
         </div>
     );

--- a/services/user/XAdmin/ui/src/components/nav-header.tsx
+++ b/services/user/XAdmin/ui/src/components/nav-header.tsx
@@ -1,5 +1,7 @@
 import { NavLink } from "react-router-dom";
 
+import { siblingUrl } from "@psibase/common-lib";
+
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { HoverBorderGradient } from "./hover-border-gradient";
@@ -10,10 +12,10 @@ import { useStatuses } from "../hooks/useStatuses";
 const Loading = () => <div>Loading...</div>;
 
 export const NavHeader = ({ title }: { title?: string }) => {
-    const { data: networkName } = useBranding();
     const { data: status, isLoading } = useStatuses();
-
     const isBootable = status && status.includes("needgenesis");
+
+    const { data: networkName } = useBranding({ enabled: !isBootable });
 
     const menuItems = [
         "Dashboard",
@@ -31,15 +33,17 @@ export const NavHeader = ({ title }: { title?: string }) => {
     return (
         <header className="mx-auto my-4 flex max-w-7xl justify-between">
             <div className="mr-12 flex items-center">
-                <div className="flex justify-center text-center">
-                    <HoverBorderGradient
-                        as="div"
-                        containerClassName="rounded-full"
-                        className="flex items-center space-x-2 bg-white text-black dark:bg-black dark:text-white"
-                    >
-                        <span>{networkName || "Network"}</span>
-                    </HoverBorderGradient>
-                </div>
+                <a href={siblingUrl()} title={`${networkName} home`}>
+                    <div className="flex justify-center text-center">
+                        <HoverBorderGradient
+                            as="div"
+                            containerClassName="rounded-full"
+                            className="flex items-center space-x-2 bg-white text-black dark:bg-black dark:text-white"
+                        >
+                            <span>{networkName || "Network"}</span>
+                        </HoverBorderGradient>
+                    </div>
+                </a>
             </div>
             {title && (
                 <h1 className=" scroll-m-20 text-4xl font-extrabold tracking-tight">

--- a/services/user/XAdmin/ui/src/components/nav-header.tsx
+++ b/services/user/XAdmin/ui/src/components/nav-header.tsx
@@ -8,12 +8,16 @@ import { HoverBorderGradient } from "./hover-border-gradient";
 import { MenuContent } from "./menu-content";
 import { useBranding } from "../hooks/useBranding";
 import { useStatuses } from "../hooks/useStatuses";
+import { useKeyDevices } from "../hooks/useKeyDevices";
 
 const Loading = () => <div>Loading...</div>;
 
 export const NavHeader = ({ title }: { title?: string }) => {
     const { data: status, isLoading } = useStatuses();
+    const { data: keyDevices } = useKeyDevices();
+
     const isBootable = status && status.includes("needgenesis");
+    const hasKeyDevices = keyDevices && keyDevices.length > 0;
 
     const { data: networkName } = useBranding({ enabled: !isBootable });
 
@@ -22,7 +26,7 @@ export const NavHeader = ({ title }: { title?: string }) => {
         "Peers",
         "Logs",
         "Configuration",
-        "Keys and devices",
+        ...(hasKeyDevices ? ["Keys and devices"] : []),
         ...(isBootable ? ["Boot"] : []),
     ];
 

--- a/services/user/XAdmin/ui/src/components/nav-header.tsx
+++ b/services/user/XAdmin/ui/src/components/nav-header.tsx
@@ -1,12 +1,16 @@
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { MenuContent } from "./menu-content";
 import { NavLink } from "react-router-dom";
-import { useStatuses } from "../hooks/useStatuses";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
 import { HoverBorderGradient } from "./hover-border-gradient";
+import { MenuContent } from "./menu-content";
+import { useBranding } from "../hooks/useBranding";
+import { useStatuses } from "../hooks/useStatuses";
 
 const Loading = () => <div>Loading...</div>;
 
 export const NavHeader = ({ title }: { title?: string }) => {
+    const { data: networkName } = useBranding();
     const { data: status, isLoading } = useStatuses();
 
     const isBootable = status && status.includes("needgenesis");
@@ -16,6 +20,7 @@ export const NavHeader = ({ title }: { title?: string }) => {
         "Peers",
         "Logs",
         "Configuration",
+        "Keys and devices",
         ...(isBootable ? ["Boot"] : []),
     ];
 
@@ -26,15 +31,15 @@ export const NavHeader = ({ title }: { title?: string }) => {
     return (
         <header className="mx-auto my-4 flex max-w-7xl justify-between">
             <div className="mr-12 flex items-center">
-                <div className=" flex justify-center text-center">
+                <div className="flex justify-center text-center">
                     <HoverBorderGradient
                         as="div"
                         containerClassName="rounded-full"
                         className="flex items-center space-x-2 bg-white text-black dark:bg-black dark:text-white"
                     >
-                        <span>psibase</span>
+                        <span>{networkName || "Network"}</span>
                     </HoverBorderGradient>
-                </div>{" "}
+                </div>
             </div>
             {title && (
                 <h1 className=" scroll-m-20 text-4xl font-extrabold tracking-tight">
@@ -46,7 +51,10 @@ export const NavHeader = ({ title }: { title?: string }) => {
                     <Tabs>
                         <TabsList>
                             {menuItems.map((item) => (
-                                <NavLink key={item} to={item}>
+                                <NavLink
+                                    key={item}
+                                    to={item.split(" ").join("-").toLowerCase()}
+                                >
                                     {({ isActive }) => (
                                         <TabsTrigger
                                             value={item}

--- a/services/user/XAdmin/ui/src/configuration/interfaces.ts
+++ b/services/user/XAdmin/ui/src/configuration/interfaces.ts
@@ -42,6 +42,11 @@ export type KeyDevice = {
     unlocked: boolean;
 };
 
+export type ServerKey = {
+    rawData: string;
+    service: string;
+};
+
 const port = z.coerce.number();
 
 const LogConfigSchema = z.object({

--- a/services/user/XAdmin/ui/src/hooks/useBranding.ts
+++ b/services/user/XAdmin/ui/src/hooks/useBranding.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { z } from "zod";
+
+import { queryKeys } from "@/lib/queryKeys";
+
+export const useBranding = () =>
+    useQuery({
+        queryKey: [queryKeys.branding],
+        queryFn: async () => {
+            // supervisor is only available after the chain boots
+            const s = await import("@psibase/common-lib");
+            const supervisor = new s.Supervisor();
+            const res = await supervisor.functionCall({
+                service: "branding",
+                intf: "queries",
+                method: "getNetworkName",
+                params: [],
+            });
+            return z.string().parse(res);
+        },
+    });

--- a/services/user/XAdmin/ui/src/hooks/useBranding.ts
+++ b/services/user/XAdmin/ui/src/hooks/useBranding.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { queryKeys } from "@/lib/queryKeys";
 
-export const useBranding = () =>
+export const useBranding = ({ enabled = false }: { enabled?: boolean }) =>
     useQuery({
         queryKey: [queryKeys.branding],
         queryFn: async () => {
@@ -18,4 +18,5 @@ export const useBranding = () =>
             });
             return z.string().parse(res);
         },
+        enabled,
     });

--- a/services/user/XAdmin/ui/src/hooks/useKeyDevices.ts
+++ b/services/user/XAdmin/ui/src/hooks/useKeyDevices.ts
@@ -17,6 +17,19 @@ export const useKeyDevices = () =>
         },
     });
 
+export const useServerKeys = () =>
+    useQuery({
+        queryKey: queryKeys.serverKeys,
+        queryFn: async () => {
+            try {
+                return await chain.getServerKeys();
+            } catch (e) {
+                console.error("Failed to fetch server keys", e);
+                throw new Error("Failed to fetch server keys");
+            }
+        },
+    });
+
 export const useAddServerKey = () =>
     useMutation<CryptoKey, string, string>({
         mutationKey: queryKeys.addServerKey,

--- a/services/user/XAdmin/ui/src/lib/chainEndpoints.ts
+++ b/services/user/XAdmin/ui/src/lib/chainEndpoints.ts
@@ -14,6 +14,7 @@ import {
     type KeyDevice,
     type PsinodeConfigSelect,
     type PsinodeConfigUpdate,
+    type ServerKey,
     psinodeConfigSchema,
 } from "../configuration/interfaces";
 import { putJson } from "../helpers";
@@ -206,7 +207,7 @@ class Chain {
     }: {
         key?: string;
         device?: string;
-    }): Promise<{ rawData: string; service: string }[]> {
+    }): Promise<ServerKey[]> {
         const res = await postJson("/native/admin/keys", {
             service: "verify-sig",
             rawData: key,
@@ -224,6 +225,10 @@ class Chain {
             device,
             pin,
         });
+    }
+
+    public getServerKeys(): Promise<ServerKey[]> {
+        return getJson("/native/admin/keys");
     }
 }
 

--- a/services/user/XAdmin/ui/src/lib/keys.ts
+++ b/services/user/XAdmin/ui/src/lib/keys.ts
@@ -1,7 +1,7 @@
-function arrayBufferToHex(buffer: ArrayBuffer): string {
+function arrayBufferToHex(buffer: ArrayBuffer, separator: string = ""): string {
     return Array.from(new Uint8Array(buffer))
         .map((byte) => byte.toString(16).padStart(2, "0"))
-        .join("");
+        .join(separator);
 }
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
@@ -87,4 +87,10 @@ export async function exportKeyToPEM(
         console.error(`Error exporting ${keyType} to PEM format:`, error);
         throw error;
     }
+}
+
+export async function calculateKeyFingerprint(hexDER: string): Promise<string> {
+    const derBuffer = hexToArrayBuffer(hexDER);
+    const hashBuffer = await crypto.subtle.digest("SHA-256", derBuffer);
+    return arrayBufferToHex(hashBuffer, ":");
 }

--- a/services/user/XAdmin/ui/src/lib/queryKeys.ts
+++ b/services/user/XAdmin/ui/src/lib/queryKeys.ts
@@ -6,9 +6,11 @@ export const queryKeys = {
     packages: ["packages"] as const,
     peers: ["peers"] as const,
     statuses: ["statuses"] as const,
+    branding: ["branding"] as const,
 
     // security devices
     addServerKey: ["addServerKey"] as const,
     keyDevices: ["keyDevices"] as const,
     unlockKeyDevice: ["unlockKeyDevice"] as const,
+    serverKeys: ["serverKeys"] as const,
 };

--- a/services/user/XAdmin/ui/src/pages/create-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/create-page.tsx
@@ -31,6 +31,7 @@ import { bootChain } from "@/lib/bootChain";
 import { calculateIndex } from "@/lib/calculateIndex";
 import { getId } from "@/lib/getId";
 import { getRequiredPackages } from "@/lib/getRequiredPackages";
+import { generateP256Key } from "@/lib/keys";
 
 // types
 import {
@@ -54,7 +55,6 @@ import { getDefaultSelectedPackages } from "../hooks/useTemplatedPackages";
 // relative imports
 import { SetupWrapper } from "./setup-wrapper";
 import { DependencyDialog } from "./dependency-dialog";
-import { generateP256Key } from "@/lib/keys";
 
 export const BlockProducerSchema = z.object({
     name: z.string().min(1),

--- a/services/user/XAdmin/ui/src/pages/create-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/create-page.tsx
@@ -6,6 +6,13 @@ import { z } from "zod";
 
 // ShadCN UI Imports
 import { useToast } from "@/components/ui/use-toast";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
 
 // components
 import {
@@ -29,6 +36,7 @@ import { getRequiredPackages } from "@/lib/getRequiredPackages";
 import {
     BootCompleteSchema,
     BootCompleteUpdate,
+    KeyDeviceSchema,
     PackageInfo,
     RequestUpdate,
     RequestUpdateSchema,
@@ -50,11 +58,6 @@ import { generateP256Key } from "@/lib/keys";
 
 export const BlockProducerSchema = z.object({
     name: z.string().min(1),
-});
-
-export const KeyDeviceSchema = z.object({
-    id: z.string().min(1),
-    pin: z.string().optional(),
 });
 
 interface DependencyState {
@@ -310,7 +313,24 @@ export const CreatePage = () => {
                     )}
                     {currentStep === Step.KeyDevice && (
                         <div className="flex justify-center">
-                            <KeyDeviceForm form={keyDeviceForm} next={next} />
+                            <Card className="min-w-[350px]">
+                                <CardHeader>
+                                    <CardTitle>
+                                        Select security device
+                                    </CardTitle>
+                                    <CardDescription>
+                                        Where do you want your block producer
+                                        server key to be stored?
+                                    </CardDescription>
+                                </CardHeader>
+                                <CardContent>
+                                    <KeyDeviceForm
+                                        form={keyDeviceForm}
+                                        next={next}
+                                        deviceNotFoundErrorMessage="No security devices were found. Please ensure one is available. Alternatively, you may boot in an insecure keyless mode by going back and selecting the Development boot template."
+                                    />
+                                </CardContent>
+                            </Card>
                         </div>
                     )}
                     {currentStep === Step.Confirmation && (

--- a/services/user/XAdmin/ui/src/pages/keys-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/keys-page.tsx
@@ -1,6 +1,4 @@
-// TODO: Do not display this tab if the server is booted without any key devices
-// TODO: Psibase pill link (invalidate at boot or peer so updated name appears and link to home)
-
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import {
@@ -12,8 +10,9 @@ import {
     FolderKey,
     CircleAlert,
     Loader2,
+    Lock,
+    Unlock,
 } from "lucide-react";
-import { useEffect, useState } from "react";
 
 import {
     Table,
@@ -39,16 +38,24 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog";
+import { ToastAction } from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
+import { Tabs } from "@/components/ui/tabs";
+import { TabsList } from "@/components/ui/tabs";
+import { TabsTrigger } from "@/components/ui/tabs";
+import { TabsContent } from "@/components/ui/tabs";
 
+import { EmptyBlock } from "@/components/EmptyBlock";
 import { KeyDeviceForm } from "@/components/forms/key-device-form";
 import { KeyDeviceSchema } from "@/types";
 import { hexDERPublicKeyToCryptoKey, exportKeyToPEM } from "@/lib/keys";
-
-import { useServerKeys, useAddServerKey } from "../hooks/useKeyDevices";
-import { EmptyBlock } from "@/components/EmptyBlock";
-import { useToast } from "@/components/ui/use-toast";
 import { getErrorMessage } from "@/lib/utils";
-import { ToastAction } from "@/components/ui/toast";
+
+import {
+    useServerKeys,
+    useAddServerKey,
+    useKeyDevices,
+} from "../hooks/useKeyDevices";
 
 const splitDerKey = (key: string) => {
     const segment0 = key.slice(0, key.length - 30);
@@ -74,41 +81,69 @@ const downloadAsFile = (content: string, filename: string) => {
 
 export const KeysPage = () => {
     const { toast } = useToast();
-    const [dialogOpen, setDialogOpen] = useState(false);
+    const [newKeyDialogOpen, setNewKeyDialogOpen] = useState(false);
+    const [unlockDialogOpen, setUnlockDialogOpen] = useState(false);
 
     const {
         data: serverKeys,
-        refetch,
-        error,
-        isError,
-        isLoading,
+        isLoading: isLoadingServerKeys,
+        error: errorFetchingServerKeys,
+        isError: isErrorFetchingServerKeys,
+        refetch: refetchServerKeys,
     } = useServerKeys();
     const { mutate: addServerKey } = useAddServerKey();
+
+    const {
+        data: keyDevices,
+        isLoading: isKeyDevicesLoading,
+        error: errorFetchingKeyDevices,
+        isError: isErrorFetchingKeyDevices,
+        refetch: refetchKeyDevices,
+    } = useKeyDevices();
+    const hasKeyDevices = keyDevices && keyDevices.length > 0;
 
     const keyDeviceForm = useForm<z.infer<typeof KeyDeviceSchema>>();
 
     useEffect(() => {
-        if (!isError) return;
+        if (!isErrorFetchingServerKeys) return;
         toast({
             variant: "destructive",
             title: "Error fetching server keys",
-            description: error?.message || "Unknown error.",
+            description: errorFetchingServerKeys?.message || "Unknown error.",
             action: (
                 <ToastAction
                     altText="Try fetch again"
-                    onClick={() => refetch()}
+                    onClick={() => refetchServerKeys()}
                 >
                     Try again
                 </ToastAction>
             ),
         });
-    }, [isError, error]);
+    }, [isErrorFetchingServerKeys, errorFetchingServerKeys]);
 
-    const onSubmit = async (e?: React.SyntheticEvent) => {
+    const onSubmit = async (
+        e?: React.SyntheticEvent,
+        shouldCreateKey: boolean = false
+    ) => {
         e?.preventDefault();
         try {
-            await addServerKey(keyDeviceForm.getValues().id);
-            setDialogOpen(false);
+            const isPassable = await keyDeviceForm.trigger();
+            if (!isPassable) return;
+
+            if (shouldCreateKey) {
+                await addServerKey(keyDeviceForm.getValues().id);
+                toast({
+                    title: "Added",
+                    description: "The key has been added to the server.",
+                });
+            } else {
+                toast({
+                    title: "Unlocked",
+                    description: "The security device has been unlocked.",
+                });
+            }
+            setNewKeyDialogOpen(false);
+            setUnlockDialogOpen(false);
         } catch (error) {
             const message = getErrorMessage(error);
             toast({
@@ -117,7 +152,11 @@ export const KeysPage = () => {
                 description: `${message || "Unknown error"}. Please try again.`,
             });
         }
-        setTimeout(refetch, 1000);
+
+        setTimeout(() => {
+            refetchServerKeys();
+            refetchKeyDevices();
+        }, 1000);
     };
 
     const copyKeyAsPEM = async (derHex: string) => {
@@ -125,6 +164,10 @@ export const KeysPage = () => {
             const cryptoKey = await hexDERPublicKeyToCryptoKey(derHex);
             const pemKey = await exportKeyToPEM(cryptoKey, "PUBLIC KEY");
             await copyToClipboard(pemKey);
+            toast({
+                title: "Copied",
+                description: "The key has been copied to the clipboard.",
+            });
         } catch (error) {
             console.error("Failed to copy key as PEM:", error);
             const message = getErrorMessage(error);
@@ -141,6 +184,10 @@ export const KeysPage = () => {
             const cryptoKey = await hexDERPublicKeyToCryptoKey(derHex);
             const pemKey = await exportKeyToPEM(cryptoKey, "PUBLIC KEY");
             downloadAsFile(pemKey, "publicKey.pem");
+            toast({
+                title: "Downloaded",
+                description: "The key has been downloaded.",
+            });
         } catch (error) {
             console.error("Failed to copy key as PEM:", error);
             const message = getErrorMessage(error);
@@ -152,7 +199,7 @@ export const KeysPage = () => {
         }
     };
 
-    if (isLoading) {
+    if (isLoadingServerKeys || isKeyDevicesLoading) {
         return (
             <main className="flex h-[450px] select-none items-center justify-center">
                 <Loader2 className="animate-spin" size={64} />
@@ -160,18 +207,21 @@ export const KeysPage = () => {
         );
     }
 
-    // there was an error and no keys have been fetched
-    if (!serverKeys && isError) {
+    // there was an error and no security devices have been fetched
+    if (!keyDevices && isErrorFetchingKeyDevices) {
         return (
             <main className="flex select-none justify-center">
                 <div className="mt-4 w-full">
                     <EmptyBlock
                         buttonLabel="Try again"
-                        onClick={refetch}
+                        onClick={() => {
+                            refetchServerKeys();
+                            refetchKeyDevices();
+                        }}
                         title="Something went wrong"
-                        description={`Server keys could not be fetched. ${
-                            error?.message
-                                ? `Error: ${error?.message}.`
+                        description={`Security devices could not be fetched. ${
+                            errorFetchingKeyDevices?.message
+                                ? `Error: ${errorFetchingKeyDevices?.message}.`
                                 : "Unknown error"
                         }.`}
                         ButtonIcon={CircleAlert}
@@ -181,137 +231,286 @@ export const KeysPage = () => {
         );
     }
 
-    // fetch was successful and there are no keys
-    if (serverKeys && serverKeys.length === 0) {
+    // there are no key devices configured for the chain
+    if (!hasKeyDevices) {
         return (
             <main className="flex select-none justify-center">
                 <div className="mt-4 w-full">
                     <EmptyBlock
-                        buttonLabel="New Key"
-                        onClick={() => setDialogOpen(true)}
-                        title="No server keys"
-                        description="There are no keys available to the server for signing."
-                        ButtonIcon={FileKey2}
+                        title="No security devices"
+                        description="No security devices were found for storing server keys. Please ensure one is available."
+                        ButtonIcon={CircleAlert}
                     />
                 </div>
             </main>
         );
     }
 
-    // fetch was successful and there are keys
+    // there was an error and no keys have been fetched
+    if (!serverKeys && isErrorFetchingServerKeys) {
+        return (
+            <main className="flex select-none justify-center">
+                <div className="mt-4 w-full">
+                    <EmptyBlock
+                        buttonLabel="Try again"
+                        onClick={() => {
+                            refetchServerKeys();
+                            refetchKeyDevices();
+                        }}
+                        title="Something went wrong"
+                        description={`Server keys could not be fetched. ${
+                            errorFetchingServerKeys?.message
+                                ? `Error: ${errorFetchingServerKeys?.message}.`
+                                : "Unknown error"
+                        }.`}
+                        ButtonIcon={CircleAlert}
+                    />
+                </div>
+            </main>
+        );
+    }
+
     return (
         <main className="flex select-none justify-center">
-            <div className="space-y-2">
-                <div className="flex justify-end">
-                    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-                        <DialogTrigger asChild>
-                            <Button size="sm" variant="outline">
-                                <SquarePlus className="mr-2 h-4 w-4" />
-                                New key
-                            </Button>
-                        </DialogTrigger>
-                        <DialogContent className="sm:max-w-[425px]">
-                            <DialogHeader>
-                                <DialogTitle>Create a new key</DialogTitle>
-                                <DialogDescription>
-                                    Which device do you want to generate a key
-                                    with?
-                                </DialogDescription>
-                            </DialogHeader>
-                            <KeyDeviceForm
-                                form={keyDeviceForm}
-                                next={onSubmit}
-                                deviceNotFoundErrorMessage="No security devices were found. Please ensure one is available."
-                            />
-                            <DialogFooter>
-                                <Button type="submit" onClick={onSubmit}>
-                                    Create key
-                                </Button>
-                            </DialogFooter>
-                        </DialogContent>
-                    </Dialog>
-                </div>
-                <div className="rounded-md border">
-                    <Table className="table-fixed">
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead className="w-32 text-center">
-                                    Auth service
-                                </TableHead>
-                                <TableHead className="w-full">
-                                    Public key (hex-encoded DER)
-                                </TableHead>
-                                <TableHead className="w-16 text-right"></TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {serverKeys?.map((key) => (
-                                <TableRow key={key.rawData}>
-                                    <TableCell className="px-4 py-2 text-center font-medium">
-                                        {key.service}
-                                    </TableCell>
-                                    <TableCell className="max-w-0 px-4 py-2">
-                                        <div className="flex">
-                                            <div className="truncate">
-                                                {splitDerKey(key.rawData)[0]}
-                                            </div>
-                                            <div className="shrink-0">
-                                                {splitDerKey(key.rawData)[1]}
-                                            </div>
-                                        </div>
-                                    </TableCell>
-                                    <TableCell className="px-4 py-2 text-right">
-                                        <DropdownMenu>
-                                            <DropdownMenuTrigger asChild>
-                                                <Button
-                                                    variant="ghost"
-                                                    size="icon"
-                                                >
-                                                    <MoreHorizontal className="h-4 w-4" />
-                                                    <span className="sr-only">
-                                                        Open menu
-                                                    </span>
-                                                </Button>
-                                            </DropdownMenuTrigger>
-                                            <DropdownMenuContent align="end">
-                                                <DropdownMenuItem
-                                                    onClick={() =>
-                                                        copyToClipboard(
-                                                            key.rawData
-                                                        )
-                                                    }
-                                                >
-                                                    <Copy className="mr-2 h-4 w-4" />
-                                                    Copy hex DER
-                                                </DropdownMenuItem>
-                                                <DropdownMenuItem
-                                                    onClick={() =>
-                                                        copyKeyAsPEM(
-                                                            key.rawData
-                                                        )
-                                                    }
-                                                >
-                                                    <FileKey className="mr-2 h-4 w-4" />
-                                                    Copy PEM
-                                                </DropdownMenuItem>
-                                                <DropdownMenuItem
-                                                    onClick={() =>
-                                                        downloadKeyAsPEM(
-                                                            key.rawData
-                                                        )
-                                                    }
-                                                >
-                                                    <FolderKey className="mr-2 h-4 w-4" />
-                                                    Download PEM
-                                                </DropdownMenuItem>
-                                            </DropdownMenuContent>
-                                        </DropdownMenu>
-                                    </TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                </div>
+            <div className="w-full space-y-2">
+                <Tabs defaultValue="devices" className="">
+                    <div className="flex justify-between">
+                        <TabsList>
+                            <TabsTrigger value="devices">Devices</TabsTrigger>
+                            <TabsTrigger value="keys">Keys</TabsTrigger>
+                        </TabsList>
+                        <div className="flex gap-2">
+                            <Dialog
+                                open={unlockDialogOpen}
+                                onOpenChange={setUnlockDialogOpen}
+                            >
+                                <DialogTrigger asChild>
+                                    <Button size="sm" variant="outline">
+                                        <Unlock className="mr-2 h-4 w-4" />
+                                        Unlock a device
+                                    </Button>
+                                </DialogTrigger>
+                                <DialogContent className="sm:max-w-[425px]">
+                                    <DialogHeader>
+                                        <DialogTitle>
+                                            Unlock a security device
+                                        </DialogTitle>
+                                        <DialogDescription>
+                                            Which device do you want to unlock?
+                                        </DialogDescription>
+                                    </DialogHeader>
+                                    <KeyDeviceForm
+                                        form={keyDeviceForm}
+                                        next={() => onSubmit()}
+                                        deviceNotFoundErrorMessage="No security devices were found. Please ensure one is available."
+                                    />
+                                    <DialogFooter>
+                                        <Button
+                                            type="submit"
+                                            onClick={onSubmit}
+                                        >
+                                            Unlock
+                                        </Button>
+                                    </DialogFooter>
+                                </DialogContent>
+                            </Dialog>
+                            <Dialog
+                                open={newKeyDialogOpen}
+                                onOpenChange={setNewKeyDialogOpen}
+                            >
+                                <DialogTrigger asChild>
+                                    <Button size="sm" variant="outline">
+                                        <SquarePlus className="mr-2 h-4 w-4" />
+                                        New key
+                                    </Button>
+                                </DialogTrigger>
+                                <DialogContent className="sm:max-w-[425px]">
+                                    <DialogHeader>
+                                        <DialogTitle>
+                                            Create a new key
+                                        </DialogTitle>
+                                        <DialogDescription>
+                                            Which device do you want to generate
+                                            a key with?
+                                        </DialogDescription>
+                                    </DialogHeader>
+                                    <KeyDeviceForm
+                                        form={keyDeviceForm}
+                                        next={() => onSubmit(undefined, true)}
+                                        deviceNotFoundErrorMessage="No security devices were found. Please ensure one is available."
+                                    />
+                                    <DialogFooter>
+                                        <Button
+                                            type="submit"
+                                            onClick={(e) => onSubmit(e, true)}
+                                        >
+                                            Create key
+                                        </Button>
+                                    </DialogFooter>
+                                </DialogContent>
+                            </Dialog>
+                        </div>
+                    </div>
+                    <TabsContent value="devices">
+                        <div className="rounded-md border">
+                            <Table className="table-fixed">
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead className="w-48 text-center">
+                                            Device name
+                                        </TableHead>
+                                        <TableHead className="w-full">
+                                            Device ID
+                                        </TableHead>
+                                        <TableHead className="w-24 text-center">
+                                            Status
+                                        </TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {keyDevices?.map((device) => (
+                                        <TableRow key={device.id}>
+                                            <TableCell className="px-4 py-2 text-center font-medium">
+                                                {device.name}
+                                            </TableCell>
+                                            <TableCell className="max-w-0 px-4 py-2">
+                                                {device.id}
+                                            </TableCell>
+                                            <TableCell className="mt-0.5 flex items-center justify-center px-4 py-2">
+                                                {device.unlocked ? (
+                                                    <Unlock className="h-4 w-4" />
+                                                ) : (
+                                                    <Lock
+                                                        className="h-4 w-4"
+                                                        color="red"
+                                                    />
+                                                )}
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    </TabsContent>
+                    <TabsContent value="keys">
+                        {serverKeys && serverKeys?.length === 0 ? (
+                            <div className="mt-4 w-full">
+                                <EmptyBlock
+                                    buttonLabel={
+                                        keyDevices.every((kd) => !kd.unlocked)
+                                            ? undefined
+                                            : "New Key"
+                                    }
+                                    onClick={() => setNewKeyDialogOpen(true)}
+                                    title="No server keys available"
+                                    description={
+                                        keyDevices.every((kd) => !kd.unlocked)
+                                            ? "No server keys are available. Unlock a device to view keys in that device or create a new key to continue."
+                                            : "There are no server keys available to the server for signing."
+                                    }
+                                    ButtonIcon={FileKey2}
+                                />
+                            </div>
+                        ) : (
+                            <div className="rounded-md border">
+                                <Table className="table-fixed">
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className="w-32 text-center">
+                                                Auth service
+                                            </TableHead>
+                                            <TableHead className="w-full">
+                                                Public key (hex-encoded DER)
+                                            </TableHead>
+                                            <TableHead className="w-16 text-right"></TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {serverKeys?.map((key) => (
+                                            <TableRow key={key.rawData}>
+                                                <TableCell className="px-4 py-2 text-center font-medium">
+                                                    {key.service}
+                                                </TableCell>
+                                                <TableCell className="max-w-0 px-4 py-2">
+                                                    <div className="flex">
+                                                        <div className="truncate">
+                                                            {
+                                                                splitDerKey(
+                                                                    key.rawData
+                                                                )[0]
+                                                            }
+                                                        </div>
+                                                        <div className="shrink-0">
+                                                            {
+                                                                splitDerKey(
+                                                                    key.rawData
+                                                                )[1]
+                                                            }
+                                                        </div>
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell className="px-4 py-2 text-right">
+                                                    <DropdownMenu>
+                                                        <DropdownMenuTrigger
+                                                            asChild
+                                                        >
+                                                            <Button
+                                                                variant="ghost"
+                                                                size="icon"
+                                                            >
+                                                                <MoreHorizontal className="h-4 w-4" />
+                                                                <span className="sr-only">
+                                                                    Open menu
+                                                                </span>
+                                                            </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent align="end">
+                                                            <DropdownMenuItem
+                                                                onClick={() => {
+                                                                    copyToClipboard(
+                                                                        key.rawData
+                                                                    );
+                                                                    toast({
+                                                                        title: "Copied",
+                                                                        description:
+                                                                            "The key has been copied to the clipboard.",
+                                                                    });
+                                                                }}
+                                                            >
+                                                                <Copy className="mr-2 h-4 w-4" />
+                                                                Copy hex DER
+                                                            </DropdownMenuItem>
+                                                            <DropdownMenuItem
+                                                                onClick={() =>
+                                                                    copyKeyAsPEM(
+                                                                        key.rawData
+                                                                    )
+                                                                }
+                                                            >
+                                                                <FileKey className="mr-2 h-4 w-4" />
+                                                                Copy PEM
+                                                            </DropdownMenuItem>
+                                                            <DropdownMenuItem
+                                                                onClick={() =>
+                                                                    downloadKeyAsPEM(
+                                                                        key.rawData
+                                                                    )
+                                                                }
+                                                            >
+                                                                <FolderKey className="mr-2 h-4 w-4" />
+                                                                Download PEM
+                                                            </DropdownMenuItem>
+                                                        </DropdownMenuContent>
+                                                    </DropdownMenu>
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </div>
+                        )}
+                    </TabsContent>
+                </Tabs>
             </div>
         </main>
     );

--- a/services/user/XAdmin/ui/src/pages/keys-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/keys-page.tsx
@@ -15,6 +15,7 @@ import {
     Unlock,
     Fingerprint,
     Hexagon,
+    ShieldOff,
 } from "lucide-react";
 
 import {
@@ -63,12 +64,6 @@ import {
     useAddServerKey,
     useKeyDevices,
 } from "../hooks/useKeyDevices";
-
-const splitDerKey = (key: string) => {
-    const segment0 = key.slice(0, key.length - 30);
-    const segment1 = key.slice(key.length - 30);
-    return [segment0, segment1];
-};
 
 const copyToClipboard = async (text: string) => {
     await navigator.clipboard.writeText(text);
@@ -133,7 +128,7 @@ export const KeysPage = () => {
     }, [isErrorFetchingServerKeys, errorFetchingServerKeys]);
 
     useEffect(() => {
-        if (!serverKeys) return;
+        if (!serverKeys || !window.isSecureContext) return;
 
         const loadFingerprints = async () => {
             const prints: Record<string, string> = {};
@@ -146,7 +141,21 @@ export const KeysPage = () => {
         };
 
         loadFingerprints();
-    }, [serverKeys]);
+    }, [serverKeys, window.isSecureContext]);
+
+    if (!window.isSecureContext) {
+        return (
+            <main className="flex select-none justify-center">
+                <div className="mt-4 w-full">
+                    <EmptyBlock
+                        title="Keys and devices is not available"
+                        description="This panel is only available in secure contexts (HTTPS or localhost)."
+                        ButtonIcon={ShieldOff}
+                    />
+                </div>
+            </main>
+        );
+    }
 
     const onSubmit = async (
         e?: React.SyntheticEvent,

--- a/services/user/XAdmin/ui/src/pages/keys-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/keys-page.tsx
@@ -5,7 +5,6 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import {
     MoreHorizontal,
-    Copy,
     SquarePlus,
     FileKey2,
     FileKey,
@@ -14,6 +13,8 @@ import {
     Loader2,
     Lock,
     Unlock,
+    Fingerprint,
+    Hexagon,
 } from "lucide-react";
 
 import {
@@ -485,6 +486,24 @@ export const KeysPage = () => {
                                                             <DropdownMenuItem
                                                                 onClick={() => {
                                                                     copyToClipboard(
+                                                                        fingerprints[
+                                                                            key
+                                                                                .rawData
+                                                                        ]?.toUpperCase()
+                                                                    );
+                                                                    toast({
+                                                                        title: "Copied",
+                                                                        description:
+                                                                            "The key fingerprint has been copied to the clipboard.",
+                                                                    });
+                                                                }}
+                                                            >
+                                                                <Fingerprint className="mr-2 h-4 w-4" />
+                                                                Copy fingerprint
+                                                            </DropdownMenuItem>
+                                                            <DropdownMenuItem
+                                                                onClick={() => {
+                                                                    copyToClipboard(
                                                                         key.rawData
                                                                     );
                                                                     toast({
@@ -494,7 +513,7 @@ export const KeysPage = () => {
                                                                     });
                                                                 }}
                                                             >
-                                                                <Copy className="mr-2 h-4 w-4" />
+                                                                <Hexagon className="mr-2 h-4 w-4" />
                                                                 Copy hex DER
                                                             </DropdownMenuItem>
                                                             <DropdownMenuItem

--- a/services/user/XAdmin/ui/src/pages/keys-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/keys-page.tsx
@@ -1,0 +1,318 @@
+// TODO: Do not display this tab if the server is booted without any key devices
+// TODO: Psibase pill link (invalidate at boot or peer so updated name appears and link to home)
+
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import {
+    MoreHorizontal,
+    Copy,
+    SquarePlus,
+    FileKey2,
+    FileKey,
+    FolderKey,
+    CircleAlert,
+    Loader2,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+
+import { KeyDeviceForm } from "@/components/forms/key-device-form";
+import { KeyDeviceSchema } from "@/types";
+import { hexDERPublicKeyToCryptoKey, exportKeyToPEM } from "@/lib/keys";
+
+import { useServerKeys, useAddServerKey } from "../hooks/useKeyDevices";
+import { EmptyBlock } from "@/components/EmptyBlock";
+import { useToast } from "@/components/ui/use-toast";
+import { getErrorMessage } from "@/lib/utils";
+import { ToastAction } from "@/components/ui/toast";
+
+const splitDerKey = (key: string) => {
+    const segment0 = key.slice(0, key.length - 30);
+    const segment1 = key.slice(key.length - 30);
+    return [segment0, segment1];
+};
+
+const copyToClipboard = async (text: string) => {
+    await navigator.clipboard.writeText(text);
+};
+
+const downloadAsFile = (content: string, filename: string) => {
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+};
+
+export const KeysPage = () => {
+    const { toast } = useToast();
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    const {
+        data: serverKeys,
+        refetch,
+        error,
+        isError,
+        isLoading,
+    } = useServerKeys();
+    const { mutate: addServerKey } = useAddServerKey();
+
+    const keyDeviceForm = useForm<z.infer<typeof KeyDeviceSchema>>();
+
+    useEffect(() => {
+        if (!isError) return;
+        toast({
+            variant: "destructive",
+            title: "Error fetching server keys",
+            description: error?.message || "Unknown error.",
+            action: (
+                <ToastAction
+                    altText="Try fetch again"
+                    onClick={() => refetch()}
+                >
+                    Try again
+                </ToastAction>
+            ),
+        });
+    }, [isError, error]);
+
+    const onSubmit = async (e?: React.SyntheticEvent) => {
+        e?.preventDefault();
+        try {
+            await addServerKey(keyDeviceForm.getValues().id);
+            setDialogOpen(false);
+        } catch (error) {
+            const message = getErrorMessage(error);
+            toast({
+                variant: "destructive",
+                title: "Error adding server key",
+                description: `${message || "Unknown error"}. Please try again.`,
+            });
+        }
+        setTimeout(refetch, 1000);
+    };
+
+    const copyKeyAsPEM = async (derHex: string) => {
+        try {
+            const cryptoKey = await hexDERPublicKeyToCryptoKey(derHex);
+            const pemKey = await exportKeyToPEM(cryptoKey, "PUBLIC KEY");
+            await copyToClipboard(pemKey);
+        } catch (error) {
+            console.error("Failed to copy key as PEM:", error);
+            const message = getErrorMessage(error);
+            toast({
+                variant: "destructive",
+                title: "Error copying key",
+                description: `${message || "Unknown error"}. Please try again.`,
+            });
+        }
+    };
+
+    const downloadKeyAsPEM = async (derHex: string) => {
+        try {
+            const cryptoKey = await hexDERPublicKeyToCryptoKey(derHex);
+            const pemKey = await exportKeyToPEM(cryptoKey, "PUBLIC KEY");
+            downloadAsFile(pemKey, "publicKey.pem");
+        } catch (error) {
+            console.error("Failed to copy key as PEM:", error);
+            const message = getErrorMessage(error);
+            toast({
+                variant: "destructive",
+                title: "Error downloading key",
+                description: `${message || "Unknown error"}. Please try again.`,
+            });
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <main className="flex h-[450px] select-none items-center justify-center">
+                <Loader2 className="animate-spin" size={64} />
+            </main>
+        );
+    }
+
+    // there was an error and no keys have been fetched
+    if (!serverKeys && isError) {
+        return (
+            <main className="flex select-none justify-center">
+                <div className="mt-4 w-full">
+                    <EmptyBlock
+                        buttonLabel="Try again"
+                        onClick={refetch}
+                        title="Something went wrong"
+                        description={`Server keys could not be fetched. ${
+                            error?.message
+                                ? `Error: ${error?.message}.`
+                                : "Unknown error"
+                        }.`}
+                        ButtonIcon={CircleAlert}
+                    />
+                </div>
+            </main>
+        );
+    }
+
+    // fetch was successful and there are no keys
+    if (serverKeys && serverKeys.length === 0) {
+        return (
+            <main className="flex select-none justify-center">
+                <div className="mt-4 w-full">
+                    <EmptyBlock
+                        buttonLabel="New Key"
+                        onClick={() => setDialogOpen(true)}
+                        title="No server keys"
+                        description="There are no keys available to the server for signing."
+                        ButtonIcon={FileKey2}
+                    />
+                </div>
+            </main>
+        );
+    }
+
+    // fetch was successful and there are keys
+    return (
+        <main className="flex select-none justify-center">
+            <div className="space-y-2">
+                <div className="flex justify-end">
+                    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+                        <DialogTrigger asChild>
+                            <Button size="sm" variant="outline">
+                                <SquarePlus className="mr-2 h-4 w-4" />
+                                New key
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent className="sm:max-w-[425px]">
+                            <DialogHeader>
+                                <DialogTitle>Create a new key</DialogTitle>
+                                <DialogDescription>
+                                    Which device do you want to generate a key
+                                    with?
+                                </DialogDescription>
+                            </DialogHeader>
+                            <KeyDeviceForm
+                                form={keyDeviceForm}
+                                next={onSubmit}
+                                deviceNotFoundErrorMessage="No security devices were found. Please ensure one is available."
+                            />
+                            <DialogFooter>
+                                <Button type="submit" onClick={onSubmit}>
+                                    Create key
+                                </Button>
+                            </DialogFooter>
+                        </DialogContent>
+                    </Dialog>
+                </div>
+                <div className="rounded-md border">
+                    <Table className="table-fixed">
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="w-32 text-center">
+                                    Auth service
+                                </TableHead>
+                                <TableHead className="w-full">
+                                    Public key (hex-encoded DER)
+                                </TableHead>
+                                <TableHead className="w-16 text-right"></TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {serverKeys?.map((key) => (
+                                <TableRow key={key.rawData}>
+                                    <TableCell className="px-4 py-2 text-center font-medium">
+                                        {key.service}
+                                    </TableCell>
+                                    <TableCell className="max-w-0 px-4 py-2">
+                                        <div className="flex">
+                                            <div className="truncate">
+                                                {splitDerKey(key.rawData)[0]}
+                                            </div>
+                                            <div className="shrink-0">
+                                                {splitDerKey(key.rawData)[1]}
+                                            </div>
+                                        </div>
+                                    </TableCell>
+                                    <TableCell className="px-4 py-2 text-right">
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                >
+                                                    <MoreHorizontal className="h-4 w-4" />
+                                                    <span className="sr-only">
+                                                        Open menu
+                                                    </span>
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align="end">
+                                                <DropdownMenuItem
+                                                    onClick={() =>
+                                                        copyToClipboard(
+                                                            key.rawData
+                                                        )
+                                                    }
+                                                >
+                                                    <Copy className="mr-2 h-4 w-4" />
+                                                    Copy hex DER
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem
+                                                    onClick={() =>
+                                                        copyKeyAsPEM(
+                                                            key.rawData
+                                                        )
+                                                    }
+                                                >
+                                                    <FileKey className="mr-2 h-4 w-4" />
+                                                    Copy PEM
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem
+                                                    onClick={() =>
+                                                        downloadKeyAsPEM(
+                                                            key.rawData
+                                                        )
+                                                    }
+                                                >
+                                                    <FolderKey className="mr-2 h-4 w-4" />
+                                                    Download PEM
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </div>
+            </div>
+        </main>
+    );
+};

--- a/services/user/XAdmin/ui/src/pages/keys-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/keys-page.tsx
@@ -1,5 +1,3 @@
-// TODO: check for secure context
-
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";

--- a/services/user/XAdmin/ui/src/routing.tsx
+++ b/services/user/XAdmin/ui/src/routing.tsx
@@ -1,18 +1,16 @@
-import { Navigate, Route, Routes } from "react-router-dom";
+import { useEffect } from "react";
+import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
+
 import App from "./App";
-
 import { LogsPage } from "./log/logs-page";
-
 import { DashboardPage } from "./pages/dashboard-page";
 import { SetupPage } from "./pages/setup-page";
 import { PeersPage } from "./peers/peers-page";
 import { ConfigurationPage } from "./configuration/configuration-page";
 import { JoinPage } from "./pages/join-page";
 import { CreatePage } from "./pages/create-page";
-
-import { useNavigate } from "react-router-dom";
+import { KeysPage } from "./pages/keys-page";
 import { useStatuses } from "./hooks/useStatuses";
-import { useEffect } from "react";
 
 export const Routing = () => {
     const { data: status, isLoading } = useStatuses();
@@ -43,6 +41,7 @@ export const Routing = () => {
                 <Route path="configuration" element={<ConfigurationPage />} />
                 <Route path="peers" element={<PeersPage />} />
                 <Route path="logs" element={<LogsPage />} />
+                <Route path="keys-and-devices" element={<KeysPage />} />
                 <Route
                     path=""
                     element={<Navigate to="/dashboard" replace={true} />}

--- a/services/user/XAdmin/ui/src/types.ts
+++ b/services/user/XAdmin/ui/src/types.ts
@@ -74,3 +74,8 @@ export const WrappedPackages = z
     .array();
 
 export type PackageInfoShape = z.infer<typeof PackageInfoSchema>;
+
+export const KeyDeviceSchema = z.object({
+    id: z.string().min(1),
+    pin: z.string().optional(),
+});


### PR DESCRIPTION
- If the server has an HSM configured, display security devices and public keys after boot.
- Display [un]lock status of security devices and allow admin to unlock security devices.
- Display public keys for all unlocked security devices.
- Copy public keys as hex-encoded DER or PEM and download as `.pem`.
- Make network name in nav header dynamic and link to network home page.
- Loading states, error states and success messaging.