### PR TITLE
Fix CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16.3)
-cmake_policy(VERSION 3.16.3...3.25.1)
+cmake_policy(VERSION 3.16.3...3.31.6)
 project(psibase)
 include(ExternalProject)
 

--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -1,3 +1,5 @@
+cmake_policy(VERSION 3.16.3...3.31.6)
+
 function(json_append_string VAR VALUE)
     set(initial ${${VAR}})
     string(REGEX REPLACE "([\\\"])" "\\\\\\1" result ${VALUE})

--- a/libraries/psibase/sdk/toolchain.cmake
+++ b/libraries/psibase/sdk/toolchain.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.16.3)
 
 if(NOT DEFINED WASI_SDK_PREFIX AND DEFINED ENV{WASI_SDK_PREFIX})
     set(WASI_SDK_PREFIX $ENV{WASI_SDK_PREFIX})

--- a/wasm/toolchain.cmake
+++ b/wasm/toolchain.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16.3)
 
 set(CMAKE_SYSTEM_NAME WASI)
 set(CMAKE_SYSTEM_VERSION 1)


### PR DESCRIPTION
CMake < 3.10 is deprecated. Some new warnings (CMP0174 and CMP0177) show up in 3.31.