### PR TITLE
Fix registry account creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,8 +502,10 @@ psibase_package(
     DESCRIPTION "Auth service that delegates authorization to another account"
     SERVICE auth-delegate
         WASM ${CMAKE_CURRENT_BINARY_DIR}/AuthDelegate.wasm
-        SERVER auth-delegate
         DATA ${Plugins_OUTPUT_FILE_auth_delegate} /plugin.wasm
+        SERVER r-auth-dlg
+    SERVICE r-auth-dlg
+        WASM ${CMAKE_CURRENT_BINARY_DIR}/RAuthDelegate.wasm
     DEPENDS wasm
     DEPENDS ${Plugins_DEP}
     PACKAGE_DEPENDS "HttpServer(^${PSIBASE_VERSION})" "Sites(^${PSIBASE_VERSION})"

--- a/rust/psibase/src/services/auth_delegate.rs
+++ b/rust/psibase/src/services/auth_delegate.rs
@@ -25,7 +25,7 @@ mod service {
     }
 
     #[action]
-    fn newAccount(name: AccountNumber) {
+    fn newAccount(name: AccountNumber, owner: AccountNumber) {
         unimplemented!()
     }
 }

--- a/services/system/AuthDelegate/CMakeLists.txt
+++ b/services/system/AuthDelegate/CMakeLists.txt
@@ -1,5 +1,6 @@
 function(add suffix)
     add_system_service("${suffix}" AuthDelegate src/AuthDelegate.cpp)
+    add_system_service("${suffix}" RAuthDelegate src/RAuthDelegate.cpp)
 endfunction(add)
 
 add_subdirectory(test)

--- a/services/system/AuthDelegate/include/services/system/AuthDelegate.hpp
+++ b/services/system/AuthDelegate/include/services/system/AuthDelegate.hpp
@@ -89,9 +89,8 @@ namespace SystemService
       /// for the owned account will check authorization for the owner instead.
       void setOwner(psibase::AccountNumber owner);
 
-      /// Create a new account with the specified name.
-      /// The sender of the action will be the owner of the new account.
-      void newAccount(psibase::AccountNumber name);
+      /// Create a new account with the specified name, owned by the specified `owner` account.
+      void newAccount(psibase::AccountNumber name, psibase::AccountNumber owner);
 
      private:
       Tables                        db{psibase::getReceiver()};
@@ -104,7 +103,7 @@ namespace SystemService
                 method(isAuthSys, sender, authorizers, authSet),
                 method(isRejectSys, sender, rejecters, authSet),
                 method(setOwner, owner),
-                method(newAccount, name)
+                method(newAccount, name, owner)
                 //
    )
 

--- a/services/system/AuthDelegate/include/services/system/AuthDelegate.hpp
+++ b/services/system/AuthDelegate/include/services/system/AuthDelegate.hpp
@@ -16,8 +16,12 @@ namespace SystemService
    {
       psibase::AccountNumber account;
       psibase::AccountNumber owner;
+
+      auto secondary() const { return std::tie(owner, account); }
    };
    PSIO_REFLECT(AuthDelegateRecord, account, owner)
+   using AuthDelegateTable = psibase::
+       Table<AuthDelegateRecord, &AuthDelegateRecord::account, &AuthDelegateRecord::secondary>;
 
    /// The `auth-delegate` service is an auth service that can be used to authenticate actions for accounts.
    ///
