### PR TITLE
Fix concurrent push transaction

### DIFF
--- a/libraries/psibase/common/include/psibase/Table.hpp
+++ b/libraries/psibase/common/include/psibase/Table.hpp
@@ -862,6 +862,10 @@ namespace psibase
    template <typename... Tables>
    using SubjectiveTables = DbTables<DbId::subjective, Tables...>;
 
+   /// Defines tables in the `temporary` database
+   template <typename... Tables>
+   using TemporaryTables = DbTables<DbId::temporary, Tables...>;
+
    // An empty key that can be used for any singleton table
    struct SingletonKey
    {

--- a/libraries/psibase/common/include/psibase/db.hpp
+++ b/libraries/psibase/common/include/psibase/db.hpp
@@ -146,6 +146,10 @@ namespace psibase
       nativeSubjective,
 
       endIndependent,
+
+      /// Subjective tables that are local to the transaction/query/callback
+      /// context.
+      temporary,
    };
 
    inline constexpr uint32_t numChainDatabases = ((uint32_t)DbId::numChainDatabases);

--- a/libraries/psibase/native/include/psibase/db.hpp
+++ b/libraries/psibase/native/include/psibase/db.hpp
@@ -203,6 +203,8 @@ namespace psibase
       std::size_t saveSubjective();
       void        restoreSubjective(std::size_t depth);
 
+      void clearTemporary();
+
       // TODO: kvPutRaw, kvRemoveRaw: return deltas
       // TODO: getters: pass in input buffers instead of returning KVResult
 

--- a/libraries/psibase/native/src/NativeFunctions.cpp
+++ b/libraries/psibase/native/src/NativeFunctions.cpp
@@ -36,7 +36,7 @@ namespace psibase
             return (DbId)db;
          if (db == uint32_t(DbId::native))
             return (DbId)db;
-         if (db == uint32_t(DbId::subjective))
+         if (db == uint32_t(DbId::subjective) || db == uint32_t(DbId::temporary))
          {
             uint64_t prefix = self.code.codeNum.value;
             std::reverse(reinterpret_cast<char*>(&prefix), reinterpret_cast<char*>(&prefix + 1));
@@ -80,7 +80,7 @@ namespace psibase
       bool keyHasServicePrefix(uint32_t db)
       {
          return db == uint32_t(DbId::service) || db == uint32_t(DbId::writeOnly) ||
-                db == uint32_t(DbId::subjective);
+                db == uint32_t(DbId::subjective) || db == uint32_t(DbId::temporary);
       }
 
       struct Writable
@@ -100,7 +100,7 @@ namespace psibase
                   "key prefix must match service during write");
          };
 
-         if (db == uint32_t(DbId::subjective) &&
+         if ((db == uint32_t(DbId::subjective) || db == uint32_t(DbId::temporary)) &&
              (self.code.flags & CodeRow::isSubjective || self.allowDbReadSubjective) &&
              (self.code.flags & CodeRow::allowWriteSubjective))
             // Not chargeable since subjective services are skipped during replay

--- a/libraries/psibase/native/src/TransactionContext.cpp
+++ b/libraries/psibase/native/src/TransactionContext.cpp
@@ -47,7 +47,10 @@ namespace psibase
    {
    }
 
-   TransactionContext::~TransactionContext() {}
+   TransactionContext::~TransactionContext()
+   {
+      blockContext.db.clearTemporary();
+   }
 
    static void execGenesisAction(TransactionContext& self, const Action& action);
    static void execProcessTransaction(TransactionContext& self, bool checkFirstAuthAndExit);

--- a/libraries/psibase/native/src/useTriedent.cpp
+++ b/libraries/psibase/native/src/useTriedent.cpp
@@ -716,6 +716,13 @@ namespace psibase
          }
          subjectiveLimit = depth;
       }
+
+      void clearTemporary()
+      {
+         check(subjectiveRevisions.empty(),
+               "Cannot clear subjective db while a subjective transaction is pending");
+         temporaryDb.reset();
+      }
    };  // DatabaseImpl
 
    Database::Database(SharedDatabase shared, ConstRevisionPtr revision)
@@ -837,6 +844,11 @@ namespace psibase
    void Database::restoreSubjective(std::size_t depth)
    {
       impl->restoreSubjective(depth);
+   }
+
+   void Database::clearTemporary()
+   {
+      impl->clearTemporary();
    }
 
    void Database::kvPutRaw(DbId db, psio::input_stream key, psio::input_stream value)

--- a/libraries/psibase/native/src/useTriedent.cpp
+++ b/libraries/psibase/native/src/useTriedent.cpp
@@ -447,6 +447,7 @@ namespace psibase
       std::array<std::size_t, numIndependentDatabases> changeSetPos;
       std::size_t                                      socketChangePos;
       IndependentRevision                              db;
