### PR TITLE
Fix accounts key import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,7 @@ psibase_package(
         DATA GLOB ${CMAKE_CURRENT_SOURCE_DIR}/services/system/Accounts/ui/dist/* /
         DATA ${Plugins_OUTPUT_FILE_accounts} /plugin.wasm
         DATA ${Plugins_OUTPUT_FILE_account_tokens} /account-tokens.wasm
-        INIT
+        POSTINSTALL ${CMAKE_CURRENT_SOURCE_DIR}/services/system/Accounts/postinstall.json
     SERVICE r-accounts
         WASM ${CMAKE_CURRENT_BINARY_DIR}/RAccounts.wasm
         SCHEMA ${CMAKE_CURRENT_BINARY_DIR}/RAccounts-schema.json

--- a/services/system/Accounts/postinstall.json
+++ b/services/system/Accounts/postinstall.json
@@ -1,0 +1,14 @@
+[
+    {
+        "sender": "accounts",
+        "service": "accounts",
+        "method": "init",
+        "data": {}
+    },
+    {
+        "sender": "accounts",
+        "service": "sites",
+        "method": "enablespa",
+        "data": { "enable": true }
+    }
+]

--- a/services/system/Accounts/ui/src/AccountSelection.tsx
+++ b/services/system/Accounts/ui/src/AccountSelection.tsx
@@ -4,7 +4,7 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import debounce from "debounce";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { z } from "zod";
 
 import { useAcceptInvite } from "@/hooks/useAcceptInvite";
@@ -59,7 +59,12 @@ const formSchema = z.object({
 
 export const AccountSelection = () => {
     const [searchParams] = useSearchParams();
-    const token: string = z.string().parse(searchParams.get("token"));
+
+    const token = searchParams.get("token");
+
+    if (!token) {
+        throw new Error("No token was found in the URL");
+    }
 
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),
@@ -67,15 +72,6 @@ export const AccountSelection = () => {
             username: "",
         },
     });
-
-    const key = searchParams.get("key");
-
-    const navigate = useNavigate();
-
-    // Auto nav if the key param is present,
-    if (key) {
-        navigate(`/key?key=${key}`);
-    }
 
     const [isModalOpen, setIsModalOpen] = useState(false);
 

--- a/services/system/Accounts/ui/src/KeyImport.tsx
+++ b/services/system/Accounts/ui/src/KeyImport.tsx
@@ -79,6 +79,11 @@ function KeyImport() {
     const [searchParams] = useSearchParams();
 
     const key = searchParams.get("key");
+
+    if (!key) {
+        throw new Error("No key was found in the URL");
+    }
+
     const { data: extractedPrivateKey } = useDecodeB64(key);
     const { data: publicKey } = usePrivateToPublicKey(
         extractedPrivateKey || "",

--- a/services/system/Accounts/ui/src/components/error-boundary.tsx
+++ b/services/system/Accounts/ui/src/components/error-boundary.tsx
@@ -1,0 +1,30 @@
+import {
+    isRouteErrorResponse,
+    useNavigate,
+    useRouteError,
+} from "react-router-dom";
+
+import { ErrorCard } from "./error-card";
+
+export const ErrorBoundary = () => {
+    const error = useRouteError();
+    const navigate = useNavigate();
+
+    let message = "Unknown error";
+
+    if (isRouteErrorResponse(error)) {
+        message = error.data.message ?? error.statusText;
+    } else if (error instanceof Error) {
+        message = error.message;
+    }
+
+    return (
+        <ErrorCard
+            errorMessage={message}
+            action={() => navigate(-1)}
+            actionLabel="Go back"
+        />
+    );
+};
+
+export default ErrorBoundary;

--- a/services/system/Accounts/ui/src/components/error-card.tsx
+++ b/services/system/Accounts/ui/src/components/error-card.tsx
@@ -1,0 +1,45 @@
+import { TriangleAlert } from "lucide-react";
+
+import { Button } from "@shared/shadcn/ui/button";
+import {
+    Card,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
+} from "@shared/shadcn/ui/card";
+
+interface Props {
+    errorMessage: string;
+    action?: () => void;
+    actionLabel?: string;
+}
+
+export const ErrorCard = ({
+    errorMessage,
+    action,
+    actionLabel = "Login",
+}: Props) => {
+    return (
+        <Card className="mx-auto mt-4 w-[350px]">
+            <CardHeader>
+                <div className="mx-auto">
+                    <TriangleAlert className="text-destructive h-12 w-12" />
+                </div>
+                <CardTitle>Hmm...</CardTitle>
+                <CardDescription>{errorMessage}</CardDescription>
+                {action && (
+                    <CardFooter className="flex justify-end">
+                        <Button
+                            onClick={() => {
+                                action();
+                            }}
+                        >
+                            {actionLabel}
+                        </Button>
+                    </CardFooter>
+                )}
+            </CardHeader>
+        </Card>
+    );
+};

--- a/services/system/Accounts/ui/src/router.tsx
+++ b/services/system/Accounts/ui/src/router.tsx
@@ -3,11 +3,13 @@ import { createBrowserRouter } from "react-router-dom";
 import { AccountSelection } from "./AccountSelection";
 import KeyImport from "./KeyImport";
 import Root from "./Root";
+import ErrorBoundary from "./components/error-boundary";
 
 const Router = createBrowserRouter([
     {
         path: "/",
         element: <Root />,
+        errorElement: <ErrorBoundary />,
         children: [
             {
                 path: "/",

--- a/services/system/AuthSig/ui/src/AccountSelection.tsx
+++ b/services/system/AuthSig/ui/src/AccountSelection.tsx
@@ -60,7 +60,7 @@ export const AccountSelection = () => {
 
     const { data: account } = useAccountLookup(selectedAccount);
     const { data: privateKey } = usePublicToPrivate(account?.pubkey);
-    const url = modifyUrlParams(siblingUrl("", "accounts"), {
+    const url = modifyUrlParams(siblingUrl("", "accounts", "key"), {
         key: privateKey || "",
     });
 


### PR DESCRIPTION
- Modifies the auth-sig UI to target the `/key` path on the tokens app for key import, in order to simplify and streamline accounts UI redirect logic.
- Modifies build to turn SPA mode on by default for the accounts app (a bug we didn't see)
- Fixes the parsing error when trying to import a key (the bug we did see)
- Simplifies/streamlines accounts app redirect logic
- Enhances error reporting