### PR TITLE
Fix logging of requests with an absolute-form target

### DIFF
--- a/libraries/psibase_http/handle_request.cpp
+++ b/libraries/psibase_http/handle_request.cpp
@@ -244,9 +244,8 @@ namespace psibase::http
    }
 
    // Returns the host and path for the request. See RFC 9112 § 3.2 and 3.3
-   template <typename Body, typename Allocator>
    std::pair<beast::string_view, beast::string_view> parse_request_target(
-       const bhttp::request<Body, bhttp::basic_fields<Allocator>>& request)
+       const http_session_base::request_type& request)
    {
       auto target = request.target();
       if (target.starts_with('/') || target == "*")

--- a/libraries/psibase_http/http_session_base.cpp
+++ b/libraries/psibase_http/http_session_base.cpp
@@ -8,6 +8,8 @@ using std::chrono::steady_clock;
 
 namespace psibase::http
 {
+   std::pair<beast::string_view, beast::string_view> parse_request_target(
+       const http_session_base::request_type& request);
 
    void handle_request(server_state&                     server,
                        http_session_base::request_type&& req,
@@ -74,17 +76,17 @@ namespace psibase::http
       }
 
       {
-         const auto& req = parser->get();
+         const auto& req             = parser->get();
+         auto [req_host, req_target] = parse_request_target(req);
          request_attrs.emplace(std::tuple{
              boost::log::add_scoped_logger_attribute(
                  logger, "RequestMethod",
                  boost::log::attributes::constant{std::string(req.method_string())}),
              boost::log::add_scoped_logger_attribute(
                  logger, "RequestTarget",
-                 boost::log::attributes::constant{std::string(req.target())}),
+                 boost::log::attributes::constant{std::string(req_target)}),
              boost::log::add_scoped_logger_attribute(
-                 logger, "RequestHost",
-                 boost::log::attributes::constant{std::string(req[bhttp::field::host])})});
+                 logger, "RequestHost", boost::log::attributes::constant{std::string(req_host)})});
          PSIBASE_LOG(logger, debug) << "Received HTTP request";
       }
 


### PR DESCRIPTION
Before:
```
Handled HTTP request: POST transact.ahttp://transact.a/push_transaction 200
```

After:
```
Handled HTTP request: POST transact.a/push_transaction 200
```