### PR TITLE
Implement speculative transaction execution

### DIFF
--- a/programs/psinode/tests/test_txqueue.py
+++ b/programs/psinode/tests/test_txqueue.py
@@ -39,7 +39,9 @@ class TestTransactionQueue(unittest.TestCase):
             txqueue.push_transaction(Transaction(a.get_tapos(timeout=4), [inc, fail], []))
         with a.get('/value', 's-counter') as response:
             response.raise_for_status()
-            self.assertEqual(response.json(), 1)
+            # Applying the transaction doesn't wait for speculative execution
+            # to complete, so the transaction may be attempted twice
+            self.assertIn(response.json(), [1, 2])
 
     @testutil.psinode_test
     def test_forward(self, cluster):

--- a/services/system/Transact/include/services/system/Transact.hpp
+++ b/services/system/Transact/include/services/system/Transact.hpp
@@ -288,6 +288,10 @@ namespace SystemService
       /// Called by native code at the beginning of each block
       void startBlock();
 
+      /// Called by RTransact to execute a transaction speculatively
+      void execTrx(psio::view<const psio::shared_view_ptr<psibase::Transaction>> trx,
+                   bool                                                          speculative);
+
       /// Sets the time between snapshots
       ///
       /// A value of 0 will disable snapshots. This is a chain-wide
@@ -338,7 +342,7 @@ namespace SystemService
       std::vector<char> runAs(psibase::Action action, std::vector<ServiceMethod> allowedActions);
 
       /// Checks authorization for the sender of the first action
-      void checkFirstAuth(psibase::Checksum256                   id,
+      bool checkFirstAuth(psibase::Checksum256                   id,
                           psio::view<const psibase::Transaction> transaction);
 
       /// Get the currently executing transaction
@@ -363,6 +367,7 @@ namespace SystemService
                 method(startBoot, bootTransactions),
                 method(finishBoot),
                 method(startBlock),
+                method(execTrx, transaction, speculative),
                 method(setSnapTime, seconds),
                 method(addCallback, type, objective, action),
                 method(removeCallback, type, objective, action),


### PR DESCRIPTION
- Transactions are not forwarded until speculative execution and signature verification succeeds
- The leader does *not* wait for speculative execution to succeed to include a transaction in a block
- Speculative execution is skipped during boot