### PR TITLE
Fix verify services in the block header

### DIFF
--- a/libraries/psibase/native/include/psibase/BlockContext.hpp
+++ b/libraries/psibase/native/include/psibase/BlockContext.hpp
@@ -21,8 +21,10 @@ namespace psibase
       bool              needGenesisAction = false;
       bool              started           = false;
       bool              active            = false;
-      //
-      std::map<AccountNumber, bool> modifiedAuthAccounts;
+      // Both of these are supersets of the actual values,
+      // as they are not reverted when a transaction fails.
+      std::set<AccountNumber>     modifiedAuthAccounts;
+      std::set<CodeByHashKeyType> removedCode;
 
       loggers::common_logger trxLogger;
 
@@ -71,9 +73,8 @@ namespace psibase
 
       // The action has the same database access rules as queries
       void execAsyncAction(Action&& action);
-      auto execAsyncExport(std::string_view  fn,
-                           Action&&          action,
-                           TransactionTrace& trace) -> ActionTrace&;
+      auto execAsyncExport(std::string_view fn, Action&& action, TransactionTrace& trace)
+          -> ActionTrace&;
 
       void execAllInBlock();
 

--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -358,50 +358,89 @@ namespace psibase
    void updateAuthServices(Database&   db,
                            StatusRow&  status,
                            Block&      current,
-                           const auto& modifiedAuthAccounts)
+                           const auto& modifiedAuthAccounts,
+                           const auto& removedCode)
    {
       auto& currentAuthServices = status.consensus.next ? status.consensus.next->consensus.services
                                                         : status.consensus.current.services;
 
       std::vector<BlockHeaderAuthAccount> modifiedAuthServices;
-      for (const auto& account : currentAuthServices)
+      std::vector<BlockHeaderCode>        authCode;
+      // Used for set-union of modified and current accounts
+      auto currentIter = currentAuthServices.begin();
+      auto currentEnd  = currentAuthServices.end();
+      // Tracking of CodeByHashRows
+      auto origCodeKeys    = getCodeKeys(currentAuthServices);
+      auto visitedCodeKeys = std::map<CodeByHashKeyType, bool>{};
+      auto hasCode         = [&](const BlockHeaderAuthAccount& account, bool existing = true)
       {
-         if (modifiedAuthAccounts.find(account.codeNum) == modifiedAuthAccounts.end())
+         auto key             = codeByHashKey(account.codeHash, account.vmType, account.vmVersion);
+         auto [pos, inserted] = visitedCodeKeys.insert({key, false});
+         if (inserted)
          {
-            modifiedAuthServices.push_back(account);
-         }
-      }
-      for (const auto& [name, exists] : modifiedAuthAccounts)
-      {
-         if (exists)
-         {
-            auto row = db.kvGet<CodeRow>(CodeRow::db, codeKey(name));
-            assert(!!row);
-            if (row->codeHash != Checksum256{})
+            existing = existing || std::ranges::binary_search(origCodeKeys, key);
+            if (existing && removedCode.find(key) == removedCode.end())
             {
-               modifiedAuthServices.push_back({.codeNum   = row->codeNum,
-                                               .codeHash  = row->codeHash,
-                                               .vmType    = row->vmType,
-                                               .vmVersion = row->vmVersion});
+               pos->second = true;
+            }
+            if (!pos->second)
+            {
+               if (auto code = db.kvGet<CodeByHashRow>(CodeByHashRow::db, key))
+               {
+                  if (!existing)
+                  {
+                     authCode.push_back({.vmType    = code->vmType,
+                                         .vmVersion = code->vmVersion,
+                                         .code      = std::move(code->code)});
+                  }
+                  pos->second = true;
+               }
+            }
+         }
+         return pos->second;
+      };
+      for (const auto& account : modifiedAuthAccounts)
+      {
+         // Copy elements of currentAuthServices that were not touched
+         const BlockHeaderAuthAccount* existing = nullptr;
+         while (currentIter != currentEnd)
+         {
+            if (currentIter->codeNum < account)
+            {
+               if (hasCode(*currentIter))
+                  modifiedAuthServices.push_back(*currentIter);
+               ++currentIter;
+            }
+            else
+            {
+               if (currentIter->codeNum == account)
+               {
+                  existing = &*currentIter;
+                  ++currentIter;
+               }
+               break;
+            }
+         }
+         // look up the account
+         if (auto row = db.kvGet<CodeRow>(CodeRow::db, codeKey(account)))
+         {
+            if (row->flags & CodeRow::isAuthService)
+            {
+               BlockHeaderAuthAccount item{.codeNum   = row->codeNum,
+                                           .codeHash  = row->codeHash,
+                                           .vmType    = row->vmType,
+                                           .vmVersion = row->vmVersion};
+               if (hasCode(item, existing && *existing == item))
+                  modifiedAuthServices.push_back(item);
             }
          }
       }
-      std::ranges::sort(modifiedAuthServices,
-                        [](const auto& lhs, const auto& rhs) { return lhs.codeNum < rhs.codeNum; });
+      // Copy any trailing elements
+      std::copy_if(currentIter, currentEnd, std::back_inserter(modifiedAuthServices), hasCode);
+      // Check for changes and update the consensus field
       if (modifiedAuthServices != currentAuthServices)
       {
-         current.header.authCode.emplace();
-         auto               origKeys    = getCodeKeys(currentAuthServices);
-         auto               currentKeys = getCodeKeys(modifiedAuthServices);
-         decltype(origKeys) addedKeys;
-         std::ranges::set_difference(currentKeys, origKeys, std::back_inserter(addedKeys));
-         for (const auto& key : addedKeys)
-         {
-            auto code = db.kvGet<CodeByHashRow>(CodeByHashRow::db, key);
-            check(!!code, "Missing code for auth service");
-            current.header.authCode->push_back(
-                {.vmType = code->vmType, .vmVersion = code->vmVersion, .code = code->code});
-         }
+         current.header.authCode = std::move(authCode);
          if (!status.consensus.next)
             status.consensus.next =
                 PendingConsensus{{status.consensus.current.data, std::move(modifiedAuthServices)},
@@ -423,7 +462,7 @@ namespace psibase
       auto status = db.kvGet<StatusRow>(StatusRow::db, statusKey());
       check(status.has_value(), "missing status record");
 
-      updateAuthServices(db, *status, current, modifiedAuthAccounts);
+      updateAuthServices(db, *status, current, modifiedAuthAccounts, removedCode);
 
       if (status->consensus.next && status->consensus.next->blockNum == status->current.blockNum)
       {

--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -377,10 +377,13 @@ namespace psibase
          {
             auto row = db.kvGet<CodeRow>(CodeRow::db, codeKey(name));
             assert(!!row);
-            modifiedAuthServices.push_back({.codeNum   = row->codeNum,
-                                            .codeHash  = row->codeHash,
-                                            .vmType    = row->vmType,
-                                            .vmVersion = row->vmVersion});
+            if (row->codeHash != Checksum256{})
+            {
+               modifiedAuthServices.push_back({.codeNum   = row->codeNum,
+                                               .codeHash  = row->codeHash,
+                                               .vmType    = row->vmType,
+                                               .vmVersion = row->vmVersion});
+            }
          }
       }
       std::ranges::sort(modifiedAuthServices,
@@ -589,9 +592,8 @@ namespace psibase
       tc.execNonTrxAction(0, action, atrace);
    }
 
-   auto BlockContext::execAsyncExport(std::string_view  fn,
-                                      Action&&          action,
-                                      TransactionTrace& trace) -> ActionTrace&
+   auto BlockContext::execAsyncExport(std::string_view fn, Action&& action, TransactionTrace& trace)
+       -> ActionTrace&
    {
       SignedTransaction  trx;
       auto&              atrace = trace.actionTraces.emplace_back();

--- a/libraries/psibase/native/src/TransactionContext.cpp
+++ b/libraries/psibase/native/src/TransactionContext.cpp
@@ -119,7 +119,7 @@ namespace psibase
             db.kvPut(CodeRow::db, account.key(), account);
             if (service.flags & CodeRow::isAuthService)
             {
-               self.blockContext.modifiedAuthAccounts.insert({service.service, true});
+               self.blockContext.modifiedAuthAccounts.insert(service.service);
             }
             setCode(db, service.service, service.vmType, service.vmVersion,
                     {service.code.data(), service.code.size()});

--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -450,6 +450,19 @@ namespace psibase
       {
          return kvGet<V>(psibase::DbId::service, key);
       }
+
+      std::optional<std::vector<char>> kvGreaterEqualRaw(DbId               db,
+                                                         psio::input_stream key,
+                                                         uint32_t           matchKeySize);
+
+      template <typename V, typename K>
+      inline std::optional<V> kvGreaterEqual(DbId db, const K& key, uint32_t matchKeySize)
+      {
+         auto v = kvGreaterEqualRaw(db, psio::convert_to_key(key), matchKeySize);
+         if (!v)
+            return std::nullopt;
+         return psio::from_frac<V>(*v);
+      }
    };  // TestChain
 
 }  // namespace psibase

--- a/libraries/psibase/tester/src/tester.cpp
+++ b/libraries/psibase/tester/src/tester.cpp
@@ -312,3 +312,13 @@ std::optional<std::vector<char>> psibase::TestChain::kvGetRaw(psibase::DbId     
       return std::nullopt;
    return psibase::getResult(size);
 }
+
+std::optional<std::vector<char>> psibase::TestChain::kvGreaterEqualRaw(DbId               db,
+                                                                       psio::input_stream key,
+                                                                       uint32_t matchKeySize)
+{
+   auto size = tester::raw::kvGreaterEqual(id, db, key.pos, key.remaining(), matchKeySize);
+   if (size == -1)
+      return std::nullopt;
+   return psibase::getResult(size);
+}

--- a/services/psibase_tests/AbortService.cpp
+++ b/services/psibase_tests/AbortService.cpp
@@ -1,0 +1,12 @@
+#include "AbortService.hpp"
+
+#include <psibase/dispatch.hpp>
+
+using namespace psibase;
+
+void AbortService::abort(std::string message)
+{
+   abortMessage(message);
+}
+
+PSIBASE_DISPATCH(AbortService)

--- a/services/psibase_tests/AbortService.hpp
+++ b/services/psibase_tests/AbortService.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <psibase/AccountNumber.hpp>
+#include <psibase/Service.hpp>
+#include <string>
+
+struct AbortService : psibase::Service
+{
+   static constexpr auto service = psibase::AccountNumber{"abort"};
+   void                  abort(std::string message);
+};
+
+PSIO_REFLECT(AbortService, method(abort, message))

--- a/services/psibase_tests/CMakeLists.txt
+++ b/services/psibase_tests/CMakeLists.txt
@@ -18,6 +18,8 @@ function(add suffix)
     service(memo-service "${suffix}" memo-service.cpp)
     service(clock-service "${suffix}" clock-service.cpp)
     service(subjective-service "${suffix}" subjective-service.cpp)
+    service(RemoveCode "${suffix}" RemoveCode.cpp)
+    service(AbortService "${suffix}" AbortService.cpp)
 
     set(TEST_GENERATE_SCHEMA 1)
     service(MockCpuLimit "${suffix}" MockCpuLimit.cpp)

--- a/services/psibase_tests/CMakeLists.txt
+++ b/services/psibase_tests/CMakeLists.txt
@@ -29,7 +29,7 @@ function(add suffix)
     service(SocketListService "${suffix}" SocketListService.cpp)
     service(SocketAuth "${suffix}" SocketAuth.cpp)
 
-    add_executable(psibase-tests${suffix} test.cpp test-sig.cpp test_event.cpp test_crypto.cpp test_memo.cpp test_clock.cpp test_semver.cpp test_subjective.cpp testKvMerkle.cpp test_rpc.cpp test_socket.cpp)
+    add_executable(psibase-tests${suffix} test.cpp test-sig.cpp test_event.cpp test_crypto.cpp test_memo.cpp test_clock.cpp test_semver.cpp test_subjective.cpp testKvMerkle.cpp test_rpc.cpp test_socket.cpp test_verify_services.cpp)
     target_include_directories(psibase-tests${suffix} PUBLIC include)
     target_link_libraries(psibase-tests${suffix} services_system${suffix} psitestlib${suffix} )
     set_target_properties(psibase-tests${suffix} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})

--- a/services/psibase_tests/RemoveCode.cpp
+++ b/services/psibase_tests/RemoveCode.cpp
@@ -1,0 +1,19 @@
+#include "RemoveCode.hpp"
+
+#include <psibase/dispatch.hpp>
+
+using namespace psibase;
+
+void RemoveCode::removeCode(psibase::Checksum256 codeHash,
+                            std::uint8_t         vmType,
+                            std::uint8_t         vmVersion)
+{
+   kvRemove(CodeByHashRow::db, codeByHashKey(codeHash, vmType, vmVersion));
+}
+
+void RemoveCode::setCodeRow(psibase::CodeRow row)
+{
+   kvPut(CodeRow::db, row.key(), row);
+}
+
+PSIBASE_DISPATCH(RemoveCode)

--- a/services/psibase_tests/RemoveCode.hpp
+++ b/services/psibase_tests/RemoveCode.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <psibase/AccountNumber.hpp>
+#include <psibase/Service.hpp>
+#include <psibase/crypto.hpp>
+#include <psibase/nativeTables.hpp>
+
+struct RemoveCode : psibase::Service
+{
+   static constexpr auto service      = psibase::AccountNumber{"rm-code"};
+   static constexpr auto serviceFlags = psibase::CodeRow::allowWriteNative;
+   void removeCode(psibase::Checksum256 codeHash, std::uint8_t vmType, std::uint8_t vmVersion);
+   void setCodeRow(psibase::CodeRow row);
+};
+
+PSIO_REFLECT(RemoveCode, method(removeCode, codeHash, vmType, vmVersion), method(setCodeRow, row))

--- a/services/psibase_tests/test_verify_services.cpp
+++ b/services/psibase_tests/test_verify_services.cpp
@@ -1,0 +1,86 @@
+#include <psibase/DefaultTestChain.hpp>
+
+#include <services/system/SetCode.hpp>
+#include <services/system/VerifySig.hpp>
+
+using namespace psibase;
+using namespace SystemService;
+
+namespace psibase
+{
+   std::ostream& operator<<(std::ostream& os, const BlockHeaderAuthAccount& a)
+   {
+      return os << psio::convert_to_json(a);
+   }
+}  // namespace psibase
+
+namespace
+{
+   std::vector<BlockHeaderAuthAccount> getActual(TestChain& t)
+   {
+      std::vector<BlockHeaderAuthAccount> result;
+      std::vector<char>                   key       = psio::convert_to_key(codePrefix());
+      auto                                prefixLen = key.size();
+      while (auto row = t.kvGreaterEqualRaw(CodeRow::db, key, prefixLen))
+      {
+         auto a = psio::from_frac<CodeRow>(*row);
+         if ((a.flags & CodeRow::isAuthService) &&
+             t.kvGet<CodeByHashRow>(CodeByHashRow::db,
+                                    codeByHashKey(a.codeHash, a.vmType, a.vmVersion)))
+            result.push_back({a.codeNum, a.codeHash, a.vmType, a.vmVersion});
+         key = psio::convert_to_key(a.key());
+         key.push_back(0);
+      }
+      return result;
+   }
+
+   std::vector<BlockHeaderAuthAccount> getReported(TestChain& t)
+   {
+      if (auto status = t.kvGet<StatusRow>(StatusRow::db, statusKey()))
+      {
+         if (status->consensus.next)
+            return std::move(status->consensus.next->consensus.services);
+         else
+            return std::move(status->consensus.current.services);
+      }
+      return {};
+   }
+}  // namespace
+
+TEST_CASE("Verify service tracking")
+{
+   DefaultTestChain t;
+
+   SECTION("Add new service")
+   {
+      auto verify2 = t.addService("verify2", "VerifySig.wasm");
+      REQUIRE(t.from(SetCode::service)
+                  .to<SetCode>()
+                  .setFlags(verify2, VerifySig::serviceFlags)
+                  .succeeded());
+   }
+   SECTION("Unset flag for service")
+   {
+      REQUIRE(t.from(SetCode::service).to<SetCode>().setFlags(VerifySig::service, 0).succeeded());
+   }
+   SECTION("Remove service")
+   {
+      REQUIRE(t.from(VerifySig::service)
+                  .to<SetCode>()
+                  .setCode(VerifySig::service, 0, 0, std::vector<char>())
+                  .succeeded());
+   }
+
+   t.finishBlock();
+   CHECK(getReported(t) == getActual(t));
+
+   // add new verify service
+   // remove existing verify service
+   // set flags for verify service
+   // remove verify service flags
+   // add without code
+   // remove code
+   // add and remove
+   // remove and add
+   // failed transactions
+}


### PR DESCRIPTION
They could get out of sync with the chain in several edge cases:
- A CodeRow with a missing CodeByHashRow, would sometimes work, but could fail whenever we reload the verify services from the chain state. Make it so that such rows are not included.
- Failed transactions that affected the set of verify services were not properly reverted.
