### PR TITLE
Fixing the type checking I inadvertently disabled when I added the no-rebuild script

### DIFF
--- a/services/system/Accounts/ui/package.json
+++ b/services/system/Accounts/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+    "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/services/system/AuthSig/ui/package.json
+++ b/services/system/AuthSig/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+    "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/services/system/Producers/ui/package.json
+++ b/services/system/Producers/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+    "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/services/user/Branding/ui/package.json
+++ b/services/user/Branding/ui/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+        "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
         "preview": "vite preview"
     },

--- a/services/user/Branding/ui/tsconfig.json
+++ b/services/user/Branding/ui/tsconfig.json
@@ -56,9 +56,4 @@
     "include": [
         "src"
     ],
-    "references": [
-        {
-            "path": "./tsconfig.node.json"
-        }
-    ]
 }

--- a/services/user/CommonApi/common/packages/common-lib/package.json
+++ b/services/user/CommonApi/common/packages/common-lib/package.json
@@ -37,7 +37,7 @@
     ],
     "scripts": {
         "dev": "vite",
-        "build": "node ../../../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+        "build": "node ../../../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
         "preview": "vite preview",
         "format": "prettier --write 'src/**/*.ts'"
     },

--- a/services/user/CommonApi/common/packages/plugin-tester/ui/package.json
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+    "build": "node ../../../../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/services/user/CommonApi/common/packages/plugin-tester/ui/tsconfig.json
+++ b/services/user/CommonApi/common/packages/plugin-tester/ui/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
     /* Bundler mode */
@@ -18,15 +22,18 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
-      "/common": ["../../../../common"],
-      "@psibase/common-lib": ["../../common-lib/src"],
-      "@psibase/common-lib/*": ["../../common-lib/src/*"]
+      "/common": [
+        "../../../../common"
+      ],
+      "@psibase/common-lib": [
+        "../../common-lib/src"
+      ],
+      "@psibase/common-lib/*": [
+        "../../common-lib/src/*"
+      ]
     }
   },
-  "include": ["./src"],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ]
+  "include": [
+    "./src"
+  ],
 }

--- a/services/user/Evaluations/ui/package.json
+++ b/services/user/Evaluations/ui/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+        "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
         "preview": "vite preview"
     },

--- a/services/user/Evaluations/ui/tsconfig.json
+++ b/services/user/Evaluations/ui/tsconfig.json
@@ -59,9 +59,4 @@
     "include": [
         "src",
     ],
-    "references": [
-        {
-            "path": "./tsconfig.node.json"
-        }
-    ]
 }

--- a/services/user/Explorer/ui/package.json
+++ b/services/user/Explorer/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0 --strictPort",
     "prepare": "svelte-kit sync",
-    "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+    "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/services/user/Explorer/ui/tsconfig.json
+++ b/services/user/Explorer/ui/tsconfig.json
@@ -45,9 +45,4 @@
         "src",
         "../../CommonApi/common/resources/useGraphQLQuery.d.ts"
     ],
-    "references": [
-        {
-            "path": "./tsconfig.node.json"
-        }
-    ]
 }

--- a/services/user/Homepage/ui/package.json
+++ b/services/user/Homepage/ui/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+        "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
         "preview": "vite preview",
         "lint": "eslint --ext .ts,.tsx --ignore-path .gitignore src",
         "lint:fix": "yarn lint --fix",

--- a/services/user/Homepage/ui/tsconfig.json
+++ b/services/user/Homepage/ui/tsconfig.json
@@ -38,9 +38,4 @@
     "include": [
         "src"
     ],
-    "references": [
-        {
-            "path": "./tsconfig.node.json"
-        }
-    ]
 }

--- a/services/user/Identity/ui/package.json
+++ b/services/user/Identity/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+    "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/services/user/Identity/ui/tsconfig.json
+++ b/services/user/Identity/ui/tsconfig.json
@@ -26,9 +26,4 @@
   "include": [
     "src"
   ],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ]
 }

--- a/services/user/Permissions/ui/package.json
+++ b/services/user/Permissions/ui/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+        "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
         "preview": "vite preview"
     },

--- a/services/user/Permissions/ui/tsconfig.json
+++ b/services/user/Permissions/ui/tsconfig.json
@@ -61,9 +61,4 @@
         "./wasm-psibase/*.d.ts",
         "wasm-psibase"
     ],
