### PR TITLE
Callbacks that fail should not modify the database

### DIFF
--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -197,7 +197,9 @@ namespace psibase
 
          try
          {
+            auto session = db.startWrite(writer);
             tc.execNonTrxAction(0, action, atrace);
+            session.commit();
             BOOST_LOG_SCOPED_LOGGER_TAG(trxLogger, "Trace", trace);
             PSIBASE_LOG(trxLogger, debug) << "onBlock succeeded";
          }
@@ -249,7 +251,9 @@ namespace psibase
 
          try
          {
+            auto session = db.startWrite(writer);
             tc.execNonTrxAction(0, action, atrace);
+            session.commit();
             BOOST_LOG_SCOPED_LOGGER_TAG(trxLogger, "Trace", trace);
             PSIBASE_LOG(trxLogger, debug) << "onTransaction succeeded";
          }
@@ -331,7 +335,9 @@ namespace psibase
 
          try
          {
+            auto session = db.startWrite(writer);
             tc.execNonTrxAction(0, action, atrace);
+            session.commit();
 
             std::optional<SignedTransaction> result;
             if (!psio::from_frac(result, atrace.rawRetval))
@@ -399,7 +405,9 @@ namespace psibase
 
          try
          {
+            auto session = db.startWrite(writer);
             tc.execNonTrxAction(0, action, atrace);
+            session.commit();
 
             std::optional<std::vector<std::optional<RunToken>>> result;
             if (!psio::from_frac(result, atrace.rawRetval))

--- a/libraries/psibase/tester/src/chain_polyfill.cpp
+++ b/libraries/psibase/tester/src/chain_polyfill.cpp
@@ -90,6 +90,11 @@ void psibase::raw::kvPut(DbId        db,
                                valueLen);
 }
 
+void psibase::raw::kvRemove(DbId db, const char* key, uint32_t keyLen)
+{
+   psibase::tester::raw::kvRemove(psibase::tester::raw::getSelectedChain(), db, key, keyLen);
+}
+
 std::int32_t psibase::raw::socketSend(std::int32_t fd, const void* data, std::size_t size)
 {
    psibase::abortMessage("Tester does not support socketSend");

--- a/services/psibase_tests/CMakeLists.txt
+++ b/services/psibase_tests/CMakeLists.txt
@@ -21,6 +21,7 @@ function(add suffix)
     service(EmitEvents "${suffix}" src/EmitEvents.cpp)
     service(RemoveCode "${suffix}" src/RemoveCode.cpp)
     service(SubjectiveDb "${suffix}" src/SubjectiveDb.cpp)
+    service(NotifyService "${suffix}" src/NotifyService.cpp)
 
     set(TEST_GENERATE_SCHEMA 1)
     service(MockCpuLimit "${suffix}" src/MockCpuLimit.cpp)

--- a/services/psibase_tests/include/services/test/NotifyService.hpp
+++ b/services/psibase_tests/include/services/test/NotifyService.hpp
@@ -1,0 +1,42 @@
+#include <cstdint>
+#include <psibase/Service.hpp>
+#include <psibase/Table.hpp>
+#include <psibase/trace.hpp>
+#include <psio/view.hpp>
+
+namespace TestService
+{
+   struct BlockCountRow
+   {
+      std::uint32_t count;
+   };
+   PSIO_REFLECT(BlockCountRow, count)
+   using BlockCountTable = psibase::Table<BlockCountRow, psibase::SingletonKey{}>;
+   PSIO_REFLECT_TYPENAME(BlockCountTable)
+
+   struct TransactionCountRow
+   {
+      std::uint32_t count;
+   };
+   PSIO_REFLECT(TransactionCountRow, count)
+   using TransactionCountTable = psibase::Table<TransactionCountRow, psibase::SingletonKey{}>;
+   PSIO_REFLECT_TYPENAME(TransactionCountTable)
+
+   struct FailRow
+   {
+   };
+   PSIO_REFLECT(FailRow);
+   using FailTable = psibase::Table<FailRow, psibase::SingletonKey{}>;
+   PSIO_REFLECT_TYPENAME(FailTable)
+
+   struct NotifyService : psibase::Service
+   {
+      using WriteOnly  = psibase::WriteOnlyTables<BlockCountTable, TransactionCountTable>;
+      using Subjective = psibase::SubjectiveTables<FailTable>;
+      static constexpr auto service = psibase::AccountNumber{"notify1"};
+      void                  onBlock();
+      void onTrx(const psibase::Checksum256& id, psio::view<const psibase::TransactionTrace> trace);
+   };
+   PSIO_REFLECT(NotifyService, method(onBlock), method(onTrx, id, trace));
+   PSIBASE_REFLECT_TABLES(NotifyService, NotifyService::WriteOnly, NotifyService::Subjective)
+}  // namespace TestService

--- a/services/psibase_tests/src/NotifyService.cpp
+++ b/services/psibase_tests/src/NotifyService.cpp
@@ -1,0 +1,41 @@
+#include <services/test/NotifyService.hpp>
+
+#include <psibase/dispatch.hpp>
+
+using namespace psibase;
+using namespace TestService;
+
+void NotifyService::onBlock()
+{
+   auto count = WriteOnly{getReceiver()}.open<BlockCountTable>();
+   auto row   = count.get({}).value_or(BlockCountRow{});
+   ++row.count;
+   count.put(row);
+
+   PSIBASE_SUBJECTIVE_TX
+   {
+      if (Subjective{getReceiver()}.open<FailTable>().get({}))
+      {
+         abortMessage("as you wish");
+      }
+   }
+}
+
+void NotifyService::onTrx(const psibase::Checksum256& /*id*/,
+                          psio::view<const psibase::TransactionTrace> /*trace*/)
+{
+   auto count = WriteOnly{getReceiver()}.open<TransactionCountTable>();
+   auto row   = count.get({}).value_or(TransactionCountRow{});
+   ++row.count;
+   count.put(row);
+
+   PSIBASE_SUBJECTIVE_TX
+   {
+      if (Subjective{getReceiver()}.open<FailTable>().get({}))
+      {
+         abortMessage("as you wish");
+      }
+   }
+}
+
+PSIBASE_DISPATCH(NotifyService)

--- a/services/psibase_tests/test/CMakeLists.txt
+++ b/services/psibase_tests/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 enable_testing()
 
 function(add suffix)
-    add_executable(psibase-tests${suffix} test.cpp test-sig.cpp test_event.cpp test_crypto.cpp test_memo.cpp test_clock.cpp test_semver.cpp test_subjective.cpp testKvMerkle.cpp test_rpc.cpp test_verify_services.cpp)
+    add_executable(psibase-tests${suffix} test.cpp test-sig.cpp test_event.cpp test_crypto.cpp test_memo.cpp test_clock.cpp test_semver.cpp test_subjective.cpp testKvMerkle.cpp test_rpc.cpp test_verify_services.cpp test_notify.cpp)
     target_include_directories(psibase-tests${suffix} PUBLIC ../include)
-    target_link_libraries(psibase-tests${suffix} services_system${suffix} psitestlib${suffix} catch2)
+    target_link_libraries(psibase-tests${suffix} services_system${suffix} services_user${suffix} psitestlib${suffix} catch2)
     set_target_properties(psibase-tests${suffix} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
 endfunction(add)
 

--- a/services/psibase_tests/test/test_notify.cpp
+++ b/services/psibase_tests/test/test_notify.cpp
@@ -1,0 +1,126 @@
+#include <catch2/catch_all.hpp>
+#include <services/system/Transact.hpp>
+#include <services/test/NotifyService.hpp>
+#include <services/user/Nop.hpp>
+
+#include <psibase/DefaultTestChain.hpp>
+
+using namespace psibase;
+using namespace SystemService;
+using namespace TestService;
+using namespace UserService;
+
+// All callbacks are executed
+// If a callback fails, it does not apply changes to the database
+// If a callback fails, the remaining callbacks will still be run
+
+TEST_CASE("notify onBlock")
+{
+   DefaultTestChain      t;
+   static constexpr auto notify2 = AccountNumber{"notify2"};
+   t.addService(NotifyService::service, "NotifyService.wasm");
+   t.addService(notify2, "NotifyService.wasm");
+   t.setAutoBlockStart(false);
+   t.startBlock();
+   for (auto service : {NotifyService::service, notify2})
+   {
+      t.from(Transact::service)
+          .to<Transact>()
+          .addCallback(CallbackType::onBlock, false,
+                       Action{.service = service,
+                              .method  = MethodNumber{"onBlock"},
+                              .rawData = psio::to_frac(std::tuple())});
+   }
+   t.finishBlock();
+   auto table1 = NotifyService{}.open<BlockCountTable>();
+   auto fail   = NotifyService{}.open<FailTable>();
+   auto table2 = NotifyService::WriteOnly{notify2}.open<BlockCountTable>();
+   {
+      auto row = table1.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 1);
+   }
+   {
+      auto row = table2.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 1);
+   }
+   fail.put({});
+   t.startBlock();
+   t.finishBlock();
+   {
+      auto row = table1.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 1);
+   }
+   {
+      auto row = table2.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 2);
+   }
+   fail.remove({});
+   t.startBlock();
+   t.finishBlock();
+   {
+      auto row = table1.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 2);
+   }
+   {
+      auto row = table2.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 3);
+   }
+}
+
+TEST_CASE("notify onTransaction")
+{
+   DefaultTestChain      t;
+   static constexpr auto notify2 = AccountNumber{"notify2"};
+   t.addService(NotifyService::service, "NotifyService.wasm");
+   t.addService(notify2, "NotifyService.wasm");
+   for (auto service : {NotifyService::service, notify2})
+   {
+      t.from(Transact::service)
+          .to<Transact>()
+          .addCallback(CallbackType::onTransaction, false,
+                       Action{.service = service, .method = MethodNumber{"onTrx"}});
+   }
+   auto table1 = NotifyService{}.open<TransactionCountTable>();
+   auto fail   = NotifyService{}.open<FailTable>();
+   auto table2 = NotifyService::WriteOnly{notify2}.open<TransactionCountTable>();
+   {
+      auto row = table1.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 2);
+   }
+   {
+      auto row = table2.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 1);
+   }
+   fail.put({});
+   REQUIRE(t.from(Nop::service).to<Nop>().nop().succeeded());
+   {
+      auto row = table1.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 2);
+   }
+   {
+      auto row = table2.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 2);
+   }
+   fail.remove({});
+   REQUIRE(t.from(Nop::service).to<Nop>().nop().succeeded());
+   {
+      auto row = table1.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 3);
+   }
+   {
+      auto row = table2.get({});
+      REQUIRE(row.has_value());
+      CHECK(row->count == 3);
+   }
+}

--- a/services/user/CMakeLists.txt
+++ b/services/user/CMakeLists.txt
@@ -43,6 +43,7 @@ function(add suffix)
         Events/include
         Invite/include
         Nft/include
+        Nop/include
         Packages/include
         Sites/include
         Symbol/include

--- a/services/user/Nop/include/services/user/Nop.hpp
+++ b/services/user/Nop/include/services/user/Nop.hpp
@@ -1,0 +1,11 @@
+#include <psibase/Service.hpp>
+
+namespace UserService
+{
+   struct Nop : psibase::Service
+   {
+      static constexpr auto service = psibase::AccountNumber{"nop"};
+      void                  nop();
+   };
+   PSIO_REFLECT(Nop, method(nop))
+}  // namespace UserService


### PR DESCRIPTION
In particular, running out of memory while writing to tables with multiple indexes can leave broken invariants.