### PR TITLE
Fix test failure in test_txqueue

### DIFF
--- a/programs/psinode/tests/psinode.py
+++ b/programs/psinode/tests/psinode.py
@@ -257,14 +257,14 @@ class API:
             if len(keys) != 0:
                 raise Exception("Transaction is already signed")
             return trx
-    def push_transaction(self, trx, keys=[]):
+    def push_transaction(self, trx, keys=[], wait_for="applied"):
         '''
         Push a transaction to the chain and return the transaction trace
 
         Raise TransactionError if the transaction fails
         '''
         packed = self.pack_signed_transaction(trx, keys)
-        with self.post('/push_transaction?wait_for=applied', service='transact', headers={'Content-Type': 'application/octet-stream'}, data=packed) as result:
+        with self.post('/push_transaction?wait_for=%s' % wait_for, service='transact', headers={'Content-Type': 'application/octet-stream'}, data=packed) as result:
             result.raise_for_status()
             trace = result.json()
             if trace['error'] is not None:

--- a/programs/psinode/tests/services.py
+++ b/programs/psinode/tests/services.py
@@ -14,9 +14,9 @@ class Tokens(Service):
 
 class Transact(Service):
     service = 'transact'
-    def push_transaction(self, trx, keys=[]):
+    def push_transaction(self, trx, keys=[], wait_for="applied"):
         packed = self.api.pack_signed_transaction(trx, keys)
-        with self.post('/push_transaction?wait_for=applied', headers={'Content-Type': 'application/octet-stream'}, data=packed) as response:
+        with self.post('/push_transaction?wait_for=%s' % wait_for, headers={'Content-Type': 'application/octet-stream'}, data=packed) as response:
             response.raise_for_status()
             trace = response.json()
             if trace['error'] is not None:

--- a/programs/psinode/tests/test_txqueue.py
+++ b/programs/psinode/tests/test_txqueue.py
@@ -36,7 +36,7 @@ class TestTransactionQueue(unittest.TestCase):
         with self.assertRaises(TransactionError, msg="Transaction expired"):
             inc = Action('alice', 's-counter', 'inc', {"key":"","id":0})
             fail = Action('alice', 'tokens', 'credit', {"tokenId":1,"receiver":"bob","amount":{"value":100000000}, "memo":"fail"})
-            txqueue.push_transaction(Transaction(a.get_tapos(timeout=4), [inc, fail], []))
+            txqueue.push_transaction(Transaction(a.get_tapos(timeout=4), [inc, fail], []), wait_for="final")
         with a.get('/value', 's-counter') as response:
             response.raise_for_status()
             # Applying the transaction doesn't wait for speculative execution


### PR DESCRIPTION
with `wait_for=applied`, the speculative transaction might fail while the transaction is being applied in a block, which would cause us to check the counter too early.