### PR TITLE
Fix issue with overriding sourcemap and minify options at individual app UI level

### DIFF
--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/ui/vite.config.mts
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/ui/vite.config.mts
@@ -2,10 +2,10 @@ import path from "path";
 import { defineConfig } from "vite";
 
 import {
-    createPsibaseConfig,
-    createSharedViteConfig,
-    getSharedUIPlugins,
-    verifyViteCache,
+  createPsibaseConfig,
+  createSharedViteConfig,
+  getSharedUIPlugins,
+  verifyViteCache,
 } from "../../../vite.shared";
 
 const serviceDir = path.resolve(__dirname);
@@ -15,20 +15,20 @@ verifyViteCache(serviceDir);
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => ({
-    plugins: [
-        createSharedViteConfig({
-            projectDir: serviceDir,
-        }),
-        createPsibaseConfig({
-            service: serviceName,
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
-        ...getSharedUIPlugins(),
-    ],
-    build: {
-        minify: false,
-        sourcemap: false,
-    },
+  plugins: [
+    createSharedViteConfig({
+      projectDir: serviceDir,
+    }),
+    createPsibaseConfig({
+      service: serviceName,
+      serviceDir: serviceDir,
+      isServing: command === "serve",
+      useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
+    }),
+    ...getSharedUIPlugins(),
+  ],
+  build: {
+    minify: true,
+    sourcemap: false,
+  },
 }));

--- a/services/system/Accounts/ui/vite.config.mts
+++ b/services/system/Accounts/ui/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/system/AuthSig/ui/vite.config.mts
+++ b/services/system/AuthSig/ui/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/system/Producers/ui/vite.config.mts
+++ b/services/system/Producers/ui/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/user/Branding/ui/vite.config.mts
+++ b/services/user/Branding/ui/vite.config.mts
@@ -39,7 +39,7 @@ export default defineConfig(({ command }) => {
             ...getSharedUIPlugins(),
         ],
         build: {
-            minify: false,
+            minify: true,
             sourcemap: false,
         },
     };

--- a/services/user/Evaluations/ui/vite.config.mts
+++ b/services/user/Evaluations/ui/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/user/Fractals/ui/vite.config.mts
+++ b/services/user/Fractals/ui/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/user/Homepage/ui/vite.config.mts
+++ b/services/user/Homepage/ui/vite.config.mts
@@ -32,7 +32,7 @@ export default defineConfig(({ command }) => ({
         svgr(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/user/Identity/ui/vite.config.mts
+++ b/services/user/Identity/ui/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/user/Packages/ui/vite.config.mts
+++ b/services/user/Packages/ui/vite.config.mts
@@ -28,7 +28,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/user/Permissions/ui/vite.config.mts
+++ b/services/user/Permissions/ui/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
         rollupOptions: {
             input: {

--- a/services/user/Supervisor/ui/vite.config.mts
+++ b/services/user/Supervisor/ui/vite.config.mts
@@ -28,7 +28,7 @@ export default defineConfig(({ command }) => ({
     ],
     build: {
         target: "esnext",
-        minify: false,
+        minify: true,
         sourcemap: false,
         rollupOptions: {
             external: ["hash.js", "elliptic"],

--- a/services/user/Workshop/ui/vite.config.mts
+++ b/services/user/Workshop/ui/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/user/XAdmin/ui/vite.config.mts
+++ b/services/user/XAdmin/ui/vite.config.mts
@@ -52,7 +52,7 @@ export default defineConfig(({ command }) => ({
         ...getSharedUIPlugins(),
     ],
     build: {
-        minify: false,
+        minify: true,
         sourcemap: false,
     },
 }));

--- a/services/vite.shared.ts
+++ b/services/vite.shared.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 import type { Alias, Plugin, UserConfig } from "vite";
 
-import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
 import fs from "fs";
 import path from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -51,9 +51,6 @@ export function createSharedViteConfig(
 
     const userConfig: UserConfig = {
         build: {
-            // Disable sourcemaps in production for better caching
-            sourcemap: process.env.NODE_ENV === "development",
-            minify: process.env.NODE_ENV !== "development",
             rollupOptions,
             // Increase chunk size warning limit
             chunkSizeWarningLimit: 1000,


### PR DESCRIPTION
The shared vite config made it difficult to control the `minify` and `sourcemap` options when debugging individual app UIs. This returns control of that to the app's individual vite config.