### PR TITLE
Add a warning when a package isn't found

### DIFF
--- a/rust/psibase/src/depgraph.rs
+++ b/rust/psibase/src/depgraph.rs
@@ -397,6 +397,12 @@ impl<'a> DepGraph<'a> {
             for (meta, var) in packages.values() {
                 for dep in &meta.depends {
                     let group = self.get_matching(dep)?;
+                    if group.is_empty() {
+                        eprintln!(
+                            "warning: dependency {}-{} -> {} {} not found",
+                            meta.name, meta.version, dep.name, dep.version
+                        );
+                    }
                     any_if(&mut self.solver, *var, group);
                 }
             }


### PR DESCRIPTION
This will catch the most common way for package resolution to fail. It's possible to get the warning and still install successfully if the packages with incorrekt dependencies aren't needed. However, the warning always means that there's a problem with the package index.