### PR TITLE
Fix out-dated documentation of log formatter

### DIFF
--- a/doc/psidk/src/run-infrastructure/administration.md
+++ b/doc/psidk/src/run-infrastructure/administration.md
@@ -436,9 +436,9 @@ Examples:
 
 `/native/admin/log` is a websocket endpoint that provides access to server logs as they are generated. Each message from the server contains one log record. Messages sent to the server should be JSON objects representing the desired logger configuration for the connection.
 
-| Field  | Type             | Description                                                                                                                                          |
-|--------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| filter | String           | The [filter](./configuration/logging.md#log-filters) for this websocket. If no filter is provided, the default is to send all possible log messages. |
-| format | String or Object | The [format](./configuration/logging.md#log-formatters) for log messages. If no format is provided, the default is JSON.                             |
+| Field  | Type   | Description                                                                                                                                          |
+|--------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| filter | String | The [filter](./configuration/logging.md#log-filters) for this websocket. If no filter is provided, the default is to send all possible log messages. |
+| format | String | The [format](./configuration/logging.md#log-formatters) for log messages. If no format is provided, the default is JSON.                             |
 
 The server begins sending log messages after it receives the first logger configuration from the client. The client can change the configuration at any time.  The configuration change is asynchronous, so the server will continue to send messages using the old configuration for a short period after client sends the update but before the server processes it.

--- a/libraries/psibase/native/src/log.cpp
+++ b/libraries/psibase/native/src/log.cpp
@@ -652,7 +652,6 @@ namespace psibase::loggers
                                 {
                                    if (key == "format")
                                    {
-                                      std::string tmp;
                                       obj.format = parse_formatter(stream.get_string());
                                    }
                                    else if (key == "filter")


### PR DESCRIPTION
The log format once allowed a map of `Channel` to formatter. This was changed in e5566155688c535a56b58cc7a893b71956154f6e to use conditionals in the format string instead. I missed one reference to the old format in the docs.