### PR TITLE
Upload package data faster

### DIFF
--- a/services/system/HttpServer/CMakeLists.txt
+++ b/services/system/HttpServer/CMakeLists.txt
@@ -1,5 +1,5 @@
 function(add suffix)
-    add_system_service("${suffix}" HttpServer src/HttpServer.cpp)
+    add_system_service_full_malloc("${suffix}" HttpServer src/HttpServer.cpp)
     add_system_service("${suffix}" RHttpServer src/RHttpServer.cpp)
 endfunction(add)
 


### PR DESCRIPTION
- The order in which we upload files to the staging area doesn't matter, so there's no need to wait for one to finish before starting the next. However, we do need to wait for them all to finish before actually installing.
- This exposes the need for http-server to use full-malloc, since onBlock may need to send many responses.