### PR TITLE
Minimize copying of the transaction trace when generating a response

### DIFF
--- a/libraries/psibase/common/include/psibase/Memo.hpp
+++ b/libraries/psibase/common/include/psibase/Memo.hpp
@@ -21,6 +21,7 @@ namespace psibase
 
       std::string contents;
 
+      Memo(const char* s) : contents{s} { validate(s); }
       Memo(const std::string& s) : contents{s} { validate(s); }
       Memo() : Memo("") {}
       static bool validate(std::string_view str)

--- a/libraries/psibase/common/include/psibase/Rpc.hpp
+++ b/libraries/psibase/common/include/psibase/Rpc.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <psibase/block.hpp>
+#include <psio/nested.hpp>
 #include <string>
 #include <vector>
 
@@ -90,13 +91,22 @@ namespace psibase
    /// An HTTP reply
    ///
    /// Services return this from their `serveSys` action.
-   struct HttpReply
+   template <typename T>
+   struct BasicHttpReply
    {
       HttpStatus              status = HttpStatus::ok;
       std::string             contentType;  ///< "application/json", "text/html", ...
-      std::vector<char>       body;         ///< Response body
+      T                       body;         ///< Response body
       std::vector<HttpHeader> headers;      ///< HTTP Headers
-      PSIO_REFLECT(HttpReply, status, contentType, body, headers)
+      PSIO_REFLECT(BasicHttpReply, status, contentType, body, headers)
    };
+
+   using HttpReply = BasicHttpReply<std::vector<char>>;
+
+   template <typename T>
+   using FracpackHttpReply = BasicHttpReply<psio::nested<T>>;
+
+   template <typename T>
+   using JsonHttpReply = BasicHttpReply<psio::nested_json<T>>;
 
 }  // namespace psibase

--- a/libraries/psio/include/psio/nested.hpp
+++ b/libraries/psio/include/psio/nested.hpp
@@ -1,9 +1,62 @@
 #pragma once
 
 #include <psio/fracpack.hpp>
+#include <psio/from_json.hpp>
+#include <psio/to_hex.hpp>
+#include <psio/view.hpp>
 
 namespace psio
 {
+   template <typename Stream>
+   struct hex_output_stream
+   {
+      Stream&     stream;
+      std::size_t base;
+
+      hex_output_stream(Stream& stream) : stream(stream), base(stream.written()) {}
+
+      void about_to_write(std::size_t amount) { stream.about_to_write(amount * 2); }
+
+      void write(char ch)
+      {
+         auto nibble = [](std::uint8_t i) -> char
+         {
+            if (i <= 9)
+               return '0' + i;
+            else
+               return 'A' + i - 10;
+         };
+         stream.write(nibble(((std::uint8_t)ch) >> 4));
+         stream.write(nibble(((std::uint8_t)ch) & 0xf));
+      }
+
+      void write(const void* src, size_t size)
+      {
+         auto s = reinterpret_cast<const char*>(src);
+         for (char ch : std::span{s, size})
+         {
+            write(ch);
+         }
+      }
+
+      template <typename T>
+      void write_raw(const T& v)
+      {
+         write(&v, sizeof(v));
+      }
+
+      template <typename T>
+      void rewrite_raw(size_t offset, const T& v)
+      {
+         char                  buf[sizeof(v) * 2];
+         std::span<const char> in{reinterpret_cast<const char*>(&v), sizeof(v)};
+         psio::hex(in.begin(), in.end(), buf);
+         stream.rewrite_raw(base + offset * 2, buf);
+      }
+
+      size_t written() const { return (stream.written() - base) / 2; }
+   };
+
    /**
     * This type is serialized as a vector<char> holding the packed value.
     */
@@ -18,7 +71,10 @@ namespace psio
    template <typename T, typename Stream>
    void to_json(const nested<T>& obj, Stream& stream)
    {
-      to_json(to_frac(obj.value), stream);
+      stream.write('"');
+      hex_output_stream hex(stream);
+      to_frac(obj.value, hex);
+      stream.write('"');
    }
 
    template <typename T, typename Stream>
@@ -29,8 +85,14 @@ namespace psio
       from_frac(obj.value, tmp);
    }
 
