### PR TITLE
Fix sending response to the wrong request after server restart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ if(DEFINED WASI_SDK_PREFIX)
                          ${CMAKE_CURRENT_BINARY_DIR}/AsyncQueryService.wasm
                          ${CMAKE_CURRENT_BINARY_DIR}/SubjectiveCounterService.wasm
                          ${CMAKE_CURRENT_BINARY_DIR}/KeepSocketService.wasm
+                         ${CMAKE_CURRENT_BINARY_DIR}/SocketListService.wasm
     )
     file(APPEND ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "subdirs(\"wasm\")\n")
     ExternalProject_Add_StepTargets(wasm test)
@@ -993,7 +994,20 @@ psibase_package(
     DEPENDS wasm
 )
 
-write_package_index(test-index ${CMAKE_CURRENT_BINARY_DIR}/test-packages PSubjective Counter AsyncQuery SubjectiveCounter KeepSocket)
+psibase_package(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/test-packages/SocketList.psi
+    NAME SocketList
+    VERSION ${PSIBASE_VERSION}
+    DESCRIPTION "Lists active sockets"
+    SERVICE s-sock-list
+        WASM ${CMAKE_CURRENT_BINARY_DIR}/SocketListService.wasm
+        SERVER s-sock-list
+        FLAGS allowNativeSubjective
+    PACKAGE_DEPENDS "HttpServer(^${PSIBASE_VERSION})"
+    DEPENDS wasm
+)
+
+write_package_index(test-index ${CMAKE_CURRENT_BINARY_DIR}/test-packages PSubjective Counter AsyncQuery SubjectiveCounter KeepSocket SocketList)
 
 ExternalProject_Add(
     rust

--- a/libraries/net/include/psibase/blocknet.hpp
+++ b/libraries/net/include/psibase/blocknet.hpp
@@ -263,6 +263,7 @@ namespace psibase::net
                    }
                 });
          }
+         SocketInfo info() const { return ProducerMulticastSocketInfo{}; }
       };
 
       producer_id                  self = null_producer;
@@ -554,7 +555,7 @@ namespace psibase::net
       // TODO: rename this function to a more generic init routine
       void load_producers()
       {
-         chain().addSocket(prods_socket);
+         chain().setSocket(SocketRow::producer_multicast, prods_socket);
          chain().onChangeNextTransaction(
              [this]
              {

--- a/libraries/psibase/common/include/psibase/nativeTables.hpp
+++ b/libraries/psibase/common/include/psibase/nativeTables.hpp
@@ -286,6 +286,11 @@ namespace psibase
 
    using SocketInfo = std::variant<ProducerMulticastSocketInfo, HttpSocketInfo>;
 
+   inline auto get_gql_name(SocketInfo*)
+   {
+      return "SocketInfo";
+   }
+
    using SocketKeyType = std::tuple<std::uint16_t, std::uint8_t, std::int32_t>;
    auto socketPrefix() -> KeyPrefixType;
    auto socketKey(std::int32_t fd) -> SocketKeyType;

--- a/libraries/psibase/common/include/psibase/nativeTables.hpp
+++ b/libraries/psibase/common/include/psibase/nativeTables.hpp
@@ -20,7 +20,8 @@ namespace psibase
    static constexpr NativeTableNum consensusChangeTable       = 10;  // subjective
    static constexpr NativeTableNum snapshotTable              = 11;  // subjective
    static constexpr NativeTableNum scheduledSnapshotTable     = 12;  // both
-   static constexpr NativeTableNum logTruncateTable           = 13;
+   static constexpr NativeTableNum logTruncateTable           = 13;  // subjective
+   static constexpr NativeTableNum socketTable                = 14;  // subjective
 
    static constexpr uint8_t nativeTablePrimaryIndex = 0;
 
@@ -269,6 +270,36 @@ namespace psibase
       static const auto db = psibase::DbId::nativeSubjective;
       auto              key() const -> LogTruncateKeyType;
       PSIO_REFLECT(LogTruncateRow, start)
+   };
+
+   struct ProducerMulticastSocketInfo
+   {
+      PSIO_REFLECT(ProducerMulticastSocketInfo)
+      friend bool operator==(const ProducerMulticastSocketInfo&,
+                             const ProducerMulticastSocketInfo&) = default;
+   };
+   struct HttpSocketInfo
+   {
+      PSIO_REFLECT(HttpSocketInfo)
+      friend bool operator==(const HttpSocketInfo&, const HttpSocketInfo&) = default;
+   };
+
+   using SocketInfo = std::variant<ProducerMulticastSocketInfo, HttpSocketInfo>;
+
+   using SocketKeyType = std::tuple<std::uint16_t, std::uint8_t, std::int32_t>;
+   auto socketPrefix() -> KeyPrefixType;
+   auto socketKey(std::int32_t fd) -> SocketKeyType;
+   struct SocketRow
+   {
+      // Well-known fds
+      static constexpr std::int32_t producer_multicast = 0;
+
+      std::int32_t fd;
+      SocketInfo   info;
+
+      static const auto db = psibase::DbId::nativeSubjective;
+      auto              key() const -> SocketKeyType;
+      PSIO_REFLECT(SocketRow, fd, info)
    };
 
 }  // namespace psibase

--- a/libraries/psibase/common/src/nativeTables.cpp
+++ b/libraries/psibase/common/src/nativeTables.cpp
@@ -137,4 +137,17 @@ namespace psibase
    {
       return logTruncateKey();
    }
+
+   auto socketPrefix() -> KeyPrefixType
+   {
+      return std::tuple{socketTable, nativeTablePrimaryIndex};
+   }
+   auto socketKey(std::int32_t fd) -> SocketKeyType
+   {
+      return std::tuple{socketTable, nativeTablePrimaryIndex, fd};
+   }
+   auto SocketRow::key() const -> SocketKeyType
+   {
+      return socketKey(fd);
+   }
 }  // namespace psibase

