### PR TITLE
Add fracpack(skip) attribute

### DIFF
--- a/rust/psibase_macros/psibase-macros-derive/src/schema_macro.rs
+++ b/rust/psibase_macros/psibase-macros-derive/src/schema_macro.rs
@@ -1,4 +1,4 @@
-use crate::fracpack_macro::Options as FracpackOptions;
+use crate::fracpack_macro::{skip_field, Options as FracpackOptions};
 use darling::{error::Accumulator, FromDeriveInput, FromVariant};
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -39,6 +39,7 @@ fn visit_fields_named(
     let visit_fields = fields
         .named
         .iter()
+        .filter(|field| !skip_field(field))
         .map(|field| {
             let name_str = field.ident.as_ref().unwrap().to_string();
             let ty = visit_type(&field.ty);

--- a/rust/test_fracpack/src/lib.rs
+++ b/rust/test_fracpack/src/lib.rs
@@ -37,6 +37,9 @@ pub struct DefWontChangeInnerStruct {
     pub field_i32: i32,
 }
 
+#[derive(PartialEq, Eq, Debug, Default)]
+pub struct NotPackable;
+
 #[derive(Pack, Unpack, ToSchema, PartialEq, Eq, Debug)]
 #[fracpack(fracpack_mod = "fracpack")]
 pub struct InnerStruct {
@@ -84,6 +87,8 @@ pub struct OuterStruct {
     pub field_o_o_str: Option<Option<String>>,
     pub field_o_o_str2: Option<Option<String>>,
     pub field_o_o_inner: Option<Option<InnerStruct>>,
+    #[fracpack(skip)]
+    pub skipped: NotPackable,
 }
 
 #[derive(Pack, Unpack, ToSchema, Debug, PartialEq)]

--- a/rust/test_fracpack/tests/test.rs
+++ b/rust/test_fracpack/tests/test.rs
@@ -60,6 +60,7 @@ fn get_tests1() -> [OuterStruct; 3] {
             field_o_o_str: None,
             field_o_o_str2: Some(Some("".into())),
             field_o_o_inner: None,
+            skipped: NotPackable,
         },
         OuterStruct {
             field_u8: 0xff,
@@ -167,6 +168,7 @@ fn get_tests1() -> [OuterStruct; 3] {
             field_o_o_str: Some(None),
             field_o_o_str2: None,
             field_o_o_inner: Some(None),
+            skipped: NotPackable,
         },
         OuterStruct {
             field_u8: 0xff,
@@ -260,6 +262,7 @@ fn get_tests1() -> [OuterStruct; 3] {
                 inner_option_vec_u16: Some(vec![0x1234, 0x5678]),
                 inner_o_vec_o_u16: Some(vec![]),
             })),
+            skipped: NotPackable,
         },
     ]
 } // get_tests1()


### PR DESCRIPTION
Allows struct fields to be ignored during packing. On unpack, the field will be initialized with `Default::default`