-   template <typename T>
-   struct is_packable<nested<T>> : base_packable_impl<nested<T>, is_packable<nested<T>>>
+   // Handles any type that backs to a byte vector
+   //
+   // Derived must provide
+   // - pack_contents
+   // - unpack_contents
+   // - is_empty_container
+   template <typename T, typename Derived>
+   struct is_packable_nested_impl : base_packable_impl<T, Derived>
    {
       static constexpr uint32_t fixed_size        = 4;
       static constexpr bool     is_variable_size  = true;
@@ -38,22 +100,17 @@ namespace psio
       static constexpr bool     supports_0_offset = true;
 
       template <typename S>
-      static void pack(const nested<T>& value, S& stream)
+      static void pack(const T& value, S& stream)
       {
          std::uint32_t size = 0;
          auto          pos  = stream.written();
          stream.write_raw(size);
-         is_packable<std::remove_cvref_t<T>>::pack(value.value, stream);
+         Derived::pack_contents(value, stream);
          auto end = stream.written();
          size     = end - (pos + 4);
          stream.rewrite_raw(pos, size);
       }
 
-      static bool is_empty_container(const nested<T>&)
-      {
-         using is_p = is_packable<std::remove_cvref_t<T>>;
-         return !is_p::is_variable_size && is_p::fixed_size == 0;
-      }
       static bool is_empty_container(const char* src, uint32_t pos, uint32_t end_pos)
       {
          uint32_t fixed_size;
@@ -63,21 +120,21 @@ namespace psio
       }
 
       template <bool Verify>
-      static bool clear_container(nested<T>* value)
+      static bool clear_container(T* value)
       {
-         // We don't need to proagate these up, because an empty object
+         // We don't need to propagate these up, because an empty object
          // definitely does not contain unknown data
          bool          has_unknown = false;
          bool          known_end;
          std::uint32_t pos = 0;
-         if (!is_packable<std::remove_cvref_t<T>>::template unpack<true, Verify>(
-                 &value->value, has_unknown, known_end, value->data(), pos, 0))
+         if (!Derived::template unpack_contents<true, Verify>(value, has_unknown, known_end,
+                                                              value->data(), pos, 0))
             return false;
          return true;
       }
 
       template <bool Unpack, bool Verify>
-      [[nodiscard]] static bool unpack(nested<T>*  value,
+      [[nodiscard]] static bool unpack(T*          value,
                                        bool&       has_unknown,
                                        bool&       known_end,
                                        const char* src,
@@ -95,9 +152,8 @@ namespace psio
          }
          bool          inner_known_end;
          std::uint32_t inner_pos = pos;
-         if (!is_packable<std::remove_cvref_t<T>>::template unpack<Unpack, Verify>(
-                 Unpack ? &value->value : nullptr, has_unknown, inner_known_end, src, inner_pos,
-                 pos + size))
+         if (!Derived::template unpack_contents<Unpack, Verify>(value, has_unknown, inner_known_end,
+                                                                src, inner_pos, pos + size))
             return false;
          if constexpr (Verify)
          {
@@ -109,4 +165,115 @@ namespace psio
          return true;
       }
    };
+
+   template <typename T>
+   struct is_packable<nested<T>> : is_packable_nested_impl<nested<T>, is_packable<nested<T>>>
+   {
+      static bool is_empty_container(const nested<T>&)
+      {
+         using is_p = is_packable<std::remove_cvref_t<T>>;
+         return !is_p::is_variable_size && is_p::fixed_size == 0;
+      }
+      template <typename S>
+      static void pack_contents(const nested<T>& value, S& stream)
+      {
+         is_packable<std::remove_cvref_t<T>>::pack(value.value, stream);
+      }
+      template <bool Unpack, bool Verify>
+      static bool unpack_contents(nested<T>*  value,
+                                  bool&       has_unknown,
+                                  bool&       known_end,
+                                  const char* src,
+                                  uint32_t&   pos,
+                                  uint32_t    end_pos)
+      {
+         return is_packable<std::remove_cvref_t<T>>::template unpack<Unpack, Verify>(
+             Unpack ? &value->value : nullptr, has_unknown, known_end, src, pos, end_pos);
+      }
+   };
+
+   template <typename T>
+   struct view_interface<nested<T>> : view_base<nested<T>>
+   {
+      auto value() { return view<T>(prevalidated{this->data + 4}); }
+   };
+
+   template <typename T>
+   struct view_interface<const nested<T>> : view_base<const nested<T>>
+   {
+      auto value() { return view<const T>(prevalidated{this->data + 4}); }
+   };
+
+   template <typename T>
+   struct nested_json
+   {
+      T value;
+   };
+
+   template <typename T, typename Stream>
+   void to_json(const nested_json<T>& obj, Stream& stream)
+   {
+      stream.write('"');
+      hex_output_stream hex(stream);
+      to_json(obj.value, hex);
+      stream.write('"');
+   }
+
+   template <typename T, typename Stream>
+   void from_json(nested_json<T>& obj, Stream& stream)
+   {
+      std::vector<char> tmp;
+      from_json(tmp, stream);
+      tmp.push_back(0);
+      Stream inner{tmp.data()};
+      from_json(obj.value, inner);
+   }
+
+   template <typename T>
+   struct is_packable<nested_json<T>>
+       : is_packable_nested_impl<nested_json<T>, is_packable<nested_json<T>>>
+   {
+      static bool is_empty_container(const nested_json<T>&)
+      {
+         // The empty string is not valid JSON
+         return false;
+      }
+      template <typename S>
+      static void pack_contents(const nested_json<T>& value, S& stream)
+      {
+         to_json(value.value, stream);
+      }
+      template <bool Unpack, bool Verify>
+      static bool unpack_contents(nested<T>*  value,
+                                  bool&       has_unknown,
+                                  bool&       known_end,
+                                  const char* src,
+                                  uint32_t&   pos,
+                                  uint32_t    end_pos)
+      {
+         std::vector<char> contents;
+         contents.reserve(end_pos - pos + 1);
+         contents.insert(contents.end(), src + pos, src + end_pos);
+         contents.push_back(0);
+         if constexpr (Unpack)
+         {
+            json_token_stream stream(contents.data());
+            from_json(value->value, stream);
+         }
+         return true;
+      }
+   };
+
+   template <typename T>
+   constexpr bool packable_as_impl<nested<T>, std::vector<char>> = true;
+   template <typename T, typename U>
+   constexpr bool packable_as_impl<nested<T>, nested<U>> = PackableAs<T, U>;
+
+   template <typename T>
+   constexpr bool packable_as_impl<nested_json<T>, std::vector<char>> = true;
+   template <typename T>
+   constexpr bool packable_as_impl<nested_json<T>, std::string> = true;
+   template <typename T, typename U>
+   constexpr bool packable_as_impl<nested_json<T>, nested_json<U>> = PackableAs<T, U>;
+
 }  // namespace psio