--- a/libraries/psibase/native/include/psibase/ForkDb.hpp
+++ b/libraries/psibase/native/include/psibase/ForkDb.hpp
@@ -2062,7 +2062,10 @@ namespace psibase
          }
       }
 
-      void addSocket(const std::shared_ptr<Socket>& sock) { systemContext->sockets->add(sock); }
+      void setSocket(std::int32_t fd, const std::shared_ptr<Socket>& sock)
+      {
+         systemContext->sockets->set(*writer, fd, sock);
+      }
 
       std::vector<char> getBlockProof(ConstRevisionPtr revision, BlockNum blockNum)
       {

--- a/libraries/psibase/native/include/psibase/Socket.hpp
+++ b/libraries/psibase/native/include/psibase/Socket.hpp
@@ -43,7 +43,7 @@ namespace psibase
    struct SocketAutoCloseSet
    {
       std::set<std::shared_ptr<AutoCloseSocket>> sockets;
-      void close(const std::optional<std::string>& message = {});
+      void close(Writer& writer, Sockets& sockets, const std::optional<std::string>& message = {});
       bool owns(Sockets& sockets, const AutoCloseSocket& sock);
       ~SocketAutoCloseSet();
    };

--- a/libraries/psibase/native/include/psibase/Socket.hpp
+++ b/libraries/psibase/native/include/psibase/Socket.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <psibase/check.hpp>
+#include <psibase/db.hpp>
 #include <set>
 #include <span>
 #include <vector>
@@ -17,6 +18,7 @@ namespace psibase
       ~Socket();
       virtual void           send(std::span<const char>) = 0;
       virtual bool           canAutoClose() const;
+      virtual SocketInfo     info() const = 0;
       std::int32_t           id;
       bool                   closed = false;
       bool                   once   = false;
@@ -29,7 +31,7 @@ namespace psibase
    {
       virtual bool        canAutoClose() const override;
       virtual void        autoClose(const std::optional<std::string>& message) noexcept = 0;
-      SocketAutoCloseSet* owner;
+      SocketAutoCloseSet* owner                                                         = nullptr;
    };
 
    struct SocketChange
@@ -37,8 +39,6 @@ namespace psibase
       std::shared_ptr<AutoCloseSocket> socket;
       SocketAutoCloseSet*              owner;
    };
