### PR TITLE
Add unlock-key-device prompt to Join Network flow

### DIFF
--- a/services/user/XAdmin/ui/src/components/steps.tsx
+++ b/services/user/XAdmin/ui/src/components/steps.tsx
@@ -10,7 +10,7 @@ export const Steps = ({
     numberOfSteps: number;
 }) => {
     return (
-        <div className="flex items-center ">
+        <div className="flex items-center justify-center">
             {Array.from({ length: numberOfSteps }).map((_, index) => {
                 const isPresentOrPast = currentStep >= index + 1;
                 const isHighlight = currentStep > index + 1;

--- a/services/user/XAdmin/ui/src/pages/join-page.tsx
+++ b/services/user/XAdmin/ui/src/pages/join-page.tsx
@@ -1,10 +1,26 @@
+import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import { z } from "zod";
 
 import { useToast } from "@/components/ui/use-toast";
 
+import { PrevNextButtons } from "@/components/PrevNextButtons";
+import { KeyDeviceForm } from "@/components/forms/key-device-form";
 import { Schema, UrlForm } from "@/components/forms/url";
+import { Steps } from "@/components/steps";
 
-import { useConnect } from "../hooks/useConnect";
+import { useConnect } from "@/hooks/useConnect";
+import { useStepper } from "@/hooks/useStepper";
+import { KeyDeviceSchema } from "@/types";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@shared/shadcn/ui/card";
+
 import { SetupWrapper } from "./setup-wrapper";
 
 export const JoinPage = () => {
@@ -12,6 +28,25 @@ export const JoinPage = () => {
 
     const navigate = useNavigate();
     const { toast } = useToast();
+
+    const keyDeviceForm = useForm<z.infer<typeof KeyDeviceSchema>>();
+
+    const Step = {
+        KeyDevice: "KEY_DEVICE",
+        Completion: "COMPLETION",
+    } as const;
+
+    type StepKey = (typeof Step)[keyof typeof Step];
+
+    const {
+        canNext,
+        canPrev,
+        next,
+        previous,
+        currentStepNum,
+        currentStep,
+        maxSteps,
+    } = useStepper<StepKey>([{ step: Step.KeyDevice, form: keyDeviceForm }]);
 
     const onSubmit = async (data: Schema) => {
         const res = await connect(data);
@@ -26,15 +61,56 @@ export const JoinPage = () => {
 
     return (
         <SetupWrapper>
-            <div className="mx-auto h-full w-full  max-w-screen-lg  flex-col gap-3">
-                <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
-                    Join
-                </h1>{" "}
-                <p className="text-muted-foreground mt-3 leading-7">
-                    Connect to a psibase compatible node to join a network.
-                </p>
-                <div>
-                    <UrlForm onSubmit={onSubmit} />
+            <div className="flex h-full flex-col">
+                <div className="flex flex-1 flex-col items-center justify-center space-y-20">
+                    <Steps
+                        currentStep={currentStepNum}
+                        numberOfSteps={maxSteps}
+                    />
+                    {currentStep === Step.KeyDevice && (
+                        <div className="flex justify-center">
+                            <Card className="min-w-[350px]">
+                                <CardHeader>
+                                    <CardTitle>
+                                        Select security device
+                                    </CardTitle>
+                                    <CardDescription>
+                                        Where do you want your block producer
+                                        server key to be stored?
+                                    </CardDescription>
+                                </CardHeader>
+                                <CardContent>
+                                    <KeyDeviceForm
+                                        form={keyDeviceForm}
+                                        next={next}
+                                        deviceNotFoundErrorMessage="No security devices were found. Please ensure one is available. Alternatively, you may boot in an insecure keyless mode by going back and selecting the Development boot template."
+                                    />
+                                </CardContent>
+                            </Card>
+                        </div>
+                    )}
+                    {currentStep === Step.Completion && (
+                        <div>
+                            <h1 className="mb-4 scroll-m-20 text-3xl font-extrabold tracking-tight lg:text-4xl">
+                                Join
+                            </h1>
+                            <p className="text-muted-foreground mt-3 leading-7">
+                                Connect to a psibase compatible node to join a
+                                network.
+                            </p>
+                            <div>
+                                <UrlForm onSubmit={onSubmit} />
+                            </div>
+                        </div>
+                    )}
+                </div>
+                <div className="py-4">
+                    <PrevNextButtons
+                        canNext={canNext}
+                        canPrev={canPrev}
+                        next={next}
+                        previous={previous}
+                    />
                 </div>
             </div>
         </SetupWrapper>


### PR DESCRIPTION
The "Join Network" network initialization flow was a one-step UI. This turns it into a two-step flow, adding the unlock-key-device prompt as the first step in the flow.