### PR TITLE
add explicit cast

### DIFF
--- a/libraries/psibase/common/include/psibase/Actor.hpp
+++ b/libraries/psibase/common/include/psibase/Actor.hpp
@@ -96,6 +96,7 @@ namespace psibase
          TypedAction<Args> action{sender, receiver, method, {Args(args...)}};
          psio::size_stream ss;
          psio::to_frac(action, ss);
+         check(ss.size <= std::numeric_limits<uint32_t>::max(), "packImpl: size overflow");
          psio::shared_view_ptr<TypedAction<std::tuple<T...>>> result(
              psio::size_tag{static_cast<uint32_t>(ss.size)});
          psio::fast_buf_stream stream(result.data(), result.size());


### PR DESCRIPTION
`non-constant-expression cannot be narrowed from type 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') in initializer list`

This is a build error I've been getting
