### PR TITLE
Try to fix WatchdogTests

### DIFF
--- a/libraries/psibase/native/tests/CMakeLists.txt
+++ b/libraries/psibase/native/tests/CMakeLists.txt
@@ -5,3 +5,5 @@ link_directories(WatchdogTests ${ICU_LIBRARY_DIR} )
 add_executable(WatchdogTests WatchdogTests.cpp)
 target_link_libraries(WatchdogTests psibase catch2 Threads::Threads)
 add_test(NAME WatchdogTests COMMAND WatchdogTests)
+
+set_tests_properties(WatchdogTests PROPERTIES PROCESSORS 2)


### PR DESCRIPTION
WatchdogTests can fail due to contention. There are two ways this can happen:
- "CpuClock should be associated with the current thread" checks that the cpu time spent in a spin loop is at least 500 µs. This will fail if the thread is suspended for too long.
- "Watchdog threaded" checks that the overrun of the timer is not exceeded by too much. This will fail if the watchdog thread is not scheduled fast enough. I worked around this previously by repeating the test.

Tell ctest to reserve enough cores so the kernel doesn't need to suspend the threads.
