### PR TITLE
Bug fix: auth-sig account export feature exports wrong account

### DIFF
--- a/services/system/AuthSig/ui/src/AccountSelection.tsx
+++ b/services/system/AuthSig/ui/src/AccountSelection.tsx
@@ -1,4 +1,3 @@
-import { useLoggedInUser } from "./hooks/useLoggedInUser";
 import { useCreateConnectionToken } from "./hooks/useCreateConnectionToken";
 import { usePublicToPrivate } from "./hooks/usePrivateToPublicKey";
 import { siblingUrl } from "@psibase/common-lib";
@@ -38,16 +37,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 const ModalState = z.enum(["Off", "Warn", "Show"]);
 
 export const AccountSelection = () => {
-  const { data: currentUser } = useLoggedInUser();
-
   const { data: connectionToken } = useCreateConnectionToken();
-
-  const { data: account } = useAccountLookup(currentUser);
-
-  const { data: privateKey } = usePublicToPrivate(account?.pubkey);
-
-  const key = privateKey && pemToBase64(privateKey);
-  const url = modifyUrlParams(siblingUrl("", "accounts"), { key: key || "" });
 
   const onReveal = () => {
     setModalState(warnUser ? "Warn" : "Show");
@@ -67,6 +57,11 @@ export const AccountSelection = () => {
       );
     }
   );
+
+  const { data: account } = useAccountLookup(selectedAccount);
+  const { data: privateKey } = usePublicToPrivate(account?.pubkey);
+  const key = privateKey && pemToBase64(privateKey);
+  const url = modifyUrlParams(siblingUrl("", "accounts"), { key: key || "" });
 
   const isLoading = isLoadingConnectedAccounts;
 


### PR DESCRIPTION
This is a quick fix for the auth-sig account export feature. The account being exported was always the currently-logged in user's account, no matter what account the user selected for export in the UI.

Further UI enhancements will come in a future PR.