-    "references": [
-        {
-            "path": "./tsconfig.node.json"
-        }
-    ]
 }

--- a/services/user/Supervisor/ui/package.json
+++ b/services/user/Supervisor/ui/package.json
@@ -7,7 +7,7 @@
         "dev": "vite",
         "preview": "vite preview",
         "format": "prettier --write 'src/**/*.ts'",
-        "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'"
+        "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'"
     },
     "devDependencies": {
         "@types/node": "^22.15.0",

--- a/services/user/Workshop/ui/package.json
+++ b/services/user/Workshop/ui/package.json
@@ -61,6 +61,6 @@
     "tailwindcss": "^3.4.10",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "4.5.2"
+    "vite": "^4.5.2"
   }
 }

--- a/services/user/Workshop/ui/package.json
+++ b/services/user/Workshop/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../if-build-needed.mjs 'tsc --noEmit --skipLibCheck && vite build'",
+    "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/services/user/Workshop/ui/src/pages/Settings.tsx
+++ b/services/user/Workshop/ui/src/pages/Settings.tsx
@@ -39,13 +39,13 @@ export const Settings = () => {
         </div>
       </div>
     );
-  }  else
+  } else
     return (
       <div className="mx-auto w-full grid p-4 grid-cols-1 lg:grid-cols-2 gap-8 max-w-screen-xl">
         {isSuccess && (
           <MetaDataForm
             key={currentApp}
-            existingValues={metadata ? metadata.appMetadata : undefined}
+            existingValues={metadata?.appMetadata}
             onSubmit={async (x) => {
               await updateMetadata({
                 metadata: {

--- a/services/user/Workshop/ui/tsconfig.app.json
+++ b/services/user/Workshop/ui/tsconfig.app.json
@@ -5,7 +5,7 @@
     "lib": [
       "ES2020",
       "DOM",
-      "DOM.Iterable",
+      "DOM.Iterable"
     ],
     "module": "ESNext",
     "skipLibCheck": true,

--- a/services/user/Workshop/ui/tsconfig.node.json
+++ b/services/user/Workshop/ui/tsconfig.node.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": [
-      "ES2023"
+      "ES2023",
+      "DOM",
+      "DOM.Iterable",
+      "WebWorker"
     ],
     "module": "ESNext",
     /* Bundler mode */
@@ -21,7 +24,8 @@
       "vite/client",
       "react",
       "react-dom"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "include": [
     "vite.config.ts",

--- a/services/user/XAdmin/ui/package.json
+++ b/services/user/XAdmin/ui/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "node ../../../if-build-needed.mjs wasm:wasm-transpiled 'cd ./wasm && cargo-component build --release && cd .. && jco transpile ./wasm/target/wasm32-wasip1/release/x_admin.wasm --minify --no-nodejs-compat --base64-cutoff=4096 --valid-lifting-optimization -o ./wasm-transpiled && tsc --noEmit --skipLibCheck && vite build'",
+        "build": "node ../../../if-build-needed.mjs wasm:wasm-transpiled 'cd ./wasm && cargo-component build --release && cd .. && jco transpile ./wasm/target/wasm32-wasip1/release/x_admin.wasm --minify --no-nodejs-compat --base64-cutoff=4096 --valid-lifting-optimization -o ./wasm-transpiled && tsc -b --noEmit && vite build'",
         "preview": "vite preview"
     },
     "dependencies": {

--- a/services/user/XAdmin/ui/tsconfig.json
+++ b/services/user/XAdmin/ui/tsconfig.json
@@ -45,9 +45,4 @@
         "./wasm-transpiled/*.d.ts",
         "wasm-transpiled"
     ],
-    "references": [
-        {
-            "path": "./tsconfig.node.json"
-        }
-    ]
 }


### PR DESCRIPTION
FYI, the major change is `tsc --noEmit --SkipLibCheck` --> `tsc -b --noEmit`. Original config was `tsc -b`. The `--noEmit` saves some time each build. The `-b` turns out to be necessary due to our configuration. And the `skipLibCheck` was only needed for Workshop, and that's been added in tsconfig instead of used as a commandline arg.
`references` have also been removed from all tsconfigs that don't have multiple flavors because that changes the behavior of tsc.