-
-   using SocketChangeSet = std::vector<SocketChange>;
 
    struct SocketAutoCloseSet
    {
@@ -50,14 +50,19 @@ namespace psibase
 
    struct Sockets : std::enable_shared_from_this<Sockets>
    {
+      SharedDatabase                       sharedDb;
       std::vector<std::shared_ptr<Socket>> sockets;
       boost::dynamic_bitset<>              available;
       bool                                 stopped = false;
       std::mutex                           mutex;
-      void                                 shutdown();
-      std::int32_t                         send(std::int32_t fd, std::span<const char> buf);
-      void         add(const std::shared_ptr<Socket>& socket, SocketAutoCloseSet* owner = nullptr);
-      void         remove(const std::shared_ptr<Socket>& socket);
+      explicit Sockets(SharedDatabase sharedDb);
+      void         shutdown();
+      std::int32_t send(Writer& writer, std::int32_t fd, std::span<const char> buf);
+      void         add(Writer&                        writer,
+                       const std::shared_ptr<Socket>& socket,
+                       SocketAutoCloseSet*            owner = nullptr);
+      void         set(Writer& writer, std::int32_t fd, const std::shared_ptr<Socket>& socket);
+      void         remove(Writer& writer, const std::shared_ptr<Socket>& socket);
       std::int32_t autoClose(std::int32_t               socket,
                              bool                       value,
                              SocketAutoCloseSet*        owner,

--- a/libraries/psibase/native/include/psibase/db.hpp
+++ b/libraries/psibase/native/include/psibase/db.hpp
@@ -2,7 +2,6 @@
 
 #include_next <psibase/db.hpp>
 
-#include <psibase/Socket.hpp>
 #include <psibase/blob.hpp>
 #include <psibase/nativeTables.hpp>
 #include <psio/fracpack.hpp>
@@ -22,6 +21,11 @@ namespace triedent
 
 namespace psibase
 {
+   struct SocketAutoCloseSet;
+   struct Sockets;
+   struct SocketChange;
+   using SocketChangeSet = std::vector<SocketChange>;
+
    struct Revision;
    using ConstRevisionPtr = std::shared_ptr<const Revision>;
 
@@ -100,6 +104,7 @@ namespace psibase
       void             removeRevisions(Writer& writer, const Checksum256& irreversible);
 
       void kvPutSubjective(Writer& writer, std::span<const char> key, std::span<const char> value);
+      void kvRemoveSubjective(Writer& writer, std::span<const char> key);
       std::optional<std::vector<char>> kvGetSubjective(Writer& writer, std::span<const char> key);
 
       IndependentRevision getSubjective();

--- a/libraries/psibase/native/src/NativeFunctions.cpp
+++ b/libraries/psibase/native/src/NativeFunctions.cpp
@@ -739,7 +739,8 @@ namespace psibase
       check(code.flags & CodeRow::isSubjective || allowDbReadSubjective,
             "Sockets are only available during subjective execution");
       check(code.flags & CodeRow::allowSocket, "Service is not allowed to write to socket");
-      return transactionContext.blockContext.systemContext.sockets->send(fd, msg);
+      return transactionContext.blockContext.systemContext.sockets->send(
+          *transactionContext.blockContext.writer, fd, msg);
    }
 
    int32_t NativeFunctions::socketAutoClose(int32_t fd, bool value)

--- a/libraries/psibase/native/src/Socket.cpp
+++ b/libraries/psibase/native/src/Socket.cpp
@@ -46,7 +46,21 @@ bool SocketAutoCloseSet::owns(Sockets& sockets, const AutoCloseSocket& sock)
 
 namespace
 {
-   void doRemoveSocket(std::shared_ptr<Socket>& socket)
+   struct NullProducersSocket : Socket
+   {
+      virtual void       send(std::span<const char>) override {}
+      virtual SocketInfo info() const override { return ProducerMulticastSocketInfo{}; }
+   };
+
+   struct NullHttpSocket : AutoCloseSocket
+   {
+      NullHttpSocket() { once = true; }
+      virtual void       send(std::span<const char>) override {}
+      virtual void       autoClose(const std::optional<std::string>&) noexcept override {}
+      virtual SocketInfo info() const override { return HttpSocketInfo{}; }
+   };
+
+   void doRemoveSocket(std::shared_ptr<Socket>& socket, SharedDatabase& sharedDb, Writer& writer)
    {
       assert(!socket->closed);
       if (socket->canAutoClose())
@@ -55,10 +69,60 @@ namespace
          if (sockptr->owner)
             sockptr->owner->sockets.erase(sockptr);
       }
+      {
+         auto key = socketKey(socket->id);
+         sharedDb.kvRemoveSubjective(writer, psio::convert_to_key(key));
+      }
       socket->closed = true;
       socket.reset();
    }
+
+   struct MakeNullSocketVisitor
+   {
+      std::shared_ptr<Socket> operator()(const ProducerMulticastSocketInfo&)
+      {
+         return std::make_shared<NullProducersSocket>();
+      }
+      std::shared_ptr<Socket> operator()(const HttpSocketInfo&)
+      {
+         return std::make_shared<NullHttpSocket>();
+      }
+   };
 }  // namespace
+
+Sockets::Sockets(SharedDatabase sharedDb) : sharedDb(std::move(sharedDb))
+{
+   // emptyRevision is okay, because we only need the subjective db
+   Database db{this->sharedDb, sharedDb.emptyRevision()};
+   auto     session = db.startRead();
+   db.checkoutSubjective();
+   auto                   key       = psio::convert_to_key(socketPrefix());
+   auto                   prefixLen = key.size();
+   std::vector<SocketRow> rows;
+   while (auto kv = db.kvGreaterEqualRaw(SocketRow::db, key, prefixLen))
+   {
+      auto row = psio::from_frac<SocketRow>(std::span{kv->value.pos, kv->value.end});
+      check(row.fd >= 0, "invalid fd");
+      rows.push_back(row);
+      key.assign(kv->key.pos, kv->key.end);
+      key.push_back(0);
+   }
+
+   if (!rows.empty())
+   {
+      auto maxFd = static_cast<std::size_t>(rows.back().fd);
+      available.resize(maxFd + 1, true);
+      sockets.resize(maxFd + 1);
+      for (const auto& row : rows)
+      {
+         auto pos  = static_cast<std::size_t>(row.fd);
+         auto sock = std::visit(MakeNullSocketVisitor{}, row.info);
+         sock->id  = row.fd;
+         available.reset(pos);
+         sockets[pos] = std::move(sock);
+      }
+   }
+}
 
 void Sockets::shutdown()
 {
@@ -69,7 +133,7 @@ void Sockets::shutdown()
    tmpsockets.clear();
 }
 
-std::int32_t Sockets::send(std::int32_t fd, std::span<const char> buf)
+std::int32_t Sockets::send(Writer& writer, std::int32_t fd, std::span<const char> buf)
 {
    std::shared_ptr<Socket> p;
    {
@@ -80,14 +144,14 @@ std::int32_t Sockets::send(std::int32_t fd, std::span<const char> buf)
          return wasi_errno_badf;
       if (p->once)
       {
-         doRemoveSocket(sockets[fd]);
+         doRemoveSocket(sockets[fd], sharedDb, writer);
       }
    }
 
    p->send(buf);
    return 0;
 }
-void Sockets::add(const std::shared_ptr<Socket>& socket, SocketAutoCloseSet* owner)
+void Sockets::add(Writer& writer, const std::shared_ptr<Socket>& socket, SocketAutoCloseSet* owner)
 {
    std::lock_guard l{mutex};
    check(!stopped, "Shutting down");
@@ -107,6 +171,10 @@ void Sockets::add(const std::shared_ptr<Socket>& socket, SocketAutoCloseSet* own
       sockets.push_back(socket);
       available.push_back(false);
    }
+   {
+      SocketRow row{socket->id, socket->info()};
+      sharedDb.kvPutSubjective(writer, psio::convert_to_key(row.key()), psio::to_frac(row));
+   }
    if (owner)
    {
       assert(socket->canAutoClose());
@@ -116,12 +184,40 @@ void Sockets::add(const std::shared_ptr<Socket>& socket, SocketAutoCloseSet* own
    }
    socket->weak_sockets = shared_from_this();
 }
-void Sockets::remove(const std::shared_ptr<Socket>& socket)
+void Sockets::set(Writer& writer, std::int32_t fd, const std::shared_ptr<Socket>& socket)
+{
+   std::lock_guard l{mutex};
+   check(!stopped, "Shutting down");
+   check(fd >= 0, "invalid fd");
+   auto pos = static_cast<std::size_t>(fd);
+   if (pos + 1 > available.size())
+   {
+      available.resize(pos + 1, true);
+      sockets.resize(pos + 1);
+   }
+   if (!available[pos])
+   {
+      check(sockets[pos]->info() == socket->info(), "Replacing socket does not match");
+      sockets[pos]->weak_sockets.reset();
+      sockets[pos] = socket;
+   }
+   else
+   {
+      socket->id   = fd;
+      sockets[pos] = socket;
+      available.reset(pos);
+      SocketRow row{socket->id, socket->info()};
+      sharedDb.kvPutSubjective(writer, psio::convert_to_key(row.key()), psio::to_frac(row));
+   }
+
+   socket->weak_sockets = shared_from_this();
+}
+void Sockets::remove(Writer& writer, const std::shared_ptr<Socket>& socket)
 {
    std::lock_guard l{mutex};
    if (socket->id >= 0 && socket->id < sockets.size() && sockets[socket->id] == socket)
    {
-      doRemoveSocket(sockets[socket->id]);
+      doRemoveSocket(sockets[socket->id], sharedDb, writer);
    }
 }
 std::int32_t Sockets::autoClose(std::int32_t               fd,

--- a/libraries/psibase/native/src/SystemContext.cpp
+++ b/libraries/psibase/native/src/SystemContext.cpp
@@ -23,7 +23,7 @@ namespace psibase
           : db{std::move(db)},
             wasmCache{std::move(wasmCache)},
             watchdogManager(std::make_shared<WatchdogManager>()),
-            sockets(std::make_shared<Sockets>())
+            sockets(std::make_shared<Sockets>(this->db))
       {
       }
    };

--- a/libraries/psibase/native/src/TransactionContext.cpp
+++ b/libraries/psibase/native/src/TransactionContext.cpp
@@ -49,6 +49,7 @@ namespace psibase
 
    TransactionContext::~TransactionContext()
    {
+      ownedSockets.close(*blockContext.writer, *blockContext.systemContext.sockets);
       blockContext.db.clearTemporary();
    }
 
@@ -155,7 +156,8 @@ namespace psibase
       catch (std::exception& e)
       {
          atrace.error = e.what();
-         self.ownedSockets.close(atrace.error);
+         self.ownedSockets.close(*self.blockContext.writer,
+                                 *self.blockContext.systemContext.sockets, atrace.error);
          throw;
       }
    }
@@ -204,7 +206,8 @@ namespace psibase
       catch (std::exception& e)
       {
          atrace.error = e.what();
-         ownedSockets.close(atrace.error);
+         ownedSockets.close(*blockContext.writer, *blockContext.systemContext.sockets,
+                            atrace.error);
          throw;
       }
    }
@@ -230,7 +233,8 @@ namespace psibase
       catch (std::exception& e)
       {
          atrace.error = e.what();
-         ownedSockets.close(atrace.error);
+         ownedSockets.close(*blockContext.writer, *blockContext.systemContext.sockets,
+                            atrace.error);
          throw;
       }
    }