--- a/libraries/psio/include/psio/reflect.hpp
+++ b/libraries/psio/include/psio/reflect.hpp
@@ -418,6 +418,9 @@ namespace psio
       using type = std::tuple<std::remove_cvref_t<decltype(psio::result_of_member(F))>...>;
    };
 
+   template <typename T>
+   using struct_tuple_t = get_struct_tuple_impl<typename reflect<T>::data_members>::type;
+
    template <auto... M, typename F>
    constexpr decltype(auto) apply_members(MemberList<M...>*, F&& f)
    {

--- a/libraries/psio/include/psio/to_json.hpp
+++ b/libraries/psio/include/psio/to_json.hpp
@@ -355,6 +355,18 @@ template <typename S> void to_json(float value, S& stream)              { return
    }
 
    template <typename S>
+   void to_json(const std::span<char>& obj, S& stream)
+   {
+      to_json_hex(obj.data(), obj.size(), stream);
+   }
+
+   template <typename S>
+   void to_json(const std::span<const char>& obj, S& stream)
+   {
+      to_json_hex(obj.data(), obj.size(), stream);
+   }
+
+   template <typename S>
    void to_json(const std::vector<char>& obj, S& stream)
    {
       to_json_hex(obj.data(), obj.size(), stream);

--- a/services/system/CMakeLists.txt
+++ b/services/system/CMakeLists.txt
@@ -5,6 +5,13 @@ function(add_system_service suffix name)
     set_target_properties(${name}${suffix} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
 endfunction()
 
+function(add_system_service_full_malloc suffix name)
+    add_executable(${name}${suffix} ${ARGN})
+    target_mapped_include_directories(${name}${suffix} PUBLIC include)
+    target_link_libraries(${name}${suffix} PUBLIC services_system${suffix} psibase-service${suffix})
+    set_target_properties(${name}${suffix} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
+endfunction()
+
 function(add_system_test_impl suffix name)
     set(TARGET ${name}-test${suffix})
     add_executable(${TARGET} ${ARGN})

--- a/services/system/Transact/CMakeLists.txt
+++ b/services/system/Transact/CMakeLists.txt
@@ -1,6 +1,6 @@
 function(add suffix)
     add_system_service("${suffix}" Transact src/Transact.cpp)
-    add_system_service("${suffix}" RTransact src/RTransact.cpp)
+    add_system_service_full_malloc("${suffix}" RTransact src/RTransact.cpp)
 endfunction(add)
 
 conditional_add()

--- a/services/system/Transact/src/RTransact.cpp
+++ b/services/system/Transact/src/RTransact.cpp
@@ -58,58 +58,125 @@ std::optional<SignedTransaction> SystemService::RTransact::next()
 
 namespace
 {
-   ActionTrace pruneActionTrace(psio::view<const ActionTrace> at);
-
-   InnerTrace pruneInnerTrace(psio::view<const InnerTrace> inner)
+   namespace refs
    {
-      InnerTrace pruned;
-      if (psio::holds_alternative<ActionTrace>(inner.inner()))
+      struct InnerTrace;
+      struct Action
       {
-         pruned.inner = pruneActionTrace(psio::get<ActionTrace>(inner.inner()));
-      }
-      else
-      {
-         pruned.inner = inner.inner();
-      }
-      return pruned;
-   }
+         AccountNumber         sender;   ///< Account sending the action
+         AccountNumber         service;  ///< Service to execute the action
+         MethodNumber          method;   ///< Service method to execute
+         std::span<const char> rawData;  ///< Data for the method
+      };
+      PSIO_REFLECT(Action, sender, service, method, rawData)
 
-   Action pruneAction(psio::view<const Action> action)
-   {
-      Action pruned;
-      pruned.sender  = action.sender();
-      pruned.service = action.service();
-      pruned.method  = action.method();
-      pruned.rawData = {};
-      return pruned;
-   }
-
-   ActionTrace pruneActionTrace(psio::view<const ActionTrace> at)
-   {
-      ActionTrace pruned;
-      pruned.error     = at.error();
-      pruned.totalTime = at.totalTime();
-      pruned.rawRetval = at.rawRetval();
-      pruned.action    = pruneAction(at.action());
-      pruned.innerTraces.reserve(at.innerTraces().size());
-      for (const auto& inner : at.innerTraces())
+      struct ActionTrace
       {
-         pruned.innerTraces.push_back(pruneInnerTrace(inner));
-      }
-      return pruned;
-   }
+         Action                          action;
+         std::span<const char>           rawRetval;
+         std::vector<InnerTrace>         innerTraces;
+         std::chrono::nanoseconds        totalTime;
+         std::optional<std::string_view> error;
+      };
+      PSIO_REFLECT(ActionTrace, action, rawRetval, innerTraces, totalTime, error)
 
-   TransactionTrace pruneTrace(psio::view<const TransactionTrace> trace)
-   {
-      TransactionTrace pruned;
-      pruned.error = trace.error();
-      pruned.actionTraces.reserve(trace.actionTraces().size());
-      for (const auto& at : trace.actionTraces())
+      struct EventTrace
       {
-         pruned.actionTraces.push_back(pruneActionTrace(at));
+         std::string_view      name;
+         std::span<const char> data;
+      };
+      PSIO_REFLECT(EventTrace, name, data)
+
+      struct ConsoleTrace
+      {
+         std::string_view console;
+      };
+      PSIO_REFLECT(ConsoleTrace, console)
+
+      struct InnerTrace
+      {
+         std::variant<ConsoleTrace, EventTrace, ActionTrace> inner;
+      };
+      PSIO_REFLECT(InnerTrace, inner)
+
+      struct TransactionTrace
+      {
+         std::vector<ActionTrace>        actionTraces;
+         std::optional<std::string_view> error;
+      };
+      PSIO_REFLECT(TransactionTrace, actionTraces, error)
+   }  // namespace refs
+   using ActionRef           = refs::Action;
+   using ActionTraceRef      = refs::ActionTrace;
+   using EventTraceRef       = refs::EventTrace;
+   using ConsoleTraceRef     = refs::ConsoleTrace;
+   using InnerTraceRef       = refs::InnerTrace;
+   using TransactionTraceRef = refs::TransactionTrace;
+
+   struct PruneTrace
+   {
+      bool                            args = false;
+      std::optional<std::string_view> operator()(psio::view<const std::optional<std::string>> msg)
+      {
+         if (msg)
+         {
+            return static_cast<std::string_view>(*msg);
+         }
+         else
+         {
+            return {};
+         }
       }
-      return pruned;
-   }
+      ActionRef operator()(psio::view<const Action> action)
+      {
+         return {
+             .sender  = action.sender(),
+             .service = action.service(),
+             .method  = action.method(),
+             .rawData = args ? action.rawData() : std::span<const char>{},
+         };
+      }
+      auto operator()(psio::view<const ConsoleTrace> trace)
+      {
+         return ConsoleTraceRef{trace.console()};
+      }
+      auto operator()(psio::view<const EventTrace> trace)
+      {
+         return EventTraceRef{trace.name(), trace.data()};
+      }
+      auto operator()(psio::view<const ActionTrace> at)
+      {
+         ActionTraceRef pruned;
+         pruned.error     = (*this)(at.error());
+         pruned.totalTime = at.totalTime();
+         pruned.rawRetval = at.rawRetval();
+         pruned.action    = (*this)(at.action());
+         pruned.innerTraces.reserve(at.innerTraces().size());
+         for (const auto& inner : at.innerTraces())
+         {
+            pruned.innerTraces.push_back((*this)(inner));
+         }
+         return pruned;
+      }
+      InnerTraceRef operator()(psio::view<const InnerTrace> inner)
+      {
+         return psio::visit([this](const auto& trace) { return InnerTraceRef{(*this)(trace)}; },
+                            inner.inner());
+      }
+
+      auto operator()(psio::view<const TransactionTrace> trace)
+      {
+         TransactionTraceRef pruned;
+         pruned.error = (*this)(trace.error());
+         pruned.actionTraces.reserve(trace.actionTraces().size());
+         for (const auto& at : trace.actionTraces())
+         {
+            pruned.actionTraces.push_back((*this)(at));
+         }
+         return pruned;
+      }
+   };
+
 }  // namespace
 
 void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> trace)
