### PR TITLE
Plugin tester fixes

### DIFF
--- a/services/user/CommonApi/common/packages/plugin-tester/ui/README.md
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/README.md
@@ -47,16 +47,6 @@ The Plugin Tester is a development tool designed to help developers test and int
 - `RpcUtils.ts`: Utilities for RPC calls
 - `StringUtils.ts`: String manipulation utilities
 
-## Data Flow
-
-1. The application loads the current service information on startup
-2. Users can specify a service and plugin to load
-3. The schema is fetched using the `usePluginSchema` hook
-4. Available functions are displayed in the `FunctionSelector`
-5. When a function is selected, parameter inputs are generated based on the function's schema
-6. Users can fill in parameter values using type-appropriate input components
-7. The `ExecutionTabs` component handles function execution and displays results
-
 ## Key Concepts
 
 ### Schema Structure
@@ -77,6 +67,35 @@ The application includes a sophisticated type system that:
 - Supports complex types (records, variants, tuples, etc.)
 - Provides appropriate input components for each type
 - Generates default values based on type information
+
+### Parameter Handling and Data Flow
+
+The application processes parameters through several layers before sending them to the plugin:
+
+1. **Parameter Initialization**:
+
+   - When a function is selected in `PluginLoader`, parameters are initialized using the schema
+   - Parameter names from the schema (e.g., `"public-key"`) are converted to camelCase (e.g., `"publicKey"`)
+   - Initial values are generated based on parameter types using the `getTypeInfo` function
+
+2. **User Input Handling**:
+
+   - Input components (e.g., `StringInput`) capture user input via their `onChange` handlers
+   - Changes flow to `RichParameterEditor.handleRichEdit()` which:
+     - Updates the parameter values in the state object
+     - Special handling exists for bytelist parameters (storing both bytes and rawInput)
+
+3. **Parameter Storage**:
+
+   - All parameter values are stored in the `paramValues` state in `PluginLoader`
+   - Parameter keys are consistently in camelCase format
+   - For bytelist parameters, additional entries with `*RawInput` suffixes store raw input values
+
+4. **Parameter Processing for Execution**:
+
+   - When executing a function, `ExecutionTabs.getCleanValues()` filters out any entries ending with `RawInput`
+   - The `parseParams()` function converts the object to an array using `Object.values()`
+   - Parameters are sent to the plugin function in the order they appear in the array
 
 ### Supervisor Integration
 

--- a/services/user/CommonApi/common/packages/plugin-tester/ui/README.md
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/README.md
@@ -1,10 +1,8 @@
 # Plugin Tester
 
-A React-based application for testing and interacting with psibase plugins. This tool allows developers to load, inspect, and execute plugin functions through a user-friendly interface.
+## Overview
 
-## Project Overview
-
-The Plugin Tester is a development tool designed to help developers test and interact with psibase plugins. It provides a UI for:
+A React-based application for testing and interacting with psibase plugins. It provides a UI for:
 
 1. Loading plugin schemas from psibase services
 2. Browsing available functions
@@ -12,40 +10,35 @@ The Plugin Tester is a development tool designed to help developers test and int
 4. Executing functions and viewing responses
 5. Generating code snippets for embedding function calls in other applications
 
-## Tech Stack
-
-- **Framework**: React with TypeScript
-- **Build Tool**: Vite
-- **Dependencies**:
-  - `@psibase/common-lib`: Core library for psibase integration
-  - React 18.2.0
+It is accessed on the domain of any app that has published a plugin, through the `/common/plugin-tester` path.
 
 ## Project Structure
 