@@ -273,7 +277,8 @@ namespace psibase
       catch (std::exception& e)
       {
          atrace.error = e.what();
-         ownedSockets.close(atrace.error);
+         ownedSockets.close(*blockContext.writer, *blockContext.systemContext.sockets,
+                            atrace.error);
          throw;
       }
    }
@@ -299,7 +304,8 @@ namespace psibase
       catch (std::exception& e)
       {
          atrace.error = e.what();
-         ownedSockets.close(atrace.error);
+         ownedSockets.close(*blockContext.writer, *blockContext.systemContext.sockets,
+                            atrace.error);
          throw;
       }
    }

--- a/libraries/psibase/native/src/useTriedent.cpp
+++ b/libraries/psibase/native/src/useTriedent.cpp
@@ -1,6 +1,7 @@
 #include <psibase/db.hpp>
 
 #include <boost/filesystem/operations.hpp>
+#include <psibase/Socket.hpp>
 #include <triedent/database.hpp>
 
 namespace psibase
@@ -358,6 +359,15 @@ namespace psibase
    {
       std::lock_guard l{impl->subjectiveMutex};
       writer.upsert(impl->subjective[independentIndex(DbId::nativeSubjective)], key, value);
+      std::lock_guard lock{impl->topMutex};
+      writer.upsert(impl->topRoot, subjectiveKey, impl->subjective);
+      writer.set_top_root(impl->topRoot);
+   }
+
+   void SharedDatabase::kvRemoveSubjective(Writer& writer, std::span<const char> key)
+   {
+      std::lock_guard l{impl->subjectiveMutex};
+      writer.remove(impl->subjective[independentIndex(DbId::nativeSubjective)], key);
       std::lock_guard lock{impl->topMutex};
       writer.upsert(impl->topRoot, subjectiveKey, impl->subjective);
       writer.set_top_root(impl->topRoot);

--- a/libraries/psibase_http/handle_request.cpp
+++ b/libraries/psibase_http/handle_request.cpp
@@ -326,6 +326,7 @@ namespace psibase::http
                    session->do_read();
              });
       }
