### PR TITLE
Fix database corruption caused by reusing memory that a session is accessing

### DIFF
--- a/libraries/triedent/include/triedent/gc_queue.hpp
+++ b/libraries/triedent/include/triedent/gc_queue.hpp
@@ -92,10 +92,10 @@ namespace triedent
       size_type next(size_type pos);
       // requires _queue_mutex to be locked
       void pop_some(std::vector<std::shared_ptr<void>>& out, size_type start, size_type end);
-      // If any session is locking start, sets _waiting and ensures
+      // If block is true and any session is locking start, sets _waiting and ensures
       //   that there is a session that will notify _queue_cond.
       // returns the lowest sequence that is locked
-      size_type start_wait(size_type start, size_type end);
+      size_type start_wait(size_type start, size_type end, bool block);
       // Indicates an unlocked session
       static constexpr size_type npos = ~size_type(0);
       // At most one locked session has its wait_bit set.

--- a/libraries/triedent/include/triedent/region_allocator.hpp
+++ b/libraries/triedent/include/triedent/region_allocator.hpp
@@ -118,7 +118,7 @@ namespace triedent
       void          start_new_region(header::data* old, header::data* next, std::shared_ptr<void>&);
       void          double_region_size(header::data* old_data, header::data* new_data);
       static void   copy_header_data(header::data* old, header::data* next);
-      std::uint64_t evacuate_region(queue_item& item);
+      std::uint64_t evacuate_region(queue_item& item, char* base);
 
       static bool is_used(const queue_item& item);
       //

--- a/libraries/triedent/src/region_allocator.cpp
+++ b/libraries/triedent/src/region_allocator.cpp
@@ -238,7 +238,7 @@ namespace triedent
       }
    }
 
-   std::uint64_t region_allocator::evacuate_region(queue_item& item)
+   std::uint64_t region_allocator::evacuate_region(queue_item& item, char* base)
    {
       auto begin    = item.src_begin.load();
       auto end      = item.src_end.load();
@@ -257,7 +257,7 @@ namespace triedent
             {
                break;
             }
-            void* new_location = _base + dest;
+            void* new_location = base + dest;
             std::memcpy(new_location, p, object_size);
             item.dest_begin.store(dest + object_size);
             if (_obj_ids.compare_and_move(lock, loc,
@@ -394,10 +394,11 @@ namespace triedent
             std::cout << "evacuating region: " << item.src_begin.load() / _h->region_size
                       << std::endl;
          }
+         auto base = _base;
          l.unlock();
          auto orig_src  = item.src_begin.load();
          auto orig_dest = item.dest_begin.load();
-         auto end       = evacuate_region(item);
+         auto end       = evacuate_region(item, base);
          l.lock();
          auto src_region  = orig_src / _h->region_size;
          auto dest_region = orig_dest / _h->region_size;


### PR DESCRIPTION
The code assumed that the `_sequence` for a session is in bounds, but this was not necessarily true. If the session lock was suspended right after reading `_end`, the state of the queue could change arbitrarily before it writes `_sequence`. `session::lock` accounts for this, but it does create a transient out-of-bounds value for `_sequence` that may be seen by `start_wait`. This would cause us to remove too many items from the queue. Clearing these elements was fine, because they were already `nullptr`.  Decrementing `_size`, though, is a big problem, because it is how we know which items in the circular buffer are free and safe to reuse.
