### PR TITLE
Move creation of the system token to the Symbol service

### DIFF
--- a/services/user/Symbol/src/Symbol.cpp
+++ b/services/user/Symbol/src/Symbol.cpp
@@ -60,6 +60,16 @@ void Symbol::init()
    to<Tokens>().setUserConf("manualDebit"_m, true);
    to<Nft>().setUserConf("manualDebit"_m, true);
 
+   // Create system token
+   constexpr auto precision = Precision{4};
+   auto           tid       = to<Tokens>().create(precision, Quantity{1'000'000'000e4});
+   check(tid == Tokens::sysToken, wrongSysTokenId);
+   auto tNft = to<Tokens>().getToken(tid).ownerNft;
+   to<Nft>().debit(tNft, "Taking ownership of system token");
+
+   // Make system token default untradeable
+   to<Tokens>().setTokenConf(tid, "untradeable"_m, true);
+
    // Configure default symbol length records to establish initial prices
    auto nextSym = [](SymbolLengthRecord& s)
    {
@@ -70,7 +80,6 @@ void Symbol::init()
       return s;
    };
 
-   auto precision   = to<Tokens>().getToken(Tokens::sysToken).precision;
    auto getQuantity = [precision](Quantity_t q)
    { return (Quantity_t)(q * std::pow(10, precision.value)); };
    auto symLengthTable = Tables().open<SymbolLengthTable>();

--- a/services/user/Tokens/include/services/user/tokenTypes.hpp
+++ b/services/user/Tokens/include/services/user/tokenTypes.hpp
@@ -17,10 +17,10 @@ namespace UserService
 
       uint8_t value;
 
-      Precision(uint8_t p) : value{p} { validate(p); }
-      Precision() : Precision(0) {}
+      explicit constexpr Precision(uint8_t p) : value{p} { validate(p); }
+      constexpr Precision() : Precision(0) {}
 
-      static bool validate(const uint8_t& p)
+      static constexpr bool validate(const uint8_t& p)
       {
          if (precisionMin > p || p > precisionMax)
          {

--- a/services/user/Tokens/src/Tokens.cpp
+++ b/services/user/Tokens/src/Tokens.cpp
@@ -85,17 +85,6 @@ void Tokens::init()
       Tables().open<TokenHolderTable>().put(holder);
    }
 
-   // Create system token
-   auto tid = recurse().create(Precision{4}, Quantity{1'000'000'000e4});
-   check(tid == TID{1}, wrongSysTokenId);
-
-   // Make system token default untradeable
-   recurse().setTokenConf(tid, tokenConfig::untradeable, true);
-
-   // Pass system token ownership to symbol service
-   auto tNft = getToken(tid).ownerNft;
-   nftService.credit(tNft, Symbol::service, "Passing system token ownership");
-
    // Register proxy
    to<SystemService::HttpServer>().registerServer(RTokens::service);
 


### PR DESCRIPTION
This breaks the circular initialization dependency between Tokens and Symbols, which complicated package installation.