### PR TITLE
Allow the account name to differ from the crate name.

### DIFF
--- a/rust/cargo-psibase/src/package.rs
+++ b/rust/cargo-psibase/src/package.rs
@@ -2,8 +2,7 @@ use crate::{build, build_package_root, build_plugin, build_schema, Args, SERVICE
 use anyhow::anyhow;
 use cargo_metadata::{Metadata, Node, Package, PackageId};
 use psibase::{
-    AccountNumber, Action, Checksum256, ExactAccountNumber, Meta, PackageInfo, PackageRef,
-    PackagedService, ServiceInfo,
+    AccountNumber, Action, Checksum256, Meta, PackageInfo, PackageRef, PackagedService, ServiceInfo,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -110,8 +109,8 @@ pub fn get_package_dir(args: &Args, metadata: &MetadataIndex) -> PathBuf {
 fn should_build_package(
     filename: &Path,
     meta: &Meta,
-    services: &[(&String, ServiceInfo, PathBuf)],
-    data: &[(&String, String, PathBuf)],
+    services: &[(AccountNumber, ServiceInfo, PathBuf)],
+    data: &[(AccountNumber, String, PathBuf)],
     postinstall: &[Action],
 ) -> Result<bool, anyhow::Error> {
     let timestamp = if let Ok(metadata) = filename.metadata() {
@@ -128,11 +127,10 @@ fn should_build_package(
     if manifest.services.len() != services.len() {
         return Ok(true);
     }
-    for (name, info, path) in services {
+    for (account, info, path) in services {
         if path.metadata()?.modified()? > timestamp {
             return Ok(true);
         }
-        let account: AccountNumber = name.parse()?;
         if let Some(existing_info) = manifest.services.get(&account) {
             if info != existing_info {
                 return Ok(true);
@@ -150,11 +148,10 @@ fn should_build_package(
         existing_data.push((data.service.value, data.filename.as_str()));
     }
     let mut new_data = Vec::new();
-    for (service, dest, src) in data {
+    for (account, dest, src) in data {
         if src.metadata()?.modified()? > timestamp {
             return Ok(true);
         }
-        let account: AccountNumber = service.parse()?;
         new_data.push((account.value, dest.as_str()));
     }
     existing_data.sort();
@@ -172,10 +169,10 @@ fn should_build_package(
 }
 
 fn add_files<'a>(
-    service: &'a String,
+    service: AccountNumber,
     src: &Path,
     dest: &String,
-    out: &mut Vec<(&'a String, String, PathBuf)>,
+    out: &mut Vec<(AccountNumber, String, PathBuf)>,
 ) -> Result<(), anyhow::Error> {
     if src.is_file() {
         out.push((service, dest.clone(), src.to_path_buf()));
@@ -270,8 +267,6 @@ pub async fn build_package(
             let Some(package) = metadata.packages.get(service) else {
                 Err(anyhow!("Cannot find crate for service {}", service))?
             };
-            let account: ExactAccountNumber = package.name.parse()?;
-            accounts.push(account.into());
             let pmeta: PsibaseMetadata = get_metadata(package)?;
             for (k, v) in pmeta.dependencies {
                 depends_set.insert(PackageRef {
@@ -310,7 +305,7 @@ pub async fn build_package(
                 if dest.ends_with('/') {
                     dest.pop();
                 }
-                data_sources.push((&package.name, src, dest));
+                data_sources.push((&package.name, src.into_std_path_buf(), dest));
             }
             services.push((&package.name, info, &package.id.repr));
             if let Some(actions) = &pmeta.postinstall {
@@ -336,14 +331,6 @@ pub async fn build_package(
     let mut depends: Vec<PackageRef> = depends_set.into_iter().collect();
     depends.sort_by(|a, b| a.name.cmp(&b.name));
 
-    let meta = Meta {
-        name: package_name.to_string(),
-        version: package_version.to_string(),
-        description: package_description.unwrap_or_else(|| package_name.to_string()),
-        depends,
-        accounts,
-    };
-
     let need_to_build_root = services
         .iter()
         .find(|(_, _, id)| id.as_str() == service.unwrap())
@@ -361,8 +348,10 @@ pub async fn build_package(
                 plugin
             ))?
         };
-        data_files.push((service, path.to_string(), paths.pop().unwrap()))
+        data_sources.push((service, paths.pop().unwrap().into(), path.to_string()))
     }
+
+    let mut crate_to_account: HashMap<&String, AccountNumber> = HashMap::new();
 
     let mut service_wasms = Vec::new();
     for (service, mut info, id) in services {
@@ -380,8 +369,12 @@ pub async fn build_package(
                 service
             ))?
         };
-        info.schema = Some(build_schema(args, &[&id], &["-p", &service]).await?);
+        let schema = build_schema(args, &[&id], &["-p", &service]).await?;
+        crate_to_account.insert(service, schema.service.clone());
+        let service = schema.service.clone();
+        info.schema = Some(schema);
         service_wasms.push((service, info, paths.pop().unwrap()));
+        accounts.push(service);
     }
 
     if need_to_build_root {
@@ -390,8 +383,16 @@ pub async fn build_package(
     }
 
     for (service, src, dest) in data_sources {
-        add_files(service, src.as_std_path(), &dest, &mut data_files)?;
+        add_files(crate_to_account[service], &src, &dest, &mut data_files)?;
     }
+
+    let meta = Meta {
+        name: package_name.to_string(),
+        version: package_version.to_string(),
+        description: package_description.unwrap_or_else(|| package_name.to_string()),
+        depends,
+        accounts,
+    };
 
     let out_dir = get_package_dir(args, metadata);
     let out_path = out_dir.join(package_name.clone() + ".psi");

--- a/rust/test_contract/src/lib.rs
+++ b/rust/test_contract/src/lib.rs
@@ -5,7 +5,7 @@
 /// This service adds and multiplies `i32` numbers.
 ///
 /// This is where a detailed description would go.
-#[psibase::service]
+#[psibase::service(name = "example")]
 mod service {
     use psibase::*;
 


### PR DESCRIPTION
Mainly useful to avoid name collisions with third-party crates, e.g. brotli.