### PR TITLE
Fix wait_for=final

### DIFF
--- a/libraries/psibase/common/include/psibase/nativeTables.hpp
+++ b/libraries/psibase/common/include/psibase/nativeTables.hpp
@@ -174,7 +174,8 @@ namespace psibase
    // are sent can be changed without breaking consensus.
    enum class NotifyType : std::uint32_t
    {
-      // A block is produced or validated
+      // A block is produced or validated. The notification is
+      // sent after the StatusRow is updated with the new head.
       acceptBlock,
       // A transaction is accepted or validated
       acceptTransaction,


### PR DESCRIPTION
`onBlock` was confused about current vs head. Native updated them so that head was the block that was just produced, but RTransact used current instead. This caused two different problems:
- The fix in e2d324c1217d30a9ddd69df6bc4e32c62d1d088b didn't actually work because it saw the wrong blockNum
- The blockNum to timestamp mapping in reversible was set prematurely which was wrong whenever there were gaps in block production.