+      virtual SocketInfo                 info() const override { return HttpSocketInfo{}; }
       std::shared_ptr<http_session_base> session;
       F                                  callback;
       E                                  err;
@@ -814,7 +815,7 @@ namespace psibase::http
                 },
                 [error](const std::string& message)
                 { return error(bhttp::status::internal_server_error, message); });
-            system->sockets->add(socket, &tc.ownedSockets);
+            system->sockets->add(*bc.writer, socket, &tc.ownedSockets);
 
             auto setStatus = psio::finally(
                 [&]

--- a/programs/psinode/tests/test_txqueue.py
+++ b/programs/psinode/tests/test_txqueue.py
@@ -4,6 +4,7 @@ import testutil
 import unittest
 from predicates import *
 import time
+from threading import Thread
 from psinode import Action, Transaction, TransactionError
 from services import Tokens, Transact
 
@@ -54,6 +55,58 @@ class TestTransactionQueue(unittest.TestCase):
         a.wait(new_block())
         new_balance = tokens.balance('alice', token=1)
         self.assertEqual(old_balance - 10000, new_balance)
+
+    @testutil.psinode_test
+    def test_restart_node(self, cluster):
+        (a, b) = cluster.complete(*testutil.generate_names(2))
+        a.boot(packages=['Minimal', 'Explorer', 'TokenUsers'])
+
+        # Make sure that b is ready
+        b.wait(new_block())
+
+        # Make sure that transactions submitted to b can't reach the producer 
+        b.disconnect(a)
+
+        tx = b.pack_signed_transaction(Transaction(b.get_tapos(), actions=[Action('alice', 'tokens', 'credit', {"tokenId":1,"receiver":"bob","amount":{"value":10000}, "memo":"test"})], claims=[]))
+
+        # This should not return, because b is not getting new blocks
+        def run_delayed():
+            try:
+                b.push_transaction(tx)
+            except:
+                pass
+        delayed = Thread(target=run_delayed)
+        delayed.start()
+
+        # Push the same transaction to a
+        a.push_transaction(tx)
+
+        # Kill and restart b
+        b.shutdown(force=True)
+        b.start()
+        delayed.join()
+
+        # Submit another transaction to b
+        tx2 = b.pack_signed_transaction(Transaction(b.get_tapos(), actions=[Action('bob', 'tokens', 'credit', {"tokenId":1,"receiver":"alice","amount":{"value":10000}, "memo":"back"})], claims=[]))
+        traces = []
+        t2thread = Thread(target=lambda: traces.append(b.push_transaction(tx2)))
+        t2thread.start()
+
+        # Reconnect b to start receiving transactions
+        b.connect(a)
+
+        a.push_transaction(tx2)
+        t2thread.join();
+
+        found_bob = False
+        for trace in traces[0]['actionTraces'][0]['innerTraces']:
+            if 'ActionTrace' in trace['inner']:
+                action = trace['inner']['ActionTrace']['action']
+                if action['service'] == 'tokens' and action['method'] == 'credit':
+                    if action['sender'] == 'bob':
+                        found_bob = True
+                    self.assertNotEqual(action['sender'], 'alice')
+        self.assertTrue(found_bob)
 
 if __name__ == '__main__':
     testutil.main()

--- a/programs/psitest/main.cpp
+++ b/programs/psitest/main.cpp
@@ -283,7 +283,7 @@ struct test_chain
                                  state.shared_wasm_cache,
                                     {},
                                  state.watchdogManager,
-                                 std::make_shared<psibase::Sockets>()});
+                                 std::make_shared<psibase::Sockets>(this->db)});
       state.shared_memory_cache.init(*sys);
       head = this->db.getHead();
    }
