### PR TITLE
improve default vscode tasks/scripts

### DIFF
--- a/.vscode/scripts/build.sh
+++ b/.vscode/scripts/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+mkdir -p "$PROJECT_ROOT/build"
+cd "$PROJECT_ROOT/build"
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_DEBUG_WASM=ON \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+      -DCMAKE_INSTALL_PREFIX="psidk" "$PROJECT_ROOT"
+
+JOBS=$(( $(nproc) / 2 ))
+make install -j "$JOBS"

--- a/.vscode/scripts/continue.sh
+++ b/.vscode/scripts/continue.sh
@@ -16,4 +16,4 @@ if [ -z "$HOST_IP" ] || [ -z "$PRODUCER" ] || [ -z "$PORT" ]; then
     exit 1
 fi
 
-psinode "$PROJECT_ROOT/db" -p "$PRODUCER" --admin-authz=rw:ip:"$HOST_IP" -l "$PORT" 
+psinode "$PROJECT_ROOT/db" -p "$PRODUCER" --admin-authz=rw:ip:"$HOST_IP" --admin-authz=rw:loopback -l "$PORT" 

--- a/.vscode/scripts/continue.sh
+++ b/.vscode/scripts/continue.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Continue/resume a chain
+# Same as launch but doesn't first delete the db.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+HOST_IP=$1
+PRODUCER=$2
+PORT=$3
+
+if [ -z "$HOST_IP" ] || [ -z "$PRODUCER" ] || [ -z "$PORT" ]; then
+    echo "Error: Missing required parameters"
+    echo "Usage: $0 <host_ip> <producer> <port>"
+    exit 1
+fi
+
+psinode "$PROJECT_ROOT/db" -p "$PRODUCER" --admin-authz=rw:ip:"$HOST_IP" -l "$PORT" 

--- a/.vscode/scripts/launch.sh
+++ b/.vscode/scripts/launch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Launch a chain
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+HOST_IP=$1
+PRODUCER=$2
+PORT=$3
+
+if [ -z "$HOST_IP" ] || [ -z "$PRODUCER" ] || [ -z "$PORT" ]; then
+    echo "Error: Missing required parameters"
+    echo "Usage: $0 <host_ip> <producer> <port>"
+    exit 1
+fi
+
+
+rm -rf "$PROJECT_ROOT/db"
+psinode "$PROJECT_ROOT/db" -p "$PRODUCER" --admin-authz=rw:ip:"$HOST_IP" --admin-authz=rw:loopback -l "$PORT" 

--- a/.vscode/scripts/launch_secure.sh
+++ b/.vscode/scripts/launch_secure.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Launch a secure chain
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+HOST_IP=$1
+PRODUCER=$2
+PORT=$3
+PKCS11_MODULE=$4
+
+if [ -z "$HOST_IP" ] || [ -z "$PRODUCER" ] || [ -z "$PORT" ] || [ -z "$PKCS11_MODULE" ]; then
+    echo "Error: Missing required parameters"
+    echo "Usage: $0 <host_ip> <producer> <port> <pkcs11-module>"
+    exit 1
+fi
+
+rm -rf "$PROJECT_ROOT/db"
+psinode "$PROJECT_ROOT/db" -p "$PRODUCER" --admin-authz=rw:ip:"$HOST_IP" --admin-authz=rw:loopback -l "$PORT" --pkcs11-module="$PKCS11_MODULE" 