+      DbPtr                                            temporaryDb;
    };
 
    std::array<std::size_t, numIndependentDatabases> getChangeSetPos(
@@ -471,6 +472,7 @@ namespace psibase
       std::vector<char>                        keyBuffer;
       std::vector<char>                        valueBuffer;
 
+      DbPtr                           temporaryDb;
       IndependentChangeSet            subjectiveChanges;
       std::vector<SocketChange>       socketChanges;
       std::vector<SubjectiveRevision> subjectiveRevisions;
@@ -484,6 +486,17 @@ namespace psibase
             check(!subjectiveRevisions.empty(),
                   "subjectiveCheckout is required to access the subjective database");
             return subjectiveRevisions.back().db[independentIndex(db)];
+         }
+         else if (db == DbId::temporary)
+         {
+            if (!subjectiveRevisions.empty())
+            {
+               return subjectiveRevisions.back().temporaryDb;
+            }
+            else
+            {
+               return temporaryDb;
+            }
          }
          else
          {
@@ -592,11 +605,12 @@ namespace psibase
                "checkoutSubjective nesting exceeded limit");
          if (subjectiveRevisions.empty())
          {
-            subjectiveRevisions.push_back({{}, 0, shared.getSubjective()});
+            subjectiveRevisions.push_back({{}, 0, shared.getSubjective(), temporaryDb});
             callbackFlags = 0;
          }
          subjectiveRevisions.push_back({getChangeSetPos(subjectiveChanges), socketChanges.size(),
-                                        subjectiveRevisions.back().db});
+                                        subjectiveRevisions.back().db,
+                                        subjectiveRevisions.back().temporaryDb});
       }
 
       bool commitSubjective(Sockets& sockets, SocketAutoCloseSet& closing)
@@ -607,6 +621,8 @@ namespace psibase
          {
             subjectiveRevisions[subjectiveRevisions.size() - 2].db =
                 std::move(subjectiveRevisions.back().db);
+            subjectiveRevisions[subjectiveRevisions.size() - 2].temporaryDb =
+                std::move(subjectiveRevisions.back().temporaryDb);
             subjectiveRevisions.pop_back();
          }
          else
@@ -619,6 +635,7 @@ namespace psibase
                        std::move(subjectiveChanges), std::move(socketChanges), sockets, closing))
                {
                   subjectiveRevisions[1].db              = subjectiveRevisions[0].db;
+                  subjectiveRevisions[1].temporaryDb     = subjectiveRevisions[0].temporaryDb;
                   subjectiveRevisions[0].changeSetPos    = {};
                   subjectiveRevisions[0].socketChangePos = 0;
                   subjectiveRevisions[1].changeSetPos    = {};
@@ -628,6 +645,7 @@ namespace psibase
                   socketChanges.clear();
                   return false;
                }
+               temporaryDb = std::move(subjectiveRevisions.back().temporaryDb);
                if (callbackFlags && shared.impl->callbacks)
                {
                   shared.impl->callbacks->run(callbackFlags);

--- a/programs/psinode/tests/test_query.py
+++ b/programs/psinode/tests/test_query.py
@@ -81,9 +81,14 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(r1, {"i":5})
 
         # Test queries that cause retries
-        (r0, r1) = post_parallel(a, ('/send_with_contention', {"i":6}), ('/send_with_contention', {"i":7}))
+        (r0, r1) = post_parallel(a, ('/send_with_contention?delay=1', {"i":6}), ('/send_with_contention?delay=1', {"i":7}))
         self.assertEqual(r0, {"i":6})
         self.assertEqual(r1, {"i":7})
+
+        # Check deferReply with retries
+        (r0, r1) = post_parallel(a, ('/send_async_with_contention?delay=1', {"i":8}), ('/send_async_with_contention?delay=1', {"i":9}))
+        self.assertEqual(r0, {"i":8})
+        self.assertEqual(r1, {"i":9})
 
 if __name__ == '__main__':
     testutil.main()

--- a/rust/psibase/src/db.rs
+++ b/rust/psibase/src/db.rs
@@ -143,6 +143,10 @@ pub enum DbId {
     NativeSubjective,
 
     EndIndependent,
+
+    /// Subjective tables that are local to the transaction/query/callback
+    /// context.
+    Temporary,
 }
 
 const BEGIN_INDEPENDENT: u32 = 64;

--- a/services/psibase_tests/AsyncQueryService.cpp
+++ b/services/psibase_tests/AsyncQueryService.cpp
@@ -160,6 +160,16 @@ std::optional<HttpReply> AsyncQueryService::serveSys(const HttpRequest&         
       }
       to<HttpServer>().sendReply(*socket, reply);
    }
+   else if (path == "/send_async_with_contention")
+   {
+      auto table = Subjective{}.open<AsyncResponseTable>();
+      PSIBASE_SUBJECTIVE_TX
+      {
+         table.put({.socket = *socket, .reply = reply});
+         to<HttpServer>().deferReply(*socket);
+         wait_for(delay);
+      }
+   }
    return {};
 }
 


### PR DESCRIPTION
It failed when a retry was required, because the database reverted, but the in memory state did not. The PR moves the relevant state into a new `temporary` database.

Note: I tried to avoid native changes, but any solution I could think of created worse problems like misdirected responses.