### PR TITLE
Add install status to psibase info output

### DIFF
--- a/programs/psinode/tests/psinode.py
+++ b/programs/psinode/tests/psinode.py
@@ -580,9 +580,11 @@ class Node(API):
     def install(self, packages=[], sources=[]):
         '''installs a package'''
         self.run_psibase(['install'] + self.node_args() + ['--package-source=' + s for s in sources] + packages)
-    def run_psibase(self, args):
+    def run_psibase(self, args, *, check=True, **kw):
         self._find_psibase()
-        subprocess.run([self.psibase] + args).check_returncode()
+        result = subprocess.run([self.psibase] + args, check=check, **kw)
+        result.check_returncode()
+        return result
     def log(self):
         return open(self.logpath, 'r')
     def print_log(self):


### PR DESCRIPTION
- If the package is installed, indicate if a more recent version is available.
- If the user requested a specific version, indicate the version that is currently installed.
- Make the parsing of command line arguments more lax, to allow the the argument to be foo-1.0 instead of foo-1.0.0, for example