### PR TITLE
Fix testnet crash

### DIFF
--- a/libraries/psibase/native/include/psibase/BlockContext.hpp
+++ b/libraries/psibase/native/include/psibase/BlockContext.hpp
@@ -49,7 +49,10 @@ namespace psibase
       void      callStartBlock();
       void      callOnBlock();
       void      callOnTransaction(const Checksum256& id, const TransactionTrace& trace);
-      std::optional<SignedTransaction>         callNextTransaction();
+      std::optional<SignedTransaction> callNextTransaction();
+      // \post The size of the result is the number of proofs in the
+      // transaction. Entries that cannot be filled (including due to
+      // errors) will be set to zero.
       std::vector<Checksum256>                 callPreverify(const SignedTransaction& trx);
       void                                     callRun(psio::view<const RunRow> row);
       Checksum256                              makeEventMerkleRoot();

--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -415,13 +415,16 @@ namespace psibase
                PSIBASE_LOG(trxLogger, debug) << "preverifyTransaction succeeded";
                if (result)
                {
-                  for (const auto& [token, out] : std::views::zip(*result, tokens))
-                  {
-                     if (token && token->size() == out.size())
-                     {
-                        std::ranges::copy(*token, out.begin());
-                     }
-                  }
+                  std::ranges::transform(std::views::take(*result, tokens.size()), tokens.begin(),
+                                         [](const auto& token)
+                                         {
+                                            Checksum256 value = {};
+                                            if (token && token->size() == value.size())
+                                            {
+                                               std::ranges::copy(*token, value.begin());
+                                            }
+                                            return value;
+                                         });
                   break;
                }
             }

--- a/programs/psinode/tests/test_txqueue.py
+++ b/programs/psinode/tests/test_txqueue.py
@@ -74,9 +74,9 @@ class TestTransactionQueue(unittest.TestCase):
 
     @testutil.psinode_test
     def test_signed(self, cluster):
-        prods = cluster.complete(*testutil.generate_names(3))
-        testutil.boot_with_producers(prods, packages=['Minimal', 'Explorer', 'TokenUsers'])
-        (a, b, c) = prods
+        prods = cluster.complete(*testutil.generate_names(4))
+        testutil.boot_with_producers(prods[:3], packages=['Minimal', 'Explorer', 'TokenUsers'])
+        (a, b, c, d) = prods
 
         tokens = Tokens(a)
         old_balance = tokens.balance('alice', token=1)
@@ -94,10 +94,13 @@ class TestTransactionQueue(unittest.TestCase):
         b_balance = Tokens(b).balance('alice', token=1)
         c.wait(pred)
         c_balance = Tokens(c).balance('alice', token=1)
+        d.wait(pred)
+        d_balance = Tokens(d).balance('alice', token=1)
         expected_balance = old_balance - 10000
         self.assertEqual(a_balance, expected_balance)
         self.assertEqual(b_balance, expected_balance)
         self.assertEqual(c_balance, expected_balance)
+        self.assertEqual(d_balance, expected_balance)
 
     @testutil.psinode_test
     def test_restart_node(self, cluster):


### PR DESCRIPTION
We were assuming that `callPreverify` always returns a token for each signature, but that was only true when we found a `preverify` callback. Make the implementation uphold that postcondition consistently.

This caused a non-producing node to fail whenever it received a block with a signed transaction.