### PR TITLE
Handle errors from failure to sign

### DIFF
--- a/libraries/net/include/psibase/cft.hpp
+++ b/libraries/net/include/psibase/cft.hpp
@@ -236,8 +236,15 @@ namespace psibase::net
             for_each_key(
                 [&](const auto& k)
                 {
-                   network().sendto(new_head->producer,
-                                    ConfirmMessage{current_term, self, new_head->blockNum, k});
+                   try
+                   {
+                      network().sendto(new_head->producer,
+                                       ConfirmMessage{current_term, self, new_head->blockNum, k});
+                   }
+                   catch (std::exception& e)
+                   {
+                      PSIBASE_LOG(logger, warning) << "Failed to confirm: " << e.what();
+                   }
                 });
          }
          Base::on_fork_switch(new_head);
@@ -421,8 +428,16 @@ namespace psibase::net
          for_each_key(
              [&](const auto& k)
              {
-                network().multicast_producers(RequestVoteRequest{
-                    current_term, self, chain().get_head()->blockNum, chain().get_head()->term, k});
+                try
+                {
+                   network().multicast_producers(RequestVoteRequest{current_term, self,
+                                                                    chain().get_head()->blockNum,
+                                                                    chain().get_head()->term, k});
+                }
+                catch (std::exception& e)
+                {
+                   PSIBASE_LOG(logger, warning) << "Failed to request vote: " << e.what();
+                }
              });
          check_votes();
       }
@@ -485,12 +500,19 @@ namespace psibase::net
             for_each_key(
                 [&](const auto& k)
                 {
-                   network().sendto(request.candidate_id,
-                                    RequestVoteResponse{.term         = current_term,
-                                                        .candidate_id = request.candidate_id,
-                                                        .voter_id     = self,
-                                                        .vote_granted = vote_granted,
-                                                        .signer       = k});
+                   try
+                   {
+                      network().sendto(request.candidate_id,
+                                       RequestVoteResponse{.term         = current_term,
+                                                           .candidate_id = request.candidate_id,
+                                                           .voter_id     = self,
+                                                           .vote_granted = vote_granted,
+                                                           .signer       = k});
+                   }
+                   catch (std::exception& e)
+                   {
+                      PSIBASE_LOG(logger, warning) << "Failed to vote: " << e.what();
+                   }
                 });
          }
       }

--- a/libraries/psibase/native/include/psibase/ForkDb.hpp
+++ b/libraries/psibase/native/include/psibase/ForkDb.hpp
@@ -1198,7 +1198,16 @@ namespace psibase
                check(id == state->blockId(), "blockId does not match");
                state->revision = newRevision;
 
-               on_accept_block(state);
+               try
+               {
+                  on_accept_block(state);
+               }
+               catch (std::exception& e)
+               {
+                  PSIBASE_LOG(blockLogger, error)
+                      << "on_accept_block needs to handle any errors, but it failed with: "
+                      << e.what();
+               }
                PSIBASE_LOG(blockLogger, info) << "Accepted block";
             }
             catch (std::exception& e)