--- a/.vscode/tasks.json.sample
+++ b/.vscode/tasks.json.sample
@@ -18,7 +18,7 @@
     {
       "label": "Continue",
       "type": "shell",
-      "command": ".vscode/scripts/continue.sh <YOUR_HOST_IP> myprod 8080",
+      "command": ".vscode/scripts/continue.sh $HOST_IP myprod 8080",
       "options": {
         "statusbar": {
           "label": "$(play) Continue"
@@ -28,7 +28,7 @@
     {
       "label": "Launch",
       "type": "shell",
-      "command": ".vscode/scripts/launch.sh <YOUR_HOST_IP> myprod 8080",
+      "command": ".vscode/scripts/launch.sh $HOST_IP myprod 8080",
       "options": {
         "statusbar": {
           "label": "$(play) Launch"
@@ -38,7 +38,7 @@
     {
       "label": "Launch Secure",
       "type": "shell",
-      "command": ".vscode/scripts/launch_secure.sh <YOUR_HOST_IP> myprod 8080 /usr/lib/softhsm/libsofthsm2.so",
+      "command": ".vscode/scripts/launch_secure.sh $HOST_IP myprod 8080 /usr/lib/softhsm/libsofthsm2.so",
       "options": {
         "statusbar": {
           "label": "$(play)$(lock) Launch Secure"

--- a/.vscode/tasks.json.sample
+++ b/.vscode/tasks.json.sample
@@ -18,7 +18,7 @@
     {
       "label": "Continue",
       "type": "shell",
-      "command": ".vscode/scripts/continue.sh $HOST_IP myprod 8080",
+      "command": ".vscode/scripts/continue.sh <YOUR_HOST_IP> myprod 8080",
       "options": {
         "statusbar": {
           "label": "$(play) Continue"
@@ -28,7 +28,7 @@
     {
       "label": "Launch",
       "type": "shell",
-      "command": ".vscode/scripts/launch.sh $HOST_IP myprod 8080",
+      "command": ".vscode/scripts/launch.sh <YOUR_HOST_IP> myprod 8080",
       "options": {
         "statusbar": {
           "label": "$(play) Launch"
@@ -38,7 +38,7 @@
     {
       "label": "Launch Secure",
       "type": "shell",
-      "command": ".vscode/scripts/launch_secure.sh $HOST_IP myprod 8080 /usr/lib/softhsm/libsofthsm2.so",
+      "command": ".vscode/scripts/launch_secure.sh <YOUR_HOST_IP> myprod 8080 /usr/lib/softhsm/libsofthsm2.so",
       "options": {
         "statusbar": {
           "label": "$(play)$(lock) Launch Secure"

--- a/.vscode/tasks.json.sample
+++ b/.vscode/tasks.json.sample
@@ -1,42 +1,73 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Build",
-            "type": "shell",
-            "command": "mkdir -p build && cd build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_DEBUG_WASM=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=\"psidk\" .. && make install",
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "options": {
-                "statusbar": {
-                    "label": "$(tools) Build"
-                }
-            }
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "shell",
+      "command": ".vscode/scripts/build.sh",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "options": {
+        "statusbar": {
+          "label": "$(tools) Build"
         }
-        // Keeping the below example to show how to run service unit tests:
-        // {
-        //     "label": "Test NFT",
-        //     "type": "shell",
-        //     "command": "cd build && psitest Nft-test-debug.wasm -s -r compact",
-        //     "group": {
-        //         "kind": "test",
-        //         "isDefault": false
-        //     },
-        //     "options": {
-        //         "statusbar": {
-        //             "label": "$(beaker) Test Nft"
-        //         }
-        //     }
-        // },
-    ],
-    "inputs": [
-        {
-            "id": "testsuite",
-            "type": "promptString",
-            "default": "[mytestsuite]",
-            "description": "Enter test suite key (Example: \"[MyTestSuite]\""
+      }
+    },
+    {
+      "label": "Continue",
+      "type": "shell",
+      "command": ".vscode/scripts/continue.sh $HOST_IP myprod 8080",
+      "options": {
+        "statusbar": {
+          "label": "$(play) Continue"
         }
-    ]
+      }
+    },
+    {
+      "label": "Launch",
+      "type": "shell",
+      "command": ".vscode/scripts/launch.sh $HOST_IP myprod 8080",
+      "options": {
+        "statusbar": {
+          "label": "$(play) Launch"
+        }
+      }
+    },
+    {
+      "label": "Launch Secure",
+      "type": "shell",
+      "command": ".vscode/scripts/launch_secure.sh $HOST_IP myprod 8080 /usr/lib/softhsm/libsofthsm2.so",
+      "options": {
+        "statusbar": {
+          "label": "$(play)$(lock) Launch Secure"
+        }
+      }
+    }
+
+    // Keeping the below example to show how to run service unit tests:
+    // {
+    //     "label": "Test NFT",
+    //     "type": "shell",
+    //     "command": "cd build && psitest Nft-test-debug.wasm -s -r compact",
+    //     "group": {
+    //         "kind": "test",
+    //         "isDefault": false
+    //     },
+    //     "options": {
+    //         "statusbar": {
+    //             "label": "$(beaker) Test Nft"
+    //         }
+    //     }
+    // },
+  ],
+  "inputs": [
+    {
+      "id": "testsuite",
+      "type": "promptString",
+      "default": "[mytestsuite]",
+      "description": "Enter test suite key (Example: \"[MyTestSuite]\""
+    }
+  ]
 }


### PR DESCRIPTION
For organization, I use bash scripts instead of scripting inline in the `tasks.json` file. This also allows the script to be called from anywhere (useful for multi-root workspaces)