### PR TITLE
Cleaning up rust sdk for secondary indices

### DIFF
--- a/rust/psibase_macros/psibase-macros-lib/src/service_tables_macro/tables.rs
+++ b/rust/psibase_macros/psibase-macros-lib/src/service_tables_macro/tables.rs
@@ -210,6 +210,7 @@ pub fn process_service_tables(
                 }
 
                 fn get_secondary_keys(&self) -> Vec<#psibase_mod::RawKey> {
+                    use #psibase_mod::ToKey;
                     vec![#sks]
                 }
             }

--- a/services/system/StagedTx/service/src/db.rs
+++ b/services/system/StagedTx/service/src/db.rs
@@ -1,7 +1,7 @@
 #[psibase::service_tables]
 pub mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{AccountNumber, Action, Checksum256, Fracpack, TimePointUSec, ToKey, ToSchema};
+    use psibase::{AccountNumber, Action, Checksum256, Fracpack, TimePointUSec, ToSchema};
     use serde::{Deserialize, Serialize};
 
     #[derive(Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]

--- a/services/user/Chainmail/service/src/tables.rs
+++ b/services/user/Chainmail/service/src/tables.rs
@@ -1,7 +1,7 @@
 #[psibase::service_tables]
 pub mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{AccountNumber, Fracpack, TimePointSec, ToKey, ToSchema};
+    use psibase::{AccountNumber, Fracpack, TimePointSec, ToSchema};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "InitTable", index = 0)]

--- a/services/user/Evaluations/service/src/db.rs
+++ b/services/user/Evaluations/service/src/db.rs
@@ -2,7 +2,7 @@
 pub mod tables {
     use async_graphql::SimpleObject;
 
-    use psibase::{AccountNumber, Fracpack, ToKey, ToSchema};
+    use psibase::{AccountNumber, Fracpack, ToSchema};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "ConfigTable", index = 0)]

--- a/services/user/Registry/service/src/tables.rs
+++ b/services/user/Registry/service/src/tables.rs
@@ -2,7 +2,7 @@
 pub mod tables {
     use async_graphql::*;
     use psibase::services::accounts::Wrapper as AccountsSvc;
-    use psibase::{check, AccountNumber, Fracpack, ToKey, ToSchema};
+    use psibase::{check, AccountNumber, Fracpack, ToSchema};
     use serde::{Deserialize, Serialize};
     use url::Url;
 


### PR DESCRIPTION
primarily, just needed same use for toKey.
Also took the opportunity to clean up use statements that had formerly been needed in packages.
#1189 