### PR TITLE
Fix routing p2p messages after a node restarts

### DIFF
--- a/programs/psinode/tests/test_crash.py
+++ b/programs/psinode/tests/test_crash.py
@@ -74,6 +74,28 @@ class TestCrash(unittest.TestCase):
             time.sleep(1)
 
     @testutil.psinode_test
+    def test_restart_after_disconnect(self, cluster):
+        prods = cluster.complete(*testutil.generate_names(4))
+        testutil.boot_with_producers(prods, algorithm='cft', packages=['Minimal', 'Explorer'])
+
+        (a, b, c, d) = prods
+        # Stop d, so we have no fault tolerance
+        d.shutdown()
+
+        c.disconnect(b)
+        c.connect(b)
+        c.disconnect(a)
+        c.connect(a)
+
+        # stop and restart c
+        c.shutdown();
+        c.start()
+
+        a.connect(c)
+
+        a.wait(new_block())
+
+    @testutil.psinode_test
     def test_shutdown_all_bft(self, cluster):
         prods = cluster.complete(*testutil.generate_names(4))
         a = testutil.boot_with_producers(prods, 'bft', packages=['Minimal', 'Explorer'])


### PR DESCRIPTION
After a node was restarted, it would sometimes not receive consensus related messages, causing the chain to halt.

Nodes running with this update should be able to connect to existing nodes, however, the fix won't be effective for a connection until both nodes are upgraded.

There are still a number of issues in this PR, which will be addressed in a follow-up PR:
- There are still some structures and messages that need to be updated
- There is a small memory leak. After a node is restarted, the old entries are never removed from the tables of the other nodes.