### PR TITLE
declutter console

### DIFF
--- a/services/system/Transact/plugin/src/helpers.rs
+++ b/services/system/Transact/plugin/src/helpers.rs
@@ -7,6 +7,7 @@ use crate::types::FromExpirationTime;
 use crate::{ActionAuthPlugins, ActionClaims, ActionMetadata, ActionSenderHook, TxTransformLabel};
 use psibase::fracpack::Pack;
 use psibase::{AccountNumber, Hex, MethodNumber, SignedTransaction, Tapos, Transaction};
+use serde::Serialize;
 use Host::{client as Client, server as Server, types::PluginRef};
 
 use regex::Regex;
@@ -196,6 +197,51 @@ pub fn get_proofs_for_user(
         .collect())
 }
 
+#[derive(Serialize)]
+struct SimpleAction {
+    sender: String,
+    service: String,
+    method: String,
+}
+
+impl From<psibase::Action> for SimpleAction {
+    fn from(action: psibase::Action) -> Self {
+        SimpleAction {
+            sender: action.sender.to_string(),
+            service: action.service.to_string(),
+            method: action.method.to_string(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SimpleClaim {
+    service: String,
+}
+
+impl From<psibase::Claim> for SimpleClaim {
+    fn from(claim: psibase::Claim) -> Self {
+        SimpleClaim {
+            service: claim.service.to_string(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SimpleTx {
+    actions: Vec<SimpleAction>,
+    claims: Vec<SimpleClaim>,
+}
+
+impl From<Transaction> for SimpleTx {
+    fn from(tx: Transaction) -> Self {
+        SimpleTx {
+            actions: tx.actions.into_iter().map(Into::into).collect(),
+            claims: tx.claims.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
 pub fn make_transaction(actions: Vec<Action>, expiration_seconds: u64) -> Transaction {
     let claims = get_claims(&actions, true).expect("Failed to retrieve claims from auth plugin");
     let claims: Vec<psibase::Claim> = claims.into_iter().map(Into::into).collect();
@@ -211,9 +257,12 @@ pub fn make_transaction(actions: Vec<Action>, expiration_seconds: u64) -> Transa
         actions,
         claims,
     };
+
+    let simple_tx: SimpleTx = t.clone().into();
+
     println!(
         "Publishing transaction: \n{}",
-        serde_json::to_string_pretty(&t).unwrap()
+        serde_json::to_string_pretty(&simple_tx).unwrap()
     );
     t
 }


### PR DESCRIPTION
Removes some of the clutter from the browser console by trimming the output for printed transactions