-### Core Components
-
-- `App.tsx`: Main application component that integrates the LoginBar and PluginLoader
-- `PluginLoader.tsx`: Central component that manages plugin loading, function selection, and parameter input
-- `LoginBar.tsx`: Handles user authentication with the psibase supervisor
-
-### Key Directories
-
-- `/src/components/`: UI components for the application
-  - `ExecutionTabs.tsx`: Handles function execution and displays results
-  - `FunctionSelector.tsx`: UI for selecting functions from the loaded plugin
-  - `ParameterEditor.tsx`: Generic parameter editing component
-  - `inputs/`: Input components for different data types
-  - `editors/`: Specialized editors for complex data types
-- `/src/hooks/`: Custom React hooks
-  - `usePluginSchema.ts`: Hook for loading and parsing plugin schemas
-
-### Important Files
-
-- `types.ts`: TypeScript interfaces for the schema structure
-- `utils.ts`: Utility functions for type handling and data transformation
-- `NumericConstraints.ts`: Utilities for handling numeric types
-- `RpcUtils.ts`: Utilities for RPC calls
-- `StringUtils.ts`: String manipulation utilities
+```
+.
+├── src/
+│   ├── App.tsx                    # Main application component
+│   ├── LoginBar.tsx               # Handles user authentication with the psibase supervisor
+│   ├── PluginLoader.tsx           # Central component managing plugin loading, function selection, and parameter input
+│   ├── types.ts                   # TypeScript interfaces for the schema structure
+│   ├── utils.ts                   # Utility functions for type handling and data transformation
+│   ├── NumericConstraints.ts      # Utilities for handling numeric types
+│   ├── RpcUtils.ts                # Utilities for RPC calls
+│   ├── StringUtils.ts             # String manipulation utilities
+│   ├── components/
+│   │   ├── ExecutionTabs.tsx      # Handles function execution and displays results
+│   │   ├── FunctionSelector.tsx   # UI for selecting functions from the loaded plugin
+│   │   ├── ParameterEditor.tsx    # Generic parameter editing component
+│   │   ├── ParametersSection.tsx  # Section for organizing parameter inputs
+│   │   ├── ServiceInput.tsx       # Input for service selection
+│   │   ├── TabButton.tsx          # Tab UI component
+│   │   ├── TabControl.tsx         # Tab container component
+│   │   ├── inputs/                # Input components for different data types
+│   │   └── editors/               # Specialized editors for complex data types
+│   └── hooks/
+│       └── usePluginSchema.ts     # Hook for loading and parsing plugin schemas
+└── sample_interface.json          # Example plugin interface schema
+```
 
 ## Key Concepts
 
@@ -58,15 +51,6 @@ The plugin schema follows a structured format defined in `types.ts`:
 - `SchemaInterface`: Defines available functions
 - `SchemaFunction`: Describes a function with its parameters
 - `TypeDefinition`: Describes complex data types
-
-### Type System
-
-The application includes a sophisticated type system that:
-
-- Handles primitive types (string, number, boolean, etc.)
-- Supports complex types (records, variants, tuples, etc.)
-- Provides appropriate input components for each type
-- Generates default values based on type information
 
 ### Parameter Handling and Data Flow
 
@@ -96,30 +80,3 @@ The application processes parameters through several layers before sending them 
    - When executing a function, `ExecutionTabs.getCleanValues()` filters out any entries ending with `RawInput`
    - The `parseParams()` function converts the object to an array using `Object.values()`
    - Parameters are sent to the plugin function in the order they appear in the array
-
-### Supervisor Integration
-
-The application integrates with the psibase supervisor to:
-
-- Authenticate users
-- Load plugin schemas
-- Execute plugin functions
-- Handle responses
-
-## Usage
-
-The Plugin Tester is designed to be deployed as part of the psibase Common API and accessed through the `/common/plugin-tester/` path.
-
-## Development
-
-To run the application in development mode:
-
-```bash
-yarn dev
-```
-
-To build for production:
-
-```bash
-yarn build
-```

--- a/services/user/CommonApi/common/packages/plugin-tester/ui/README.md
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/README.md
@@ -1,0 +1,106 @@
+# Plugin Tester
+
+A React-based application for testing and interacting with psibase plugins. This tool allows developers to load, inspect, and execute plugin functions through a user-friendly interface.
+
+## Project Overview
+
+The Plugin Tester is a development tool designed to help developers test and interact with psibase plugins. It provides a UI for:
+
+1. Loading plugin schemas from psibase services
+2. Browsing available functions
+3. Constructing function parameters with appropriate input controls
+4. Executing functions and viewing responses
+5. Generating code snippets for embedding function calls in other applications
+
+## Tech Stack
+
+- **Framework**: React with TypeScript
+- **Build Tool**: Vite
+- **Dependencies**:
+  - `@psibase/common-lib`: Core library for psibase integration
+  - React 18.2.0
+
+## Project Structure
+
+### Core Components
+
+- `App.tsx`: Main application component that integrates the LoginBar and PluginLoader
+- `PluginLoader.tsx`: Central component that manages plugin loading, function selection, and parameter input
+- `LoginBar.tsx`: Handles user authentication with the psibase supervisor
+
+### Key Directories
+
+- `/src/components/`: UI components for the application
+  - `ExecutionTabs.tsx`: Handles function execution and displays results
+  - `FunctionSelector.tsx`: UI for selecting functions from the loaded plugin
+  - `ParameterEditor.tsx`: Generic parameter editing component
+  - `inputs/`: Input components for different data types
+  - `editors/`: Specialized editors for complex data types
+- `/src/hooks/`: Custom React hooks
+  - `usePluginSchema.ts`: Hook for loading and parsing plugin schemas
+
+### Important Files
+
+- `types.ts`: TypeScript interfaces for the schema structure
+- `utils.ts`: Utility functions for type handling and data transformation
+- `NumericConstraints.ts`: Utilities for handling numeric types
+- `RpcUtils.ts`: Utilities for RPC calls
+- `StringUtils.ts`: String manipulation utilities
+
+## Data Flow
+
+1. The application loads the current service information on startup
+2. Users can specify a service and plugin to load
+3. The schema is fetched using the `usePluginSchema` hook
+4. Available functions are displayed in the `FunctionSelector`
+5. When a function is selected, parameter inputs are generated based on the function's schema
+6. Users can fill in parameter values using type-appropriate input components
+7. The `ExecutionTabs` component handles function execution and displays results
+
+## Key Concepts
+
+### Schema Structure
+
+The plugin schema follows a structured format defined in `types.ts`:
+
+- `Schema`: Top-level container for worlds, interfaces, and types
+- `World`: Represents a collection of exported interfaces
+- `SchemaInterface`: Defines available functions
+- `SchemaFunction`: Describes a function with its parameters
+- `TypeDefinition`: Describes complex data types
+
+### Type System
+
+The application includes a sophisticated type system that:
+
+- Handles primitive types (string, number, boolean, etc.)
+- Supports complex types (records, variants, tuples, etc.)
+- Provides appropriate input components for each type
+- Generates default values based on type information
+
+### Supervisor Integration
+
+The application integrates with the psibase supervisor to:
+
+- Authenticate users
+- Load plugin schemas
+- Execute plugin functions
+- Handle responses
+
+## Usage
+
+The Plugin Tester is designed to be deployed as part of the psibase Common API and accessed through the `/common/plugin-tester/` path.
+
+## Development
+
+To run the application in development mode:
+
+```bash
+yarn dev
+```
+
+To build for production:
+
+```bash
+yarn build
+```