@@ -27,8 +31,7 @@ namespace SystemService
    {
      public:
       static constexpr auto service = psibase::AccountNumber("auth-delegate");
-      using AuthDelegateTable = psibase::Table<AuthDelegateRecord, &AuthDelegateRecord::account>;
-      using Tables            = psibase::ServiceTables<AuthDelegateTable>;
+      using Tables                  = psibase::ServiceTables<AuthDelegateTable>;
 
       /// This is an implementation of the standard auth service interface defined in [SystemService::AuthInterface]
       ///

--- a/services/system/AuthDelegate/include/services/system/RAuthDelegate.hpp
+++ b/services/system/AuthDelegate/include/services/system/RAuthDelegate.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <psibase/Rpc.hpp>
+#include <psibase/Service.hpp>
+#include <psibase/serviceEntry.hpp>
+
+namespace SystemService
+{
+   class RAuthDelegate : public psibase::Service
+   {
+     public:
+      static constexpr auto service = psibase::AccountNumber("r-auth-dlg");
+
+      auto serveSys(psibase::HttpRequest request) -> std::optional<psibase::HttpReply>;
+   };
+   PSIO_REFLECT(RAuthDelegate,  //
+                method(serveSys, request))
+}  // namespace SystemService

--- a/services/system/AuthDelegate/plugin/Cargo.toml
+++ b/services/system/AuthDelegate/plugin/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 wit-bindgen-rt = { version = "0.34.0", features = ["bitflags"] }
-psibase = { path = "../../../../rust/psibase/" }
+psibase = { path = "../../../../rust/psibase/", version = "0.15.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/services/system/AuthDelegate/plugin/src/errors.rs
+++ b/services/system/AuthDelegate/plugin/src/errors.rs
@@ -3,4 +3,5 @@ use psibase::plugin_error;
 plugin_error! {
     pub ErrorType<'a>
     NotYetImplemented(msg: &'a str) => "Not yet implemented: {msg}",
+    InvalidAccountName => "Invalid account name",
 }

--- a/services/system/AuthDelegate/plugin/src/lib.rs
+++ b/services/system/AuthDelegate/plugin/src/lib.rs
@@ -1,24 +1,58 @@
 #[allow(warnings)]
 mod bindings;
+use std::str::FromStr;
+
+use bindings::*;
 mod errors;
 use errors::ErrorType::*;
+use exports::auth_delegate::plugin::api::{Error, Guest as Api};
+use exports::transact_hook_user_auth::{Claim, Guest as HookUserAuth, Proof};
+use transact::plugin::intf::add_action_to_transaction;
 
-// Other plugins
-use bindings::exports::transact_hook_user_auth::{Guest as HookUserAuth, *};
-use bindings::host::common::types as CommonTypes;
+use psibase::fracpack::Pack;
+use psibase::*;
 
 struct AuthDelegate;
 
+fn get_account_number(name: &str) -> Result<AccountNumber, Error> {
+    AccountNumber::from_str(name).map_err(|_| Error::from(InvalidAccountName))
+}
+
 impl HookUserAuth for AuthDelegate {
-    fn on_user_auth_claim(_account_name: String) -> Result<Option<Claim>, CommonTypes::Error> {
+    fn on_user_auth_claim(_account_name: String) -> Result<Option<Claim>, Error> {
         Err(NotYetImplemented("get_claims"))?
     }
 
     fn on_user_auth_proof(
         _account_name: String,
         _transaction_hash: Vec<u8>,
-    ) -> Result<Option<Proof>, CommonTypes::Error> {
+    ) -> Result<Option<Proof>, Error> {
         Err(NotYetImplemented("get_proofs"))?
+    }
+}
+
+impl Api for AuthDelegate {
+    fn set_owner(owner: String) -> Result<(), Error> {
+        use psibase::services::auth_delegate::action_structs::setOwner as set_owner_action;
+        let set_owner = set_owner_action {
+            owner: get_account_number(owner.as_str())?,
+        };
+        Ok(add_action_to_transaction(
+            set_owner_action::ACTION_NAME,
+            &set_owner.packed(),
+        )?)
+    }
+
+    fn new_account(name: String, owner: String) -> Result<(), Error> {
+        use psibase::services::auth_delegate::action_structs::newAccount as new_account_action;
+        let new_account = new_account_action {
+            name: get_account_number(name.as_str())?,
+            owner: get_account_number(owner.as_str())?,
+        };
+        Ok(add_action_to_transaction(
+            new_account_action::ACTION_NAME,
+            &new_account.packed(),
+        )?)
     }
 }
 

--- a/services/system/AuthDelegate/plugin/wit/impl.wit
+++ b/services/system/AuthDelegate/plugin/wit/impl.wit
@@ -1,6 +1,9 @@
-package auth-sig:plugin;
+package auth-delegate:plugin;
 
 world impl {
     include host:common/imports;
     include transact:plugin/hook-user-auth;
+    include transact:plugin/imports;
+
+    export api;
 }

--- a/services/system/AuthDelegate/plugin/wit/world.wit
+++ b/services/system/AuthDelegate/plugin/wit/world.wit
@@ -1,0 +1,18 @@
+package auth-delegate:plugin;
+
+interface api {
+    use host:common/types.{error};
+
+    /// Set the owner of the sender account
+    ///
+    /// Whenever a sender using this auth service submits a transaction, authorization
+    /// for the owned account will check authorization for the owner instead.
+    set-owner: func(owner: string) -> result<_, error>;
+
+    /// Create a new account with the specified name, owned by the specified `owner` account.
+    new-account: func(name: string, owner: string) -> result<_, error>;
+}
+
+world imports {
+    import api;
+}

--- a/services/system/AuthDelegate/src/RAuthDelegate.cpp
+++ b/services/system/AuthDelegate/src/RAuthDelegate.cpp
@@ -1,0 +1,55 @@
+#include <psibase/dispatch.hpp>
+#include <psibase/serveGraphQL.hpp>
+#include <psibase/serveSchema.hpp>
+#include <psibase/serveSimpleUI.hpp>
+#include <services/system/AuthDelegate.hpp>
+#include <services/system/RAuthDelegate.hpp>
+
+using namespace psibase;
+using namespace std;
+
+namespace SystemService
+{
+   struct Query
+   {
+      /// Get the accounts that are owned by the specified account
+      auto owned(AccountNumber account) const
+      {
+         return AuthDelegate::Tables{AuthDelegate::service}
+             .open<AuthDelegateTable>()
+             .getIndex<1>()
+             .subindex<AccountNumber>(account);
+      }
+
+      /// Get the owner of the specified account
+      auto owner(AccountNumber account) const
+      {
+         return AuthDelegate::Tables{AuthDelegate::service}
+             .open<AuthDelegateTable>()
+             .getIndex<0>()
+             .get(account);
+      }
+   };
+   PSIO_REFLECT(Query,                   //
+                method(owned, account),  //
+                method(owner, account)   //
+                                         //
+   );
+
+   std::optional<HttpReply> RAuthDelegate::serveSys(HttpRequest request)
+   {
+      if (auto result = serveGraphQL(request, Query{}))
+         return result;
+
+      if (auto result = serveSimpleUI<AuthDelegate, false>(request))
+         return result;
+
+      if (auto result = serveSchema<AuthDelegate>(request))
+         return result;
+
+      return std::nullopt;
+
+   }  // serveSys
+}  // namespace SystemService
+
+PSIBASE_DISPATCH(SystemService::RAuthDelegate)

--- a/services/user/Packages/src/Packages.cpp
+++ b/services/user/Packages/src/Packages.cpp
@@ -22,7 +22,7 @@ namespace UserService
       AccountNumber getOwner(AccountNumber account)
       {
          auto db = AuthDelegate::Tables(AuthDelegate::service);
-         if (auto row = db.open<AuthDelegate::AuthDelegateTable>().getIndex<0>().get(account))
+         if (auto row = db.open<AuthDelegateTable>().getIndex<0>().get(account))
             return row->owner;
          else
             abortMessage("Cannot find owner for " + account.str());

--- a/services/user/Packages/src/RPackages.cpp
+++ b/services/user/Packages/src/RPackages.cpp
@@ -21,9 +21,8 @@ namespace UserService
       {
          std::vector<psibase::AccountNumber> result;
          auto accountIndex = Accounts::Tables(Accounts::service).open<AccountTable>().getIndex<0>();
-         auto ownerIndex   = AuthDelegate::Tables(AuthDelegate::service)
-                               .open<AuthDelegate::AuthDelegateTable>()
-                               .getIndex<0>();
+         auto ownerIndex =
+             AuthDelegate::Tables(AuthDelegate::service).open<AuthDelegateTable>().getIndex<0>();
          for (auto account : accounts)
          {
             if (auto accountRow = accountIndex.get(account))

--- a/services/user/Registry/service/src/lib.rs
+++ b/services/user/Registry/service/src/lib.rs
@@ -63,7 +63,7 @@ pub mod service {
 
     #[action]
     fn createApp(account: AccountNumber) {
-        psibase::services::auth_delegate::Wrapper::call().newAccount(account);
+        psibase::services::auth_delegate::Wrapper::call().newAccount(account, get_sender());
     }
 
     #[action]


### PR DESCRIPTION
Found a bug testing `psibase.io` deployment yesterday that prevents staged-tx from going through in workshop.

The reason we didn't catch it previously was because even though the owner of workshop's created apps was set incorrectly, we were only testing while being logged in as the producer account (or we were on an insecure deployment).

This now correctly sets the owner of the new project accounts created in workshop to the intended owner.