@@ -117,7 +184,7 @@ void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> 
    check(getSender() == AccountNumber{}, "Wrong sender");
    printf("trace size: %zu\n", find_view_span(trace).size());
 
-   TransactionTrace pruned = pruneTrace(trace);
+   TransactionTraceRef pruned = PruneTrace{true}(trace);
 
    auto                          clients = Subjective{}.open<TraceClientTable>();
    std::optional<TraceClientRow> row;
@@ -143,26 +210,34 @@ void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> 
    }
    if (json)
    {
-      HttpReply           reply{.contentType = "application/json"};
-      psio::vector_stream stream{reply.body};
-
-      to_json(std::move(pruned), stream);
+      JsonHttpReply<TransactionTraceRef&> reply{.contentType = "application/json", .body{pruned}};
+      ActionViewBuilder<HttpServer>       http{getReceiver(), HttpServer::service};
+      auto                                action = http.sendReply(0, reply);
 
       for (auto client : row->clients)
          if (client.json)
-            to<HttpServer>().sendReply(client.socket, reply);
+         {
+            psio::get<0>(action->rawData().value()) = client.socket;
+            call(action.data(), action.size());
+         }
    }
    if (bin)
    {
-      HttpReply           reply{.contentType = "application/octet-stream"};
-      psio::vector_stream stream{reply.body};
-
-      to_frac(std::move(pruned), stream);
+      FracpackHttpReply<TransactionTraceRef&> reply{.contentType = "application/octet-stream",
+                                                    .body{pruned}};
+      ActionViewBuilder<HttpServer>           http{getReceiver(), HttpServer::service};
+      auto                                    action = http.sendReply(0, reply);
 
       for (auto client : row->clients)
          if (!client.json)
-            to<HttpServer>().sendReply(client.socket, reply);
+         {
+            psio::get<0>(action->rawData().value()) = client.socket;
+            call(action.data(), action.size());
+         }
    }
+#ifdef __wasm32__
+   printf("memory usage: %lu\n", __builtin_wasm_memory_size(0) * 65536);
+#endif
 }
 
 void RTransact::onBlock()


### PR DESCRIPTION
#1050 didn't actually work because it was only applied to the (unused) form that returns a view.

This reduces the total memory usage to approximately 2 times the size of the trace for fracpack or 3 times the size of the trace for json. Since this is exactly the combined size of the input and output, this is optimal. With this change, I can boot with full JSON traces without errors.