--- a/services/user/CommonApi/common/packages/plugin-tester/ui/index.html
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Plugin Tester</title>
   </head>

--- a/services/user/CommonApi/common/packages/plugin-tester/ui/src/PluginLoader.tsx
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/src/PluginLoader.tsx
@@ -7,7 +7,7 @@ import { ExecutionTabs } from "./components/ExecutionTabs";
 import { FunctionSelector } from "./components/FunctionSelector";
 import { ParametersSection } from "./components/ParametersSection";
 import { usePluginSchema } from "./hooks/usePluginSchema";
-import { getTypeInfo } from "./utils";
+import { getTypeInfo, camelCase } from "./utils";
 
 export function PluginLoader({ supervisor }: { supervisor: Supervisor }) {
   const [service, setService] = useState("");
@@ -39,7 +39,7 @@ export function PluginLoader({ supervisor }: { supervisor: Supervisor }) {
       const initialValues = selectedFunction.params.reduce(
         (acc, param) => ({
           ...acc,
-          [param.name]: getTypeInfo(param.type, schema).defaultValue,
+          [camelCase(param.name)]: getTypeInfo(param.type, schema).defaultValue,
         }),
         {}
       );

--- a/services/user/CommonApi/common/packages/plugin-tester/ui/src/components/ExecutionTabs.tsx
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/src/components/ExecutionTabs.tsx
@@ -70,12 +70,13 @@ export function ExecutionTabs({
 
   const generateEmbedCode = (): string => {
     const cleanValues = getCleanValues();
+    const paramValues = Object.values(cleanValues);
     return `const response = await supervisor.functionCall({
   service: "${service}",
   plugin: "${plugin}",
   intf: "${camelCase(selectedInterfaceName)}",
   method: "${camelCase(selectedFunction.name)}",
-  params: ${JSON.stringify(cleanValues, null, 2)}
+  params: ${JSON.stringify(paramValues)}
 });`;
   };
 

--- a/services/user/CommonApi/common/packages/plugin-tester/ui/src/components/inputs/StringInput.tsx
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/src/components/inputs/StringInput.tsx
@@ -10,10 +10,10 @@ export const StringInput = ({ value, onChange, label }: StringInputProps) => {
   return (
     <div className="input-field">
       {label && <label>{label}</label>}
-      <input
-        type="text"
+      <textarea
         className="common-input"
         value={value}
+        rows={1}
         onChange={(e) => onChange(e.target.value)}
       />
     </div>


### PR DESCRIPTION
This fixes three issues:
1. String inputs couldn't have newline literals, and using "\n" was getting encoded incorrectly (as "\\n") by json stringify. Now the string input is a textarea so we can use actual newlines.
2. Parameter words that needed to be converted to camelCase were, in some cases, resulting in two entries in `paramValues` (one camelCase and one kebab-case). Now only the camelCase variant should be stored.
3. The embed code was serializing the parameters as an object instead of putting the values in an array.

Also added a readme. 