### PR TITLE
Add tests for signing transactions with `psibase`

### DIFF
--- a/programs/psinode/tests/name.py
+++ b/programs/psinode/tests/name.py
@@ -567,6 +567,7 @@ def is_hash_name(h):
     return (h & (0x01 << (64 - 8))) > 0
 
 def method_to_number(input):
+    input = input.replace('_', '')
     if len(input) == 0:
         return 0;
 


### PR DESCRIPTION
#1080 and #1087 did not include test cases because the python wrappers lacked support for signing.