--- a/programs/psinode/CMakeLists.txt
+++ b/programs/psinode/CMakeLists.txt
@@ -31,6 +31,12 @@ set_target_properties(psinode PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_
 
 find_package(Python COMPONENTS Interpreter)
 if(Python_Interpreter_FOUND)
+    function(add_psinode_test name)
+        add_test(
+            NAME psinode_${name}
+            COMMAND ${Python_EXECUTABLE} ${name}.py --psinode=$<TARGET_FILE:psinode>
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    endfunction()
     add_test(
         NAME py_test_fracpack
         COMMAND ${Python_EXECUTABLE} test_fracpack.py
@@ -43,42 +49,20 @@ if(Python_Interpreter_FOUND)
         NAME py_test_psibase_types
         COMMAND ${Python_EXECUTABLE} test_psibase_types.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(
-        NAME psinode_test_routing
-        COMMAND ${Python_EXECUTABLE} test_routing.py --psinode=$<TARGET_FILE:psinode>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_psinode_test(test_routing)
     set_tests_properties(psinode_test_routing PROPERTIES PROCESSORS 7)
-    add_test(
-        NAME psinode_test_crash
-        COMMAND ${Python_EXECUTABLE} test_crash.py --psinode=$<TARGET_FILE:psinode>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_psinode_test(test_crash)
     set_tests_properties(psinode_test_crash PROPERTIES PROCESSORS 4)
-    add_test(
-        NAME psinode_test_psibase
-        COMMAND ${Python_EXECUTABLE} test_psibase.py --psinode=$<TARGET_FILE:psinode>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(
-        NAME psinode_test_subjective
-        COMMAND ${Python_EXECUTABLE} test_subjective.py --psinode=$<TARGET_FILE:psinode>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_psinode_test(test_psibase)
+    add_psinode_test(test_subjective)
     set_tests_properties(psinode_test_subjective PROPERTIES PROCESSORS 4)
-    add_test(
-        NAME psinode_test_txqueue
-        COMMAND ${Python_EXECUTABLE} test_txqueue.py --psinode=$<TARGET_FILE:psinode>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(
-        NAME psinode_test_query
-        COMMAND ${Python_EXECUTABLE} test_query.py --psinode=$<TARGET_FILE:psinode>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(
-        NAME psinode_test_exception_exit
-        COMMAND ${Python_EXECUTABLE} test_exception_exit.py --psinode=$<TARGET_FILE:psinode>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(
-        NAME psinode_test_snapshot
-        COMMAND ${Python_EXECUTABLE} test_snapshot.py --psinode=$<TARGET_FILE:psinode>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_psinode_test(test_txqueue)
+    add_psinode_test(test_query)
+    add_psinode_test(test_exception_exit)
+    add_psinode_test(test_snapshot)
     set_tests_properties(psinode_test_snapshot PROPERTIES PROCESSORS 4)
+    add_psinode_test(test_block_signing)
+    set_tests_properties(psinode_test_block_signing PROPERTIES PROCESSORS 4)
 endif()
 
 include(GNUInstallDirs)

--- a/programs/psinode/tests/test_block_signing.py
+++ b/programs/psinode/tests/test_block_signing.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+
+from psinode import Cluster
+from predicates import *
+import testutil
+import unittest
+
+class TestBlockSigning(unittest.TestCase):
+    @testutil.psinode_test
+    def test_missing_key(self, cluster):
+        prods = cluster.complete(*testutil.generate_names(4))
+
+        print("booting chain")
+        prods[0].boot(packages=['Minimal', 'Explorer'])
+
+        print("Setting up automatic reconnection")
+        with prods[3].get('/native/admin/config', service='x-admin') as reply:
+            reply.raise_for_status()
+            cfgd = reply.json()
+        print(cfgd)
+        cfgd["peers"] = [prods[0].socketpath, prods[1].socketpath, prods[2].socketpath]
+        print(cfgd)
+        with prods[3].put('/native/admin/config', service='x-admin', headers={'Content-Type': 'application/json'}, json=cfgd) as reply:
+            reply.raise_for_status()
+
+        print("setting producers")
+        prods[0].set_producers([prods[0], prods[1], prods[2], {"name":prods[3].producer,"auth":{"service":"verify-sig", "rawData":"3059301306072a8648ce3d020106082a8648ce3d0301070342000457ba94147759d2ec5691a669da54ccb7e6a2852fad0cbcc31814b20cdf3e995966e680f22c3f57ee7386ffe7d14fead13757d52db02a95b563ae0932f17fbe27"}}], 'bft')
+
+        prods[3].wait(producers_are(prods))
+        prods[3].wait(new_block(), timeout=20)
+
+if __name__ == '__main__':
+    testutil.main()


### PR DESCRIPTION
They were causing two problems
- When the error appeared while handling an incoming block, it would be treated as if it were a failure to execute the block, which could later cause a report of a consensus failure, when the block becomes irreversible.
- When the error appeared for other incoming messages, it would be treated as an invalid message and force the connection to be closed.

Note that this error handling is still needed even if we try to avoid entering producer mode when the key is missing, because a cryptographic device can be physically removed or otherwise become unavailable at any time and outside our control.