### PR TITLE
Only redirect GET requests to x-admin

### DIFF
--- a/libraries/psibase_http/handle_request.cpp
+++ b/libraries/psibase_http/handle_request.cpp
@@ -769,7 +769,8 @@ namespace psibase::http
                auto pos =
                    std::ranges::find_if(server.http_config->services, [&suffix](const auto& entry)
                                         { return entry.first.ends_with(suffix); });
-               if (pos != server.http_config->services.end())
+               if ((req.method() == bhttp::verb::get || req.method() == bhttp::verb::head) &&
+                   pos != server.http_config->services.end())
                {
                   location.append(pos->first);
                   l.unlock();

--- a/programs/psinode/tests/test_psibase.py
+++ b/programs/psinode/tests/test_psibase.py
@@ -173,6 +173,10 @@ class TestPsibase(unittest.TestCase):
     @testutil.psinode_test
     def test_info(self, cluster):
         a = cluster.complete(*testutil.generate_names(1))[0]
+        info = a.run_psibase(['info', 'Explorer'] + a.node_args(), stdout=subprocess.PIPE, encoding='utf-8').stdout
+        self.assertIn('status: not installed', info)
+        self.assertIn('Explorer', info)
+
         a.boot(packages=['Minimal', 'Explorer', 'Sites', 'BrotliCodec'])
 
         foo = Foo()

--- a/rust/psibase/src/main.rs
+++ b/rust/psibase/src/main.rs
@@ -922,7 +922,7 @@ async fn add_package_registry(
     result: &mut JointRegistry<BufReader<File>>,
 ) -> Result<(), anyhow::Error> {
     let chain_sources = if let Some(account) = account {
-        get_package_sources(base_url, &mut client, account).await?
+        handle_unbooted(get_package_sources(base_url, &mut client, account).await)?
     } else {
         Vec::new()
     };
@@ -1747,13 +1747,13 @@ async fn show_package<T: PackageRegistry + ?Sized>(
 }
 
 // an unbooted chain has no packages installed
-fn handle_unbooted(list: Result<PackageList, anyhow::Error>) -> Result<PackageList, anyhow::Error> {
+fn handle_unbooted<T: Default>(list: Result<T, anyhow::Error>) -> Result<T, anyhow::Error> {
     if let Err(e) = &list {
         if e.root_cause()
             .to_string()
             .contains("Node is not connected to any psibase network.")
         {
-            return Ok(PackageList::new());
+            return Ok(T::default());
         }
     }
     list

--- a/rust/psibase/src/package.rs
+++ b/rust/psibase/src/package.rs
@@ -1308,6 +1308,7 @@ pub enum PackageOrigin {
     Repo { sha256: Checksum256, file: String },
 }
 
+#[derive(Default)]
 pub struct PackageList {
     packages: HashMap<String, HashMap<String, (Meta, PackageOrigin)>>,
 }


### PR DESCRIPTION
This allows psibase to detect the errors for various graphql queries related to packages that have a reasonable interpretation for an unbooted chain. e.g. `psibase info` should only show packages from the repository. This used to work, but got broken when I added the redirect in #994.
