### PR TITLE
Reduce copies for sync calls

### DIFF
--- a/libraries/psibase/common/include/psibase/Actor.hpp
+++ b/libraries/psibase/common/include/psibase/Actor.hpp
@@ -5,6 +5,7 @@
 #include <psibase/db.hpp>
 #include <psibase/serviceState.hpp>
 #include <psio/fracpack.hpp>
+#include <psio/nested.hpp>
 
 namespace psibase
 {
@@ -48,23 +49,73 @@ namespace psibase
       }
    };
 
-   template <typename T>
-   auto fraccall(const Action& a)
+   template <typename R>
+   auto fraccall(std::span<const char> packed_action)
    {
-      auto packed_action = psio::convert_to_frac(a);  /// TODO: avoid double copy of action data
-      auto result_size   = raw::call(packed_action.data(), packed_action.size());
-      if constexpr (not std::is_same_v<void, T>)
+      auto result_size = raw::call(packed_action.data(), packed_action.size());
+      if constexpr (not std::is_same_v<void, R>)
       {
-         psio::shared_view_ptr<T> result(psio::size_tag{result_size});
+         psio::shared_view_ptr<R> result(psio::size_tag{result_size});
          raw::getResult(result.data(), result_size, 0);
          check(result.validate(), "value returned was not serialized as expected");
          return result;
       }
    }
 
+   template <typename T>
+   auto fraccall(const Action& a)
+   {
+      auto packed_action = psio::convert_to_frac(a);
+      return fraccall<T>(psio::convert_to_frac(a));
+   }
+
+   template <typename T>
+   struct TypedAction
+   {
+      AccountNumber   sender;   ///< Account sending the action
+      AccountNumber   service;  ///< Service to execute the action
+      MethodNumber    method;   ///< Service method to execute
+      psio::nested<T> rawData;  ///< Data for the method
+   };
+
+   struct PackedActionProxy
+   {
+      PackedActionProxy(AccountNumber s, AccountNumber r) : sender(s), receiver(r) {}
+
+      AccountNumber sender;
+      AccountNumber receiver;
+
+      template <typename... T>
+      std::vector<char> packImpl(std::tuple<T...>*,
+                                 MethodNumber method,
+                                 const std::type_identity_t<T>&... args)
+      {
+         TypedAction<std::tuple<const T&...>> action{
+             sender, receiver, method, {std::tuple<const T&...>(args...)}};
+         return psio::convert_to_frac(action);
+      }
+
+      template <uint32_t idx, auto MemberPtr, typename... Args>
+      auto call(Args&&... args) const
+      {
+         using member_class = decltype(psio::class_of_member(MemberPtr));
+         using param_tuple  = typename psio::make_param_value_tuple<decltype(MemberPtr)>::type;
+
+         static_assert(std::tuple_size<param_tuple>() <= sizeof...(Args),
+                       "too few arguments passed to method");
+         static_assert(std::tuple_size<param_tuple>() == sizeof...(Args),
+                       "too many arguments passed to method");
+
+         return packImpl(
+             (param_tuple*)nullptr,
+             MethodNumber(*psio::reflect<member_class>::member_function_names[idx].begin()),
+             args...);
+      }
+   };
+
    /**
- *  This will dispatch a sync call and grab the return
- */
+    *  This will dispatch a sync call and grab the return
+    */
    struct sync_call_proxy
    {
       sync_call_proxy(AccountNumber s, AccountNumber r) : sender(s), receiver(r) {}
@@ -75,17 +126,10 @@ namespace psibase
       template <uint32_t idx, auto MemberPtr, typename... Args>
       auto call(Args&&... args) const
       {
-         auto act = action_builder_proxy(sender, receiver)
+         auto act = PackedActionProxy(sender, receiver)
                         .call<idx, MemberPtr, Args...>(std::forward<Args>(args)...);
          using result_type = decltype(psio::result_of(MemberPtr));
-         if constexpr (not std::is_same_v<void, result_type>)
-         {
-            return psibase::fraccall<std::remove_cv_t<psio::remove_view_t<result_type>>>(act);
-         }
-         else
-         {
-            psibase::fraccall<void>(act);
-         }
+         return psibase::fraccall<std::remove_cv_t<psio::remove_view_t<result_type>>>(act);
       }
    };
 

