### PR TITLE
Reduce memory usage of RTransact::onTrx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ set(PSIBASE_VERSION 0.19)
 psibase_package(
     OUTPUT ${SERVICE_DIR}/Transact.psi
     NAME Transact
-    VERSION ${PSIBASE_VERSION}.0
+    VERSION ${PSIBASE_VERSION}.1
     DESCRIPTION "All transactions enter the chain through this service"
     SERVICE transact
         WASM ${CMAKE_CURRENT_BINARY_DIR}/Transact.wasm

--- a/libraries/psio/include/psio/fracpack.hpp
+++ b/libraries/psio/include/psio/fracpack.hpp
@@ -1478,8 +1478,8 @@ namespace psio
    template <typename T>
    prevalidated(T&&) -> prevalidated<T>;
    template <typename T, typename U>
-   prevalidated(T&& t,
-                U&& u) -> prevalidated<decltype(std::span{std::forward<T>(t), std::forward<U>(u)})>;
+   prevalidated(T&& t, U&& u)
+       -> prevalidated<decltype(std::span{std::forward<T>(t), std::forward<U>(u)})>;
    struct input_stream;
    prevalidated(input_stream) -> prevalidated<std::span<const char>>;
 
@@ -1568,7 +1568,7 @@ namespace psio
    constexpr bool packable_as_impl = std::is_same_v<T, U>;
 
    template <typename T, typename U>
-   concept PackableAs = packable_as_impl<std::remove_cvref_t<T>, U>;
+   concept PackableAs = std::is_same_v<T, U> || packable_as_impl<std::remove_cvref_t<T>, U>;
 
    template <typename... T, typename... U>
       requires(sizeof...(T) == sizeof...(U))

--- a/libraries/psio/include/psio/shared_view_ptr.hpp
+++ b/libraries/psio/include/psio/shared_view_ptr.hpp
@@ -127,6 +127,15 @@ namespace psio
          return std::shared_ptr<char_t<T>[]>(std::move(_data), data());
       }
 
+      template <PackableAs<T> U>
+      static shared_view_ptr<T> from_compatible(const U& value)
+      {
+         shared_view_ptr<T> result(psio::size_tag{psio::fracpack_size(value)});
+         fast_buf_stream    stream(result.data(), result.size());
+         psio::to_frac(value, stream);
+         return result;
+      }
+
      private:
       static auto validate(const std::span<const char>& data)
       {

--- a/services/system/Transact/include/services/system/RTransact.hpp
+++ b/services/system/Transact/include/services/system/RTransact.hpp
@@ -197,6 +197,14 @@ namespace SystemService
        psibase::Table<TxSuccessRecord, &TxSuccessRecord::id, TxSuccessRecord::ByBlockNum{}>;
    PSIO_REFLECT_TYPENAME(TxSuccessTable)
 
+   struct TxSuccessView
+   {
+      psibase::Checksum256                        id;
+      psibase::BlockNum                           blockNum;
+      psio::view<const psibase::TransactionTrace> trace;
+   };
+   PSIO_REFLECT(TxSuccessView, id, blockNum, trace)
+
    struct TxFailedRecord
    {
       psibase::Checksum256      id;
@@ -209,6 +217,14 @@ namespace SystemService
    using TxFailedTable =
        psibase::Table<TxFailedRecord, &TxFailedRecord::id, TxFailedRecord::ByExpiration{}>;
    PSIO_REFLECT_TYPENAME(TxFailedTable)
+
+   struct TxFailedView
+   {
+      psibase::Checksum256                        id;
+      psibase::TimePointSec                       expiration;
+      psio::view<const psibase::TransactionTrace> trace;
+   };
+   PSIO_REFLECT(TxFailedView, id, expiration, trace)
 
    // Transactions enter this service through the push_transaction endpoint
    // or over p2p (recv). Speculative execution and signature verification


### PR DESCRIPTION
- Make views packable
- Allow Table::put for shared_view_ptr and for types that are PackableAs<T>
- Avoid unpacking and repacking the trace