@@ -644,7 +644,8 @@ struct HttpSocket : psibase::AutoCloseSocket
       if (chain)
          logResponse();
    }
-   void logResponse()
+   psibase::SocketInfo info() const override { return psibase::HttpSocketInfo{}; }
+   void                logResponse()
    {
       auto view    = psio::view<const psibase::HttpReply>(psio::prevalidated{response});
       auto endTime = std::chrono::steady_clock::now();
@@ -1371,7 +1372,7 @@ struct callbacks
       std::int32_t fd;
 
       auto socket = std::make_shared<HttpSocket>();
-      chain.sys->sockets->add(socket, &tc.ownedSockets);
+      chain.sys->sockets->add(*chain.writer, socket, &tc.ownedSockets);
       if (auto pos = std::ranges::find(state.sockets, nullptr); pos != state.sockets.end())
       {
          *pos = socket;

--- a/services/psibase_tests/CMakeLists.txt
+++ b/services/psibase_tests/CMakeLists.txt
@@ -22,6 +22,7 @@ function(add suffix)
     service(AsyncQueryService "${suffix}" AsyncQueryService.cpp)
     service(SubjectiveCounterService "${suffix}" SubjectiveCounterService.cpp)
     service(KeepSocketService "${suffix}" KeepSocketService.cpp)
+    service(SocketListService "${suffix}" SocketListService.cpp)
 
     add_executable(psibase-tests${suffix} test.cpp test-sig.cpp test_event.cpp test_crypto.cpp test_memo.cpp test_clock.cpp test_semver.cpp test_subjective.cpp testKvMerkle.cpp test_rpc.cpp)
     target_include_directories(psibase-tests${suffix} PUBLIC include)

--- a/services/psibase_tests/SocketListService.cpp
+++ b/services/psibase_tests/SocketListService.cpp
@@ -1,0 +1,41 @@
+#include <psibase/Rpc.hpp>
+#include <psibase/Service.hpp>
+#include <psibase/dispatch.hpp>
+#include <psibase/nativeTables.hpp>
+#include <psibase/serveGraphQL.hpp>
+
+using namespace psibase;
+
+struct SocketListService : psibase::Service
+{
+   std::optional<HttpReply> serveSys(const HttpRequest& req);
+};
+PSIO_REFLECT(SocketListService, method(serveSys, request))
+
+namespace
+{
+
+   struct QueryRoot
+   {
+      auto sockets() const
+      {
+         checkoutSubjective();
+         auto table =
+             Table<SocketRow, &SocketRow::fd>{SocketRow::db, psio::convert_to_key(socketTable)};
+         return table.getIndex<0>();
+      }
+   };
+   PSIO_REFLECT(QueryRoot, method(sockets))
+
+}  // namespace
+
+std::optional<HttpReply> SocketListService::serveSys(const HttpRequest& req)
+{
+   if (auto reply = serveGraphQL(req, QueryRoot{}))
+   {
+      return reply;
+   }
+   return {};
+}
+
+PSIBASE_DISPATCH(SocketListService)


### PR DESCRIPTION
In the following scenario:

1. push_transaction
2. stop and restart node before transaction is processed
3. push_transaction

The trace from (1) could incorrectly be sent as a response to (3)