--- a/libraries/psio/include/psio/nested.hpp
+++ b/libraries/psio/include/psio/nested.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <psio/fracpack.hpp>
+
+namespace psio
+{
+   /**
+    * This type is serialized as a vector<char> holding the packed value.
+    */
+   template <typename T>
+   struct nested
+   {
+      using value_type = std::remove_cvref_t<T>;
+      T           value;
+      friend bool operator==(const nested&, const nested&) = default;
+   };
+
+   template <typename T, typename Stream>
+   void to_json(const nested<T>& obj, Stream& stream)
+   {
+      to_json(to_frac(obj.value), stream);
+   }
+
+   template <typename T, typename Stream>
+   void from_json(nested<T>& obj, Stream& stream)
+   {
+      std::vector<char> tmp;
+      from_json(tmp, stream);
+      from_frac(obj.value, tmp);
+   }
+
+   template <typename T>
+   struct is_packable<nested<T>> : base_packable_impl<nested<T>, is_packable<nested<T>>>
+   {
+      static constexpr uint32_t fixed_size        = 4;
+      static constexpr bool     is_variable_size  = true;
+      static constexpr bool     is_optional       = false;
+      static constexpr bool     supports_0_offset = true;
+
+      template <typename S>
+      static void pack(const nested<T>& value, S& stream)
+      {
+         std::uint32_t size = 0;
+         auto          pos  = stream.written();
+         stream.write_raw(size);
+         is_packable<std::remove_cvref_t<T>>::pack(value.value, stream);
+         auto end = stream.written();
+         size     = end - (pos + 4);
+         stream.rewrite_raw(pos, size);
+      }
+
+      static bool is_empty_container(const nested<T>&)
+      {
+         using is_p = is_packable<std::remove_cvref_t<T>>;
+         return !is_p::is_variable_size && is_p::fixed_size == 0;
+      }
+      static bool is_empty_container(const char* src, uint32_t pos, uint32_t end_pos)
+      {
+         uint32_t fixed_size;
+         if (!unpack_numeric<true>(&fixed_size, src, pos, end_pos))
+            return false;
+         return fixed_size == 0;
+      }
+
+      template <bool Verify>
+      static bool clear_container(nested<T>* value)
+      {
+         // We don't need to proagate these up, because an empty object
+         // definitely does not contain unknown data
+         bool          has_unknown = false;
+         bool          known_end;
+         std::uint32_t pos = 0;
+         if (!is_packable<std::remove_cvref_t<T>>::template unpack<true, Verify>(
+                 &value->value, has_unknown, known_end, value->data(), pos, 0))
+            return false;
+         return true;
+      }
+
+      template <bool Unpack, bool Verify>
+      [[nodiscard]] static bool unpack(nested<T>*  value,
+                                       bool&       has_unknown,
+                                       bool&       known_end,
+                                       const char* src,
+                                       uint32_t&   pos,
+                                       uint32_t    end_pos)
+      {
+         uint32_t size = 0;
+         if (!unpack_numeric<Verify>(&size, src, pos, end_pos))
+            return false;
+         if constexpr (Verify)
+         {
+            known_end = true;
+            if (size > end_pos - pos)
+               return false;
+         }
+         bool          inner_known_end;
+         std::uint32_t inner_pos = pos;
+         if (!is_packable<std::remove_cvref_t<T>>::template unpack<Unpack, Verify>(
+                 Unpack ? &value->value : nullptr, has_unknown, inner_known_end, src, inner_pos,
+                 pos + size))
+            return false;
+         if constexpr (Verify)
+         {
+            if (inner_known_end && inner_pos != pos + size)
+               return false;
+            known_end = true;
+         }
+         pos += size;
+         return true;
+      }
+   };
+}  // namespace psio

