### PR TITLE
Use in memory action construction

### DIFF
--- a/services/system/Transact/plugin/src/lib.rs
+++ b/services/system/Transact/plugin/src/lib.rs
@@ -87,7 +87,7 @@ impl Hooks for TransactPlugin {
             }
         }
 
-        // Temporary whitelist until we have oauth
+        // TODO: Use `permissions` oauth instead of hardcoded whitelist
         if transformer != "staged-tx" {
             panic!(
                 "hook_tx_transform_label: {} is not whitelisted",
@@ -166,7 +166,6 @@ impl Admin for TransactPlugin {
         if actions.len() == 0 {
             return Ok(());
         }
-        CurrentActions::clear();
 
         let actions = transform_actions(actions)?;
 

--- a/services/user/ClientData/plugin/src/lib.rs
+++ b/services/user/ClientData/plugin/src/lib.rs
@@ -51,7 +51,7 @@ impl KeyValue for ClientData {
         // Set the value on the key
         bucket
             .set(&key, &value)
-            .map_err(|e| format!("Error setting value on key: {}", e.to_string()))
+            .map_err(|e| format!("Error setting value on key {}: {}", key, e.to_string()))
             .unwrap_or_else(|e| panic!("{}", e));
 
         Ok(())

--- a/services/user/Supervisor/ui/src/callStack.ts
+++ b/services/user/Supervisor/ui/src/callStack.ts
@@ -9,6 +9,8 @@ export interface Call {
     startTime?: number;
 }
 
+const onlyPrintRootCalls = true;
+
 // Callstack implementation that manages frames for every inter-plugin call
 export class CallStack {
     private storage: Array<Call> = [];
@@ -28,7 +30,7 @@ export class CallStack {
             rootCall === "startTx" ||
             rootCall === "finishTx" ||
             initiator === "supervisor" ||
-            this.storage.length > 1
+            (onlyPrintRootCalls && this.storage.length > 1)
         )
             return;
 
@@ -50,8 +52,8 @@ export class CallStack {
         if (
             rootCall !== "startTx" &&
             rootCall !== "finishTx" &&
-            this.storage.length === 1 &&
-            initiator !== "supervisor"
+            initiator !== "supervisor" &&
+            (!onlyPrintRootCalls || this.storage.length === 1)
         ) {
             const popped = this.peek(0)!;
             const resolutionTime = Date.now() - popped.startTime!;


### PR DESCRIPTION
Avoids temporarily storing actions in localstorage, which fails for large actions (like sites:upload) due to restrictions on kv value size.

CC @Velua 