### PR TITLE
The isSubjective flag should not allow verify to load a node-local service

### DIFF
--- a/libraries/psibase/native/src/ExecutionContext.cpp
+++ b/libraries/psibase/native/src/ExecutionContext.cpp
@@ -264,7 +264,7 @@ namespace psibase
             auto ca = database.kvGet<CodeRow>(DbId::native, codeKey(service));
             check(ca.has_value(), "unknown service account: " + service.str());
             check(ca->codeHash != Checksum256{}, "service account has no code");
-            if (ca->flags & CodeRow::isSubjective)
+            if ((ca->flags & CodeRow::isSubjective) && !dbMode.verifyOnly)
             {
                auto subjectiveCode =
                    database.kvGet<CodeRow>(DbId::nativeSubjective, codeKey(service));

--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -532,6 +532,14 @@ namespace psibase
             return std::nullopt;
          return psio::from_frac<V>(*v);
       }
+
+      void kvPutRaw(DbId db, psio::input_stream key, psio::input_stream value);
+
+      template <typename K, typename V>
+      void kvPut(DbId db, const K& key, const V& value)
+      {
+         kvPutRaw(db, psio::convert_to_key(key), psio::convert_to_frac(value));
+      }
    };  // TestChain
 
 }  // namespace psibase

--- a/libraries/psibase/tester/src/tester.cpp
+++ b/libraries/psibase/tester/src/tester.cpp
@@ -573,3 +573,8 @@ std::optional<std::vector<char>> psibase::TestChain::kvGreaterEqualRaw(DbId     
       return std::nullopt;
    return psibase::getResult(size);
 }
+
+void psibase::TestChain::kvPutRaw(DbId db, psio::input_stream key, psio::input_stream value)
+{
+   tester::raw::kvPut(id, db, key.pos, key.remaining(), value.pos, value.remaining());
+}

--- a/services/psibase_tests/test_verify_services.cpp
+++ b/services/psibase_tests/test_verify_services.cpp
@@ -19,6 +19,25 @@ namespace psibase
 
 namespace
 {
+   auto pubFromPem = [](std::string param) {  //
+      return AuthSig::SubjectPublicKeyInfo{AuthSig::parseSubjectPublicKeyInfo(param)};
+   };
+
+   auto privFromPem = [](std::string param) {  //
+      return AuthSig::PrivateKeyInfo{AuthSig::parsePrivateKeyInfo(param)};
+   };
+
+   auto aliceKeys =
+       KeyPair{pubFromPem("-----BEGIN PUBLIC KEY-----\n"
+                          "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWdALpn+cGuD1klsSRXTdapYlG5mu\n"
+                          "WgoALofZYufL838GRUo43UuoGzxu/mW5T6r9Ix4/qc4gH2B+Zc6VYw/pKQ==\n"
+                          "-----END PUBLIC KEY-----\n"),
+               privFromPem("-----BEGIN PRIVATE KEY-----\n"
+                           "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg9h35bFuOZyB8i+GT\n"
+                           "HEfwKktshavRCyzHq3X55sdfgs6hRANCAARZ0Aumf5wa4PWSWxJFdN1qliUbma5a\n"
+                           "CgAuh9li58vzfwZFSjjdS6gbPG7+ZblPqv0jHj+pziAfYH5lzpVjD+kp\n"
+                           "-----END PRIVATE KEY-----\n")};
+
    std::vector<BlockHeaderAuthAccount> getActual(TestChain& t)
    {
       std::vector<BlockHeaderAuthAccount> result;
@@ -173,4 +192,33 @@ TEST_CASE("Verify service tracking")
 
    t.finishBlock();
    CHECK(getReported(t) == getActual(t));
+}
+
+TEST_CASE("No subjective verify")
+{
+   DefaultTestChain t;
+   {
+      auto          nopWasm  = readWholeFile("Nop.wasm");
+      auto          codeHash = sha256(nopWasm.data(), nopWasm.size());
+      CodeByHashRow codeByHash{
+          .codeHash = codeHash,
+          .code{nopWasm.begin(), nopWasm.end()},
+      };
+      t.kvPut(DbId::nativeSubjective, codeByHash.key(), codeByHash);
+      CodeRow code{
+          .codeNum  = VerifySig::service,
+          .flags    = CodeRow::isAuthService,
+          .codeHash = codeHash,
+      };
+      t.kvPut(DbId::nativeSubjective, code.key(), code);
+   }
+   CHECK(t.from(SetCode::service)
+             .to<SetCode>()
+             .setFlags(VerifySig::service, CodeRow::isSubjective | CodeRow::isAuthService)
+             .succeeded());
+   t.startBlock();
+   auto alice = t.addAccount("alice", aliceKeys.first);
+   auto trx   = t.signTransaction(t.makeTransaction({{alice, AccountNumber{"nop"}}}), {aliceKeys});
+   trx.proofs[0].clear();
+   CHECK(Result<void>{t.pushTransaction(trx)}.failed("signature invalid"));
 }


### PR DESCRIPTION
`isSubjective` is ignored in verify mode.