--- a/libraries/psio/include/psio/schema.hpp
+++ b/libraries/psio/include/psio/schema.hpp
@@ -15,6 +15,9 @@ namespace psio
       requires Packable<std::remove_cv_t<T>>
    class shared_view_ptr;
 
+   template <typename T>
+   struct nested;
+
    struct FracStream
    {
       FracStream(std::span<const char> buf) : src(buf.data())
@@ -1061,9 +1064,11 @@ namespace psio
       }
 
       template <typename T>
-      constexpr bool is_shared_view_ptr_v = false;
+      constexpr bool is_nested_wrapper_v = false;
       template <typename T>
-      constexpr bool is_shared_view_ptr_v<shared_view_ptr<T>> = true;
+      constexpr bool is_nested_wrapper_v<shared_view_ptr<T>> = true;
+      template <typename T>
+      constexpr bool is_nested_wrapper_v<nested<T>> = true;
 
       template <typename T>
       constexpr bool is_duration_v = false;
@@ -1176,7 +1181,7 @@ namespace psio
                   schema.insert(name, insert<std::remove_cvref_t<decltype(clio_unwrap_packable(
                                           std::declval<T&>()))>>());
                }
-               else if constexpr (is_shared_view_ptr_v<T>)
+               else if constexpr (is_nested_wrapper_v<T>)
                {
                   if (expandNested_)
                   {

--- a/libraries/psio/tests/test_fracpack.cpp
+++ b/libraries/psio/tests/test_fracpack.cpp
@@ -114,6 +114,7 @@ void test_compat_wrap(const T& t, const U& u, bool expect_unknown)
    test_compat(std::variant<T>{t}, std::variant<U>{u}, expect_unknown);
    test_compat(psio::shared_view_ptr{t}, psio::shared_view_ptr{u}, expect_unknown);
    test_compat(psio::shared_view_ptr<T>{t}, to_bytes(psio::to_frac(t)), false);
+   test_compat(psio::nested<T>{t}, to_bytes(psio::to_frac(t)), false);
 }
 
 template <typename...>

--- a/libraries/psio/tests/test_fracpack.hpp
+++ b/libraries/psio/tests/test_fracpack.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <psio/fracpack.hpp>
+#include <psio/nested.hpp>
 #include <psio/schema.hpp>
 #include <psio/shared_view_ptr.hpp>
 #include <psio/stream.hpp>
@@ -37,8 +38,7 @@ struct Catch::StringMaker<std::variant<T...>>
    {
       return std::visit(
           [](const auto& v)
-          { return Catch::StringMaker<std::remove_cvref_t<decltype(v)>>::convert(v); },
-          value);
+          { return Catch::StringMaker<std::remove_cvref_t<decltype(v)>>::convert(v); }, value);
    }
 };
 
@@ -138,6 +138,12 @@ template <typename T>
 bool bitwise_equal(const psio::shared_view_ptr<T>& lhs, const psio::shared_view_ptr<T>& rhs)
 {
    return bitwise_equal(lhs->unpack(), rhs->unpack());
+}
+
+template <typename T>
+bool bitwise_equal(const psio::nested<T>& lhs, const psio::nested<T>& rhs)
+{
+   return bitwise_equal(lhs.value, rhs.value);
 }
 
 template <typename T>
@@ -515,6 +521,13 @@ void test(std::initializer_list<T> values)
       for (const auto& v : values)
       {
          test(psio::shared_view_ptr{v});
+      }
+   }
+   // nested
+   {
+      for (const auto& v : values)
+      {
+         test(psio::nested{v});
       }
    }
    // Sandwiched between two heap objects (checks correct tracking of fixed_pos vs heap_pos)


### PR DESCRIPTION
A sync call can make 3 (!) copies of the action args. This reduces it to serialize directly into the buffer passed to call.