### PR TITLE
Parallel signature verification

### DIFF
--- a/libraries/psibase/CMakeLists.txt
+++ b/libraries/psibase/CMakeLists.txt
@@ -197,6 +197,7 @@ function(add suffix)
             native/src/PKCS11Prover.cpp
             native/src/prefix.cpp
             native/src/Prover.cpp
+            native/src/RunQueue.cpp
             native/src/Socket.cpp
             native/src/SystemContext.cpp
             native/src/TransactionContext.cpp

--- a/libraries/psibase/common/src/nativeTables.cpp
+++ b/libraries/psibase/common/src/nativeTables.cpp
@@ -150,4 +150,18 @@ namespace psibase
    {
       return socketKey(fd);
    }
+
+   auto runPrefix() -> KeyPrefixType
+   {
+      return std::tuple{runTable, nativeTablePrimaryIndex};
+   }
+   auto runKey(std::uint64_t id) -> RunKeyType
+   {
+      return std::tuple{runTable, nativeTablePrimaryIndex, id};
+   }
+   auto RunRow::key() const -> RunKeyType
+   {
+      return runKey(id);
+   }
+
 }  // namespace psibase

--- a/libraries/psibase/native/include/psibase/BlockContext.hpp
+++ b/libraries/psibase/native/include/psibase/BlockContext.hpp
@@ -45,6 +45,7 @@ namespace psibase
       void      callOnBlock();
       void      callOnTransaction(const Checksum256& id, const TransactionTrace& trace);
       std::optional<SignedTransaction>         callNextTransaction();
+      void                                     callRun(psio::view<const RunRow> row);
       Checksum256                              makeEventMerkleRoot();
       Checksum256                              makeTransactionMerkle();
       std::pair<ConstRevisionPtr, Checksum256> writeRevision(

--- a/libraries/psibase/native/include/psibase/ForkDb.hpp
+++ b/libraries/psibase/native/include/psibase/ForkDb.hpp
@@ -2038,6 +2038,7 @@ namespace psibase
       }
 
       void onChangeNextTransaction(auto&& fn) { dbCallbacks.nextTransaction = fn; }
+      void onChangeRunQueue(auto&& fn) { dbCallbacks.runQueue = fn; }
 
       void recvMessage(const Socket& sock, const std::vector<char>& data)
       {

--- a/libraries/psibase/native/include/psibase/RunQueue.hpp
+++ b/libraries/psibase/native/include/psibase/RunQueue.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+namespace psibase
+{
+   struct SharedState;
+
+   class RunQueue
+   {
+     public:
+      explicit RunQueue(std::shared_ptr<SharedState>);
+      ~RunQueue();
+      // Tell any thread pools to check for rows to execute
+      void notify();
+
+     private:
+      struct Impl;
+      friend class WasmThreadPool;
+      std::unique_ptr<Impl> impl;
+   };
+
+   class WasmThreadPool
+   {
+     public:
+      WasmThreadPool(RunQueue& queue, std::size_t numThreads);
+      ~WasmThreadPool();
+      void setNumThreads(std::size_t numThreads);
+
+     private:
+      struct Impl;
+      std::unique_ptr<Impl> impl;
+   };
+}  // namespace psibase

--- a/libraries/psibase/native/include/psibase/db.hpp
+++ b/libraries/psibase/native/include/psibase/db.hpp
@@ -64,13 +64,19 @@ namespace psibase
    struct DatabaseCallbacks
    {
       std::function<void()> nextTransaction;
+      std::function<void()> runQueue;
       static const unsigned nextTransactionFlag = 1;
+      static const unsigned runQueueFlag        = 2;
       using Flags                               = unsigned;
       void run(Flags& flags)
       {
          if ((flags & nextTransactionFlag) != 0 && nextTransaction)
          {
             nextTransaction();
+         }
+         if ((flags & runQueueFlag) && runQueue)
+         {
+            runQueue();
          }
          flags = 0;
       }

--- a/libraries/psibase/native/src/NativeFunctions.cpp
+++ b/libraries/psibase/native/src/NativeFunctions.cpp
@@ -286,6 +286,19 @@ namespace psibase
          }
       }
 
