### PR TITLE
Avoid overwriting existing log files

### DIFF
--- a/libraries/psibase/native/src/log.cpp
+++ b/libraries/psibase/native/src/log.cpp
@@ -1090,6 +1090,7 @@ namespace psibase::loggers
          static void init(backend_type&) {}
          void        apply(boost::log::sinks::text_file_backend& backend) const
          {
+            backend.set_open_mode(std::ios_base::out | std::ios_base::app);
             backend.set_file_name_pattern(filename.native());
             backend.set_target_file_name_pattern(target.native());
             backend.set_rotation_size(rotationSize);
@@ -1459,7 +1460,8 @@ namespace psibase::loggers
       boost::shared_ptr<boost::log::sinks::sink> make_sink(const sink_config& cfg)
       {
          return std::visit(
-             [&](auto& backend) {
+             [&](auto& backend)
+             {
                 return static_cast<boost::shared_ptr<boost::log::sinks::sink>>(
                     make_sink(cfg, backend));
              },


### PR DESCRIPTION
Boost.Log rotates on close, which doesn't work when we kill the process.