### PR TITLE
Reduce r-transact memory consumption

### DIFF
--- a/services/system/Transact/include/services/system/RTransact.hpp
+++ b/services/system/Transact/include/services/system/RTransact.hpp
@@ -83,17 +83,8 @@ namespace SystemService
       std::vector<TraceClientInfo> clients;
    };
    PSIO_REFLECT(TraceClientRow, id, clients)
-   using TraceClientTable = psibase::Table<TraceClientRow, &TraceClientRow::id>;
 
-   // Holds the size of the last transaction trace
-   struct TraceSizeRow
-   {
-      psibase::Checksum256 id;
-      uint64_t             size;
-      auto                 primary_key() const { return psibase::SingletonKey{}; }
-   };
-   PSIO_REFLECT(TraceSizeRow, id, size)
-   using TraceSizeTable = psibase::Table<TraceSizeRow, &TraceSizeRow::primary_key>;
+   using TraceClientTable = psibase::Table<TraceClientRow, &TraceClientRow::id>;
 
    class RTransact : psibase::Service
    {
@@ -102,8 +93,7 @@ namespace SystemService
       using Subjective              = psibase::SubjectiveTables<PendingTransactionTable,
                                                                 TransactionDataTable,
                                                                 AvailableSequenceTable,
-                                                                TraceClientTable,
-                                                                TraceSizeTable>;
+                                                                TraceClientTable>;
       using WriteOnly = psibase::WriteOnlyTables<UnappliedTransactionTable, ReversibleBlocksTable>;
       std::optional<psibase::SignedTransaction> next();
       // Handles transactions coming over P2P

--- a/services/system/Transact/include/services/system/RTransact.hpp
+++ b/services/system/Transact/include/services/system/RTransact.hpp
@@ -83,8 +83,17 @@ namespace SystemService
       std::vector<TraceClientInfo> clients;
    };
    PSIO_REFLECT(TraceClientRow, id, clients)
-
    using TraceClientTable = psibase::Table<TraceClientRow, &TraceClientRow::id>;
+
+   // Holds the size of the last transaction trace
+   struct TraceSizeRow
+   {
+      psibase::Checksum256 id;
+      uint64_t             size;
+      auto                 primary_key() const { return psibase::SingletonKey{}; }
+   };
+   PSIO_REFLECT(TraceSizeRow, id, size)
+   using TraceSizeTable = psibase::Table<TraceSizeRow, &TraceSizeRow::primary_key>;
 
    class RTransact : psibase::Service
    {
@@ -93,7 +102,8 @@ namespace SystemService
       using Subjective              = psibase::SubjectiveTables<PendingTransactionTable,
                                                                 TransactionDataTable,
                                                                 AvailableSequenceTable,
-                                                                TraceClientTable>;
+                                                                TraceClientTable,
+                                                                TraceSizeTable>;
       using WriteOnly = psibase::WriteOnlyTables<UnappliedTransactionTable, ReversibleBlocksTable>;
       std::optional<psibase::SignedTransaction> next();
       // Handles transactions coming over P2P

--- a/services/system/Transact/src/RTransact.cpp
+++ b/services/system/Transact/src/RTransact.cpp
@@ -3,7 +3,6 @@
 #include <services/system/Transact.hpp>
 
 #include <psibase/dispatch.hpp>
-#include <psibase/serveGraphQL.hpp>
 #include <psibase/serveSchema.hpp>
 
 using namespace psibase;
@@ -117,12 +116,7 @@ namespace
 void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> trace)
 {
    check(getSender() == AccountNumber{}, "Wrong sender");
-   auto size = find_view_span(trace).size();
-   PSIBASE_SUBJECTIVE_TX
-   {
-      auto table = Subjective{}.open<TraceSizeTable>();
-      table.put({id, size});
-   }
+   printf("trace size: %zu\n", find_view_span(trace).size());
 
    TransactionTrace pruned = pruneTrace(trace);
 
@@ -440,20 +434,6 @@ void RTransact::recv(const SignedTransaction& trx)
       forwardTransaction(trx);
 }
 
-struct Query
-{
-   auto lastTraceSize() const -> std::optional<TraceSizeRow>
-   {
-      PSIBASE_SUBJECTIVE_TX
-      {
-         auto table = Subjective{}.open<TraceSizeTable>();
-         return table.get(SingletonKey{});
-      }
-      return std::nullopt;
-   }
-};
-PSIO_REFLECT(Query, method(lastTraceSize))
-
 std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest& request,
                                              std::optional<std::int32_t> socket)
 {
@@ -481,10 +461,7 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest& request
    {
       return res;
    }
-   else if (auto res = psibase::serveGraphQL(request, Query{}))
-   {
-      return res;
-   }
+
    return {};
 }
 

--- a/services/system/Transact/src/RTransact.cpp
+++ b/services/system/Transact/src/RTransact.cpp
@@ -58,42 +58,41 @@ std::optional<SignedTransaction> SystemService::RTransact::next()
 
 namespace
 {
-   ActionTrace pruneActionTrace(const ActionTrace& at);
+   ActionTrace pruneActionTrace(psio::view<const ActionTrace> at);
 
-   InnerTrace pruneInnerTrace(const InnerTrace& inner)
+   InnerTrace pruneInnerTrace(psio::view<const InnerTrace> inner)
    {
       InnerTrace pruned;
-      if (std::holds_alternative<ActionTrace>(inner.inner))
+      if (psio::holds_alternative<ActionTrace>(inner.inner()))
       {
-         pruned.inner = pruneActionTrace(std::get<ActionTrace>(inner.inner));
-         return pruned;
+         pruned.inner = pruneActionTrace(psio::get<ActionTrace>(inner.inner()));
       }
       else
       {
-         pruned.inner = inner.inner;
+         pruned.inner = inner.inner();
       }
       return pruned;
    }
 
-   Action pruneAction(const Action& action)
+   Action pruneAction(psio::view<const Action> action)
    {
       Action pruned;
-      pruned.sender  = action.sender;
-      pruned.service = action.service;
-      pruned.method  = action.method;
+      pruned.sender  = action.sender();
+      pruned.service = action.service();
+      pruned.method  = action.method();
       pruned.rawData = {};
       return pruned;
    }
 
-   ActionTrace pruneActionTrace(const ActionTrace& at)
+   ActionTrace pruneActionTrace(psio::view<const ActionTrace> at)
    {
       ActionTrace pruned;
-      pruned.error     = at.error;
-      pruned.totalTime = at.totalTime;
-      pruned.rawRetval = at.rawRetval;
-      pruned.action    = pruneAction(at.action);
-      pruned.innerTraces.reserve(at.innerTraces.size());
-      for (const auto& inner : at.innerTraces)
+      pruned.error     = at.error();
+      pruned.totalTime = at.totalTime();
+      pruned.rawRetval = at.rawRetval();
+      pruned.action    = pruneAction(at.action());
+      pruned.innerTraces.reserve(at.innerTraces().size());
+      for (const auto& inner : at.innerTraces())
       {
          pruned.innerTraces.push_back(pruneInnerTrace(inner));
       }


### PR DESCRIPTION
Decreases the memory requirements of transact by pruning `rawData` out of the transaction trace.