+      void verifySubjectiveRunTableRow(Database&          db,
+                                       psio::input_stream key,
+                                       psio::input_stream value)
+      {
+         // The runTable is only processed subjectively
+         if (psio::fracpack_validate<RunRow>({value.pos, value.end}))
+         {
+            auto row =
+                psio::view<const NotifyRow>(psio::prevalidated{std::span{value.pos, value.end}});
+            db.setCallbackFlags(DatabaseCallbacks::runQueueFlag);
+         }
+      }
+
       void verifyScheduledSnapshotRow(psio::input_stream key, psio::input_stream value)
       {
          check(psio::fracpack_validate_strict<ScheduledSnapshotRow>({value.pos, value.end}),
@@ -333,6 +346,8 @@ namespace psibase
          std::reverse((char*)&table, (char*)(&table + 1));
          if (table == notifyTable)
             verifySubjectiveNotifyTableRow(db, key, value);
+         else if (table == runTable)
+            verifySubjectiveRunTableRow(db, key, value);
          else
             throw std::runtime_error("Unrecognized key in nativeSubjective");
       }

--- a/libraries/psibase/native/src/RunQueue.cpp
+++ b/libraries/psibase/native/src/RunQueue.cpp
@@ -1,0 +1,192 @@
+#include <psibase/RunQueue.hpp>
+
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <psibase/BlockContext.hpp>
+#include <psibase/SystemContext.hpp>
+#include <psibase/TransactionContext.hpp>
+#include <thread>
+#include <vector>
+
+namespace psibase
+{
+   struct RunQueue::Impl
+   {
+      std::mutex                 mutex;
+      std::condition_variable    cond;
+      std::uint64_t              next = 0;
+      std::vector<std::uint64_t> running;
+
+      std::shared_ptr<SharedState> sharedState;
+
+      struct Item
+      {
+         Impl*             self;
+         std::vector<char> entry;
+         std::uint64_t     id;
+         Item() : self(nullptr) {}
+         Item(Impl* self, std::vector<char>&& entry, std::uint64_t id)
+             : self(self), entry(std::move(entry)), id(id)
+         {
+         }
+         Item(Item&& other) : self(other.self), entry(std::move(other.entry)), id(other.id)
+         {
+            other.self = nullptr;
+         }
+         ~Item()
+         {
+            if (self)
+            {
+               std::lock_guard l{self->mutex};
+               std::erase(self->running, id);
+            }
+         }
+         explicit                 operator bool() const { return self != nullptr; }
+         psio::view<const RunRow> get() const
+         {
+            return psio::view<const RunRow>(psio::prevalidated{entry});
+         }
+      };
+      Item pop_impl(std::unique_lock<std::mutex>&, Database& db)
+      {
+         auto prefix     = psio::convert_to_key(runPrefix());
+         auto search_key = psio::convert_to_key(runKey(next));
+         while (true)
+         {
+            auto kv = db.kvGreaterEqualRaw(RunRow::db, search_key, prefix.size());
+            if (!kv)
+            {
+               kv = db.kvGreaterEqualRaw(RunRow::db, prefix, prefix.size());
+            }
+            if (!kv)
+            {
+               next = 0;
+               return {};
+            }
+            std::vector<char> key(kv->key.pos, kv->key.end);
+            std::vector<char> runData(kv->value.pos, kv->value.end);
+            if (!psio::fracpack_validate<RunRow>(runData))
+            {
+               search_key = std::move(key);
+               search_key.push_back(0);
+               continue;
+            }
+            auto row = psio::view<const RunRow>(psio::prevalidated{runData});
+            if (psio::convert_to_key(runKey(row.id())) != key)
+            {
+               search_key = std::move(key);
+               search_key.push_back(0);
+               continue;
+            }
+            if (std::ranges::contains(running, row.id().unpack()))
+            {
+               // TODO: Don't ignore available rows in the middle
+               // of the running set.
+               return {};
+            }
+            next = row.id() + 1;
+            running.push_back(row.id());
+            return {this, std::move(runData), row.id()};
+         }
+      }
+
+      Item pop(SystemContext& systemContext, const WriterPtr& writer, auto&& done)
+      {
+         std::unique_lock l{mutex};
+         while (!done())
+         {
+            {
+               Database db{systemContext.sharedDatabase,
+                           systemContext.sharedDatabase.emptyRevision()};
+               auto     session = db.startWrite(writer);
+               db.checkoutSubjective();
+               if (auto result = pop_impl(l, db))
+               {
+                  return result;
+               }
+            }
+            cond.wait(l);
+         }
+         return {};
+      }
+   };
+
+   RunQueue::RunQueue(std::shared_ptr<SharedState> sharedState)
+       : impl(new Impl{.sharedState = std::move(sharedState)})
+   {
+   }
+
+   RunQueue::~RunQueue() = default;
+
+   void RunQueue::notify()
+   {
+      std::lock_guard l{impl->mutex};
+      impl->cond.notify_all();
+   }
+
+   struct WasmThreadPool::Impl
+   {
+      std::vector<std::jthread> threads;
+      RunQueue::Impl*           queue;
+      std::size_t               numThreads;
+
+      Impl(RunQueue::Impl* queue, std::size_t numThreads) : queue(queue), numThreads(numThreads) {}
+
+      ~Impl()
+      {
+         numThreads = 0;
+         adjustThreads();
+      }
+      // Starts or stops threads to match numThreads
+      void adjustThreads()
+      {
+         if (numThreads > threads.size())
+         {
+            // reserve is required, because the jthread destructor will
+            // deadlock if push_back throws.
+            threads.reserve(numThreads);
+            while (threads.size() < numThreads)
+            {
+               auto id = threads.size();
+               threads.push_back(std::jthread([this, id] { run(id); }));
+            }
+         }
+         else if (numThreads < threads.size())
+         {
+            queue->cond.notify_all();
+            threads.resize(numThreads);
+         }
+      }
+      void run(std::size_t threadIndex)
+      {
+         auto systemContext = queue->sharedState->getSystemContext();
+         auto writer        = systemContext->sharedDatabase.createWriter();
+         while (auto item = queue->pop(*systemContext, writer,
+                                       [this, threadIndex] { return threadIndex >= numThreads; }))
+         {
+            auto         revision = systemContext->sharedDatabase.getHead();
+            BlockContext bc{*systemContext, revision, writer, true};
+            bc.callRun(item.get());
+         }
+      }
+   };
+
+   WasmThreadPool::WasmThreadPool(RunQueue& queue, std::size_t numThreads)
+       : impl(new Impl{queue.impl.get(), numThreads})
+   {
+      impl->adjustThreads();
+   }
+
+   WasmThreadPool::~WasmThreadPool() = default;
+
+   void WasmThreadPool::setNumThreads(std::size_t numThreads)
+   {
+      {
+         std::lock_guard l(impl->queue->mutex);
+         impl->numThreads = numThreads;
+      }
+      impl->adjustThreads();
+   }
+}  // namespace psibase

--- a/services/system/Transact/include/services/system/RTransact.hpp
+++ b/services/system/Transact/include/services/system/RTransact.hpp
@@ -12,6 +12,9 @@ namespace SystemService
 {
    // Does not follow forks. Transactions are added asynchronously and removed
    // at irreversible.
+   //
+   // This row exists iff there is a PendingTransactionRecord or an
+   // UnverifiedTransactionRecord with hasError == false for the id.
    struct TransactionData
    {
       psibase::Checksum256       id;
@@ -51,6 +54,29 @@ namespace SystemService
 
    using AvailableSequenceTable = psibase::Table<AvailableSequenceRecord, psibase::SingletonKey{}>;
    PSIO_REFLECT_TYPENAME(AvailableSequenceTable)
+
+   struct UnverifiedTransactionRecord
+   {
+      psibase::Checksum256  id;
+      psibase::TimePointSec expiration;
+      std::uint32_t         remainingVerifies;
+      bool                  hasError;
+      PSIO_REFLECT(UnverifiedTransactionRecord, id, expiration, remainingVerifies, hasError)
+   };
+
+   using UnverifiedTransactionTable =
+       psibase::Table<UnverifiedTransactionRecord, &UnverifiedTransactionRecord::id>;
+   PSIO_REFLECT_TYPENAME(UnverifiedTransactionTable)
+
+   struct PendingVerifyRecord
+   {
+      psibase::Checksum256 txid;
+      std::uint64_t        runid;
+      PSIO_REFLECT(PendingVerifyRecord, txid, runid)
+   };
+
+   using PendingVerifyTable = psibase::Table<PendingVerifyRecord, &PendingVerifyRecord::runid>;
+   PSIO_REFLECT_TYPENAME(PendingVerifyTable)
 
    // Follows forks
    struct UnappliedTransactionRecord
@@ -107,7 +133,11 @@ namespace SystemService
    };
    PSIO_REFLECT(LoginReply, access_token, token_type)
 
-   class RTransact : psibase::Service
+   // Transactions enter this service through the push_transaction endpoint
+   // or over p2p (recv). Speculative execution and signature verification
+   // are dispatched asynchronously. When they complete, the transaction
+   // is pushed onto the queue to be included in blocks.
+   class RTransact : public psibase::Service
    {
      public:
       static constexpr auto service = psibase::AccountNumber{"r-transact"};
@@ -115,13 +145,17 @@ namespace SystemService
                                                                 TransactionDataTable,
                                                                 AvailableSequenceTable,
                                                                 TraceClientTable,
-                                                                JWTKeyTable>;
+                                                                JWTKeyTable,
+                                                                UnverifiedTransactionTable,
+                                                                PendingVerifyTable>;
       using WriteOnly = psibase::WriteOnlyTables<UnappliedTransactionTable, ReversibleBlocksTable>;
       std::optional<psibase::SignedTransaction> next();
       // Handles transactions coming over P2P
       void recv(const psibase::SignedTransaction& transaction);
       // Callbacks used to track successful/expired transactions
       void onTrx(const psibase::Checksum256& id, psio::view<const psibase::TransactionTrace> trace);
+      // Callback run when after signature verification
+      void onVerify(std::uint64_t id, psio::view<const psibase::TransactionTrace> trace);
       void onBlock();
       auto serveSys(const psibase::HttpRequest& request,
                     std::optional<std::int32_t> socket) -> std::optional<psibase::HttpReply>;

--- a/services/system/Transact/include/services/system/RTransact.hpp
+++ b/services/system/Transact/include/services/system/RTransact.hpp
@@ -167,6 +167,7 @@ namespace SystemService
                 method(recv, transaction),
                 method(onTrx, id, trace),
                 method(onBlock),
+                method(onVerify, id, trace),
                 method(serveSys, request, socket),
                 method(getUser, request))
    PSIBASE_REFLECT_TABLES(RTransact, RTransact::Subjective, RTransact::WriteOnly)


### PR DESCRIPTION
Adds a general purpose way for privileged services to post actions for parallel execution.

- [ ] Handle timeout
- [ ] Make number of threads configurable
- [ ] Consider what errors should cause queue entries to be removed
- [ ] Restrict services usable in verify mode
- [ ] Flush the pipeline and re-verify all signatures when there is any change to the verify services.
- [ ] Remove native calls to `verifySys`