### PR TITLE
Fix rust implementation of fracpack

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3604,9 +3604,29 @@ dependencies = [
  "cxx-build",
  "fracpack",
  "hex",
+ "indexmap 2.2.6",
+ "psibase",
  "psibase_macros",
  "serde",
+ "serde-aux",
  "serde_json",
+ "test_fracpack_macros",
+]
+
+[[package]]
+name = "test_fracpack_macros"
+version = "0.19.0"
+dependencies = [
+ "anyhow",
+ "fracpack",
+ "hex",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "test_package/query",
     "test_package/service",
     "test_fracpack",
+    "test_fracpack_macros",
     "test_subjective",
     "test_psibase_macros",
 ]
@@ -27,6 +28,7 @@ default-members = [
     "psibase_macros",
     "psibase",
     "test_fracpack",
+    "test_fracpack_macros",
 ]
 
 [workspace.package]

--- a/rust/fracpack/src/fracpack.rs
+++ b/rust/fracpack/src/fracpack.rs
@@ -75,6 +75,139 @@ custom_error! {pub Error
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[derive(Debug)]
+pub struct FracInputStream<'a> {
+    pub data: &'a [u8],
+    pub pos: u32,
+    pub has_unknown: bool,
+    pub known_end: bool,
+}
+
+impl<'a> FracInputStream<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        FracInputStream {
+            data,
+            pos: 0,
+            has_unknown: false,
+            known_end: true,
+        }
+    }
+
+    pub fn consume_trailing_optional(
+        &mut self,
+        fixed_pos: u32,
+        heap_pos: u32,
+        last_empty: bool,
+    ) -> Result<()> {
+        let mut fixed_stream = FracInputStream {
+            data: &self.data[0..heap_pos as usize],
+            pos: fixed_pos,
+            has_unknown: false,
+            known_end: true,
+        };
+        consume_trailing_optional(&mut fixed_stream, self, last_empty)
+    }
+
+    fn unpack_at<T: Unpack<'a>>(&self, pos: &mut u32) -> Result<T> {
+        assert!(!T::VARIABLE_SIZE);
+        let mut tmp = FracInputStream {
+            data: self.data,
+            pos: *pos,
+            has_unknown: false,
+            known_end: true,
+        };
+        let result = T::unpack(&mut tmp)?;
+        *pos = tmp.pos;
+        Ok(result)
+    }
+    fn verify_at<'b, T: Unpack<'b>>(&self, pos: &mut u32) -> Result<()> {
+        assert!(!T::VARIABLE_SIZE);
+        let mut tmp = FracInputStream {
+            data: self.data,
+            pos: *pos,
+            has_unknown: false,
+            known_end: true,
+        };
+        T::verify(&mut tmp)?;
+        *pos = tmp.pos;
+        Ok(())
+    }
+    pub fn advance(&mut self, len: u32) -> Result<u32> {
+        assert!(self.known_end);
+        let old_pos = self.pos;
+        let Some(pos) = self.pos.checked_add(len) else {
+            return Err(Error::ReadPastEnd);
+        };
+        if pos as usize > self.data.len() {
+            return Err(Error::ReadPastEnd);
+        }
+        self.pos = pos;
+        Ok(old_pos)
+    }
+    pub fn read_fixed(&mut self, len: u32) -> Result<Self> {
+        let old_pos = self.advance(len)?;
+        let result = FracInputStream {
+            data: &self.data[0..self.pos as usize],
+            pos: old_pos,
+            has_unknown: false,
+            known_end: true,
+        };
+        Ok(result)
+    }
+    pub(crate) fn set_pos(&mut self, pos: u32) -> Result<()> {
+        if self.known_end {
+            if self.pos != pos {
+                return Err(Error::BadOffset);
+            }
+        } else {
+            if self.pos > pos {
+                return Err(Error::BadOffset);
+            }
+            if pos > self.data.len() as u32 {
+                return Err(Error::BadOffset);
+            }
+            self.pos = pos;
+            self.known_end = true;
+        }
+        Ok(())
+    }
+    pub(crate) fn remaining(&self) -> u32 {
+        self.data.len() as u32 - self.pos
+    }
+    pub fn finish(&self) -> Result<()> {
+        if self.known_end {
+            if self.pos != self.data.len() as u32 {
+                return Err(Error::ExtraData);
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn consume_trailing_optional(
+    fixed_stream: &mut FracInputStream,
+    stream: &mut FracInputStream,
+    mut last_empty: bool,
+) -> Result<()> {
+    while fixed_stream.remaining() > 0 {
+        let orig_pos = fixed_stream.pos;
+        let offset = u32::unpack(fixed_stream)?;
+        last_empty = offset == 1;
+        if offset > 1 {
+            let Some(new_pos) = orig_pos.checked_add(offset) else {
+                return Err(Error::ReadPastEnd);
+            };
+            stream.set_pos(new_pos)?;
+            stream.known_end = false;
+        }
+        stream.has_unknown = true;
+    }
+    if last_empty {
+        return Err(Error::ExtraEmptyOptional);
+    }
+    Ok(())
+}
+
 /// Use this trait on generic functions instead of [Unpack] when
 /// the deserialized data may only be owned instead of borrowed from
 /// the source.
@@ -206,7 +339,7 @@ pub trait Unpack<'a>: Sized {
     /// ```
     ///
     /// See [Pack::unpacked], which is often more convenient.
-    fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self>;
+    fn unpack(src: &mut FracInputStream<'a>) -> Result<Self>;
 
     /// Convert from fracpack format. Also verifies the integrity of the data.
     ///
@@ -222,22 +355,22 @@ pub trait Unpack<'a>: Sized {
     /// }
     /// ```
     fn unpacked(src: &'a [u8]) -> Result<Self> {
-        let mut pos = 0;
-        Self::unpack(src, &mut pos)
+        let mut stream = FracInputStream::new(src);
+        let result = Self::unpack(&mut stream)?;
+        stream.finish()?;
+        Ok(result)
     }
 
     /// Verify the integrity of fracpack data. You don't need to call this if
     /// using [Pack::unpack] since it verifies integrity during unpack.
-    fn verify(src: &'a [u8], pos: &mut u32) -> Result<()>;
+    fn verify(src: &mut FracInputStream) -> Result<()>;
 
     /// Verify the integrity of fracpack data, plus make sure there is no
     /// leftover data after it.
-    fn verify_no_extra(src: &'a [u8]) -> Result<()> {
-        let mut pos = 0;
-        Self::verify(src, &mut pos)?;
-        if pos as usize != src.len() {
-            return Err(Error::ExtraData);
-        }
+    fn verify_no_extra(src: &[u8]) -> Result<()> {
+        let mut stream = FracInputStream::new(src);
+        Self::verify(&mut stream)?;
+        stream.finish()?;
         Ok(())
     }
 
@@ -247,66 +380,67 @@ pub trait Unpack<'a>: Sized {
     }
 
     #[doc(hidden)]
+    fn new_empty_optional() -> Result<Self> {
+        panic!("new_empty_optional must be implemented when IS_OPTIONAL == true");
+    }
+
+    #[doc(hidden)]
     fn embedded_variable_unpack(
-        src: &'a [u8],
+        src: &mut FracInputStream<'a>,
         fixed_pos: &mut u32,
-        heap_pos: &mut u32,
     ) -> Result<Self> {
         let orig_pos = *fixed_pos;
-        let offset = u32::unpack(src, fixed_pos)?;
+        let offset = src.unpack_at::<u32>(fixed_pos)?;
         if offset == 0 {
             return Self::new_empty_container();
         }
-        if *heap_pos as u64 != orig_pos as u64 + offset as u64 {
-            return Err(Error::BadOffset);
+        let Some(new_pos) = orig_pos.checked_add(offset) else {
+            return Err(Error::ReadPastEnd);
+        };
+        src.set_pos(new_pos)?;
+        if Self::new_empty_container().is_ok() {
+            if src.unpack_at::<u32>(&mut src.pos.clone())? == 0 {
+                return Err(Error::PtrEmptyList);
+            }
         }
-        Self::unpack(src, heap_pos)
+        Self::unpack(src)
     }
 
     #[doc(hidden)]
-    fn check_opt_embedded_unpack(
-        src: &'a [u8],
-        fixed_pos: &mut u32,
-        heap_pos: &mut u32,
-        _not_trailing: bool,
-        _has_opt_bytes: bool,
-    ) -> Result<Self> {
-        Self::embedded_unpack(src, fixed_pos, heap_pos)
+    fn is_empty_optional(src: &FracInputStream, fixed_pos: &mut u32) -> Result<bool> {
+        Ok(Self::IS_OPTIONAL && src.unpack_at::<u32>(fixed_pos)? == 1)
     }
 
     #[doc(hidden)]
-    fn embedded_unpack(src: &'a [u8], fixed_pos: &mut u32, heap_pos: &mut u32) -> Result<Self> {
+    fn embedded_unpack(src: &mut FracInputStream<'a>, fixed_pos: &mut u32) -> Result<Self> {
         if Self::VARIABLE_SIZE {
-            Self::embedded_variable_unpack(src, fixed_pos, heap_pos)
+            Self::embedded_variable_unpack(src, fixed_pos)
         } else {
-            Self::unpack(src, fixed_pos)
+            src.unpack_at::<Self>(fixed_pos)
         }
     }
 
     #[doc(hidden)]
-    fn embedded_variable_verify(
-        src: &'a [u8],
-        fixed_pos: &mut u32,
-        heap_pos: &mut u32,
-    ) -> Result<()> {
+    fn embedded_variable_verify(src: &mut FracInputStream, fixed_pos: &mut u32) -> Result<()> {
         let orig_pos = *fixed_pos;
-        let offset = u32::unpack(src, fixed_pos)?;
+        let offset = src.unpack_at::<u32>(fixed_pos)?;
         if offset == 0 {
-            let _ = Self::new_empty_container();
+            Self::new_empty_container()?;
             return Ok(());
         }
-        if *heap_pos as u64 != orig_pos as u64 + offset as u64 {
-            return Err(Error::BadOffset);
-        }
-        Self::verify(src, heap_pos)
+        let Some(new_pos) = orig_pos.checked_add(offset) else {
+            return Err(Error::ReadPastEnd);
+        };
+        src.set_pos(new_pos)?;
+        Self::verify(src)
     }
 
     #[doc(hidden)]
-    fn embedded_verify(src: &'a [u8], fixed_pos: &mut u32, heap_pos: &mut u32) -> Result<()> {
+    fn embedded_verify(src: &mut FracInputStream, fixed_pos: &mut u32) -> Result<()> {
         if Self::VARIABLE_SIZE {
-            Self::embedded_variable_verify(src, fixed_pos, heap_pos)
+            Self::embedded_variable_verify(src, fixed_pos)
         } else {
-            Self::verify(src, fixed_pos)
+            src.verify_at::<Self>(fixed_pos)
         }
     }
 }
@@ -358,15 +492,15 @@ impl Pack for bool {
 impl<'a> Unpack<'a> for bool {
     const FIXED_SIZE: u32 = mem::size_of::<Self>() as u32;
     const VARIABLE_SIZE: bool = false;
-    fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-        match u8::unpack(src, pos)? {
+    fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+        match u8::unpack(src)? {
             0 => Ok(false),
             1 => Ok(true),
             _ => Err(Error::BadScalar),
         }
     }
-    fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-        Self::unpack(src, pos)?;
+    fn verify(src: &mut FracInputStream) -> Result<()> {
+        Self::unpack(src)?;
         Ok(())
     }
 }
@@ -383,14 +517,16 @@ macro_rules! scalar_impl {
         impl<'a> Unpack<'a> for $t {
             const FIXED_SIZE: u32 = mem::size_of::<Self>() as u32;
             const VARIABLE_SIZE: bool = false;
-            fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-                Ok(Self::from_le_bytes(read_u8_arr(src, pos)?.into()))
+            fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+                Ok(Self::from_le_bytes(
+                    read_u8_arr(src.data, &mut src.pos)?.into(),
+                ))
             }
-            fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-                if (*pos as u64 + <Self as Unpack>::FIXED_SIZE as u64 > src.len() as u64) {
+            fn verify(src: &mut FracInputStream) -> Result<()> {
+                if (src.pos as u64 + <Self as Unpack>::FIXED_SIZE as u64 > src.data.len() as u64) {
                     Err(Error::ReadPastEnd)
                 } else {
-                    *pos += <Self as Unpack>::FIXED_SIZE;
+                    src.pos += <Self as Unpack>::FIXED_SIZE;
                     Ok(())
                 }
             }
@@ -447,50 +583,42 @@ macro_rules! unpack_ptr {
             const VARIABLE_SIZE: bool = T::VARIABLE_SIZE;
             const IS_OPTIONAL: bool = T::IS_OPTIONAL;
 
-            fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-                Ok(Self::new(<T>::unpack(src, pos)?))
+            fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+                Ok(Self::new(<T>::unpack(src)?))
             }
 
-            fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-                <T>::verify(src, pos)
+            fn verify(src: &mut FracInputStream) -> Result<()> {
+                <T>::verify(src)
             }
 
             fn new_empty_container() -> Result<Self> {
                 Ok(Self::new(<T>::new_empty_container()?))
             }
 
-            fn embedded_variable_unpack(
-                src: &'a [u8],
-                fixed_pos: &mut u32,
-                heap_pos: &mut u32,
-            ) -> Result<Self> {
-                Ok(Self::new(<T>::embedded_variable_unpack(
-                    src, fixed_pos, heap_pos,
-                )?))
+            fn new_empty_optional() -> Result<Self> {
+                Ok(Self::new(<T>::new_empty_optional()?))
             }
 
-            fn embedded_unpack(
-                src: &'a [u8],
+            fn embedded_variable_unpack(
+                src: &mut FracInputStream<'a>,
                 fixed_pos: &mut u32,
-                heap_pos: &mut u32,
             ) -> Result<Self> {
-                Ok(Self::new(<T>::embedded_unpack(src, fixed_pos, heap_pos)?))
+                Ok(Self::new(<T>::embedded_variable_unpack(src, fixed_pos)?))
+            }
+
+            fn embedded_unpack(src: &mut FracInputStream<'a>, fixed_pos: &mut u32) -> Result<Self> {
+                Ok(Self::new(<T>::embedded_unpack(src, fixed_pos)?))
             }
 
             fn embedded_variable_verify(
-                src: &'a [u8],
+                src: &mut FracInputStream,
                 fixed_pos: &mut u32,
-                heap_pos: &mut u32,
             ) -> Result<()> {
-                <T>::embedded_variable_verify(src, fixed_pos, heap_pos)
+                <T>::embedded_variable_verify(src, fixed_pos)
             }
 
-            fn embedded_verify(
-                src: &'a [u8],
-                fixed_pos: &mut u32,
-                heap_pos: &mut u32,
-            ) -> Result<()> {
-                <T>::embedded_verify(src, fixed_pos, heap_pos)
+            fn embedded_verify(src: &mut FracInputStream, fixed_pos: &mut u32) -> Result<()> {
+                <T>::embedded_verify(src, fixed_pos)
             }
         }
     };
@@ -559,63 +687,47 @@ impl<'a, T: Unpack<'a>> Unpack<'a> for Option<T> {
     const VARIABLE_SIZE: bool = true;
     const IS_OPTIONAL: bool = true;
 
-    fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-        let mut fixed_pos = *pos;
-        *pos += 4;
-        Self::embedded_unpack(src, &mut fixed_pos, pos)
+    fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+        let mut fixed_pos = src.advance(Self::FIXED_SIZE)?;
+        Self::embedded_unpack(src, &mut fixed_pos)
     }
 
-    fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-        let mut fixed_pos = *pos;
-        *pos += 4;
-        Self::embedded_verify(src, &mut fixed_pos, pos)
+    fn verify(src: &mut FracInputStream) -> Result<()> {
+        let mut fixed_pos = src.advance(Self::FIXED_SIZE)?;
+        Self::embedded_verify(src, &mut fixed_pos)
     }
 
-    fn check_opt_embedded_unpack(
-        src: &'a [u8],
-        fixed_pos: &mut u32,
-        heap_pos: &mut u32,
-        not_trailing: bool,
-        has_opt_bytes: bool,
-    ) -> Result<Self> {
-        if not_trailing || has_opt_bytes {
-            Self::embedded_unpack(src, fixed_pos, heap_pos)
-        } else {
-            Ok(None)
-        }
+    fn new_empty_optional() -> Result<Self> {
+        Ok(None)
     }
 
-    fn embedded_unpack(src: &'a [u8], fixed_pos: &mut u32, heap_pos: &mut u32) -> Result<Self> {
-        let orig_pos = *fixed_pos;
-        let offset = u32::unpack(src, fixed_pos)?;
-        if offset == 1 {
+    fn embedded_unpack(src: &mut FracInputStream<'a>, fixed_pos: &mut u32) -> Result<Self> {
+        let mut tmp_pos = *fixed_pos;
+        if Self::is_empty_optional(src, &mut tmp_pos)? {
+            *fixed_pos = tmp_pos;
             return Ok(None);
         }
-        *fixed_pos = orig_pos;
-        Ok(Some(<T>::embedded_variable_unpack(
-            src, fixed_pos, heap_pos,
-        )?))
+        Ok(Some(<T>::embedded_variable_unpack(src, fixed_pos)?))
     }
 
-    fn embedded_verify(src: &'a [u8], fixed_pos: &mut u32, heap_pos: &mut u32) -> Result<()> {
-        let orig_pos = *fixed_pos;
-        let offset = u32::unpack(src, fixed_pos)?;
-        if offset == 1 {
+    fn embedded_verify(src: &mut FracInputStream, fixed_pos: &mut u32) -> Result<()> {
+        let mut tmp_pos = *fixed_pos;
+        if Self::is_empty_optional(src, &mut tmp_pos)? {
+            *fixed_pos = tmp_pos;
             return Ok(());
         }
-        *fixed_pos = orig_pos;
-        T::embedded_variable_verify(src, fixed_pos, heap_pos)
+        T::embedded_variable_verify(src, fixed_pos)
     }
 }
 
 trait BytesConversion<'a>: Sized {
-    fn fracpack_verify_if_str(bytes: &'a [u8]) -> Result<()>;
+    fn fracpack_verify_if_str(bytes: &[u8]) -> Result<()>;
     fn fracpack_from_bytes(bytes: &'a [u8]) -> Result<Self>;
     fn fracpack_as_bytes(&'a self) -> &'a [u8];
 }
 
 impl<'a> BytesConversion<'a> for String {
-    fn fracpack_verify_if_str(bytes: &'a [u8]) -> Result<()> {
+    fn fracpack_verify_if_str(bytes: &[u8]) -> Result<()> {
         std::str::from_utf8(bytes).or(Err(Error::BadUTF8))?;
         Ok(())
     }
@@ -628,7 +740,7 @@ impl<'a> BytesConversion<'a> for String {
 }
 
 impl<'a> BytesConversion<'a> for &'a str {
-    fn fracpack_verify_if_str(bytes: &'a [u8]) -> Result<()> {
+    fn fracpack_verify_if_str(bytes: &[u8]) -> Result<()> {
         std::str::from_utf8(bytes).or(Err(Error::BadUTF8))?;
         Ok(())
     }
@@ -641,7 +753,7 @@ impl<'a> BytesConversion<'a> for &'a str {
 }
 
 impl<'a> BytesConversion<'a> for &'a [u8] {
-    fn fracpack_verify_if_str(_bytes: &'a [u8]) -> Result<()> {
+    fn fracpack_verify_if_str(_bytes: &[u8]) -> Result<()> {
         Ok(())
     }
     fn fracpack_from_bytes(bytes: &'a [u8]) -> Result<Self> {
@@ -672,21 +784,23 @@ macro_rules! bytes_impl {
             const FIXED_SIZE: u32 = 4;
             const VARIABLE_SIZE: bool = true;
 
-            fn unpack(src: &'a [u8], pos: &mut u32) -> Result<$t> {
-                let len = u32::unpack(src, pos)?;
+            fn unpack(src: &mut FracInputStream<'a>) -> Result<$t> {
+                let len = u32::unpack(src)?;
                 let bytes = src
-                    .get(*pos as usize..(*pos + len) as usize)
+                    .data
+                    .get(src.pos as usize..(src.pos + len) as usize)
                     .ok_or(Error::ReadPastEnd)?;
-                *pos += len;
+                src.pos += len;
                 <$t>::fracpack_from_bytes(bytes)
             }
 
-            fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-                let len = u32::unpack(src, pos)?;
+            fn verify(src: &mut FracInputStream) -> Result<()> {
+                let len = u32::unpack(src)?;
                 let bytes = src
-                    .get(*pos as usize..(*pos + len) as usize)
+                    .data
+                    .get(src.pos as usize..(src.pos + len) as usize)
                     .ok_or(Error::ReadPastEnd)?;
-                *pos += len;
+                src.pos += len;
                 <$t>::fracpack_verify_if_str(bytes)?;
                 Ok(())
             }
@@ -732,40 +846,30 @@ impl<'a, T: Unpack<'a>> Unpack<'a> for Vec<T> {
     const VARIABLE_SIZE: bool = true;
 
     // TODO: optimize scalar
-    fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-        let num_bytes = u32::unpack(src, pos)?;
+    fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+        let num_bytes = u32::unpack(src)?;
         if num_bytes % T::FIXED_SIZE != 0 {
             return Err(Error::BadSize);
         }
-        let hp = *pos as u64 + num_bytes as u64;
-        let mut heap_pos = hp as u32;
-        if heap_pos as u64 != hp {
-            return Err(Error::ReadPastEnd);
-        }
         let len = (num_bytes / T::FIXED_SIZE) as usize;
+        let mut fixed_pos = src.advance(num_bytes)?;
         let mut result = Self::with_capacity(len);
         for _ in 0..len {
-            result.push(T::embedded_unpack(src, pos, &mut heap_pos)?);
+            result.push(T::embedded_unpack(src, &mut fixed_pos)?);
         }
-        *pos = heap_pos;
         Ok(result)
     }
 
     // TODO: optimize scalar
-    fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-        let num_bytes = u32::unpack(src, pos)?;
+    fn verify(src: &mut FracInputStream) -> Result<()> {
+        let num_bytes = u32::unpack(src)?;
         if num_bytes % T::FIXED_SIZE != 0 {
             return Err(Error::BadSize);
         }
-        let hp = *pos as u64 + num_bytes as u64;
-        let mut heap_pos = hp as u32;
-        if heap_pos as u64 != hp {
-            return Err(Error::ReadPastEnd);
-        }
+        let mut fixed_pos = src.advance(num_bytes)?;
         for _ in 0..num_bytes / T::FIXED_SIZE {
-            T::embedded_verify(src, pos, &mut heap_pos)?;
+            T::embedded_verify(src, &mut fixed_pos)?;
         }
-        *pos = heap_pos;
         Ok(())
     }
 
@@ -803,16 +907,13 @@ impl<'a, T: Unpack<'a>, const N: usize> Unpack<'a> for [T; N] {
         T::FIXED_SIZE * N as u32
     };
 
-    fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-        let hp = *pos as u64 + T::FIXED_SIZE as u64 * N as u64;
-        let mut heap_pos = hp as u32;
-        if heap_pos as u64 != hp {
-            return Err(Error::ReadPastEnd);
-        }
+    fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+        let total_size: u32 = T::FIXED_SIZE * N as u32;
+        let mut fixed_pos = src.advance(total_size)?;
 
         let mut items: Vec<T> = Vec::with_capacity(N);
         for _ in 0..N {
-            items.push(T::embedded_unpack(src, pos, &mut heap_pos)?);
+            items.push(T::embedded_unpack(src, &mut fixed_pos)?);
         }
 
         let result: [T; N] = items.try_into().unwrap_or_else(|v: Vec<T>| {
@@ -822,20 +923,15 @@ impl<'a, T: Unpack<'a>, const N: usize> Unpack<'a> for [T; N] {
                 v.len()
             )
         });
-        *pos = heap_pos;
         Ok(result)
     }
 
-    fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-        let hp = *pos as u64 + T::FIXED_SIZE as u64 * N as u64;
-        let mut heap_pos = hp as u32;
-        if heap_pos as u64 != hp {
-            return Err(Error::ReadPastEnd);
-        }
+    fn verify(src: &mut FracInputStream) -> Result<()> {
+        let total_size: u32 = T::FIXED_SIZE * N as u32;
+        let mut fixed_pos = src.advance(total_size)?;
         for _ in 0..N {
-            T::embedded_verify(src, pos, &mut heap_pos)?;
+            T::embedded_verify(src, &mut fixed_pos)?;
         }
-        *pos = heap_pos;
         Ok(())
     }
 }
@@ -872,43 +968,27 @@ impl<'a, $($n: Unpack<'a>),+> Unpack<'a> for $t $(where $($w)*)? {
     const FIXED_SIZE: u32 = 4;
     const VARIABLE_SIZE: bool = true;
 
-    fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-        let num_bytes = u32::unpack(src, pos)?;
+    fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+        let num_bytes = u32::unpack(src)?;
         if num_bytes % <$t as IntoIterator>::Item::FIXED_SIZE != 0 {
             return Err(Error::BadSize);
-        }
-        let hp = *pos as u64 + num_bytes as u64;
-        let mut heap_pos = hp as u32;
-        if heap_pos as u64 != hp {
-            return Err(Error::ReadPastEnd);
         }
         let len = (num_bytes / <$t as IntoIterator>::Item::FIXED_SIZE) as usize;
-        let mut err = Ok(());
-        let result = (0..len).map_while(|_| {
-            match <$t as IntoIterator>::Item::embedded_unpack(src, pos, &mut heap_pos) {
-                Ok(item) => { Some(item) },
-                Err(e) => { err = Err(e); None }
-            }
-        }).collect();
-        err?;
-        *pos = heap_pos;
-        Ok(result)
+        let mut fixed_pos = src.advance(num_bytes)?;
+        (0..len).map(|_| {
+            <$t as IntoIterator>::Item::embedded_unpack(src, &mut fixed_pos)
+        }).collect()
     }
 
-    fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-        let num_bytes = u32::unpack(src, pos)?;
+    fn verify(src: &mut FracInputStream) -> Result<()> {
+        let num_bytes = u32::unpack(src)?;
         if num_bytes % <$t as IntoIterator>::Item::FIXED_SIZE != 0 {
             return Err(Error::BadSize);
         }
-        let hp = *pos as u64 + num_bytes as u64;
-        let mut heap_pos = hp as u32;
-        if heap_pos as u64 != hp {
-            return Err(Error::ReadPastEnd);
-        }
+        let mut fixed_pos = src.advance(num_bytes)?;
         for _ in 0..num_bytes / <$t as IntoIterator>::Item::FIXED_SIZE {
-            <$t as IntoIterator>::Item::embedded_verify(src, pos, &mut heap_pos)?;
+            <$t as IntoIterator>::Item::embedded_verify(src, &mut fixed_pos)?;
         }
-        *pos = heap_pos;
         Ok(())
     }
 
@@ -968,32 +1048,38 @@ macro_rules! tuple_impls {
                 const FIXED_SIZE: u32 = 4;
 
                 #[allow(non_snake_case,unused_mut)]
-                fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-                    let fixed_size = u16::unpack(src, pos)?;
-                    let mut heap_pos = *pos + fixed_size as u32;
-                    if heap_pos < *pos {
-                        return Err(Error::BadOffset);
-                    }
-                    let _initial_pos = *pos;
+                fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+                    let fixed_size = u16::unpack(src)?;
+                    let mut fixed_pos = src.advance(fixed_size as u32)?;
+                    let heap_pos = src.pos;
+                    let mut last_empty = false;
                     let _trailing_optional_index = [$(<$name as Unpack>::IS_OPTIONAL,)*].iter().rposition(|is_optional: &bool| !is_optional).map_or(0, |idx| idx + 1);
                     $(
-                        let $name = $name::check_opt_embedded_unpack(src, pos, &mut heap_pos, $n < _trailing_optional_index, *pos - _initial_pos < fixed_size as u32)?;
+                        let $name = if $n < _trailing_optional_index || fixed_pos < heap_pos {
+                            last_empty = <$name as Unpack>::is_empty_optional(src, &mut fixed_pos.clone())?;
+                            $name::embedded_unpack(src, &mut fixed_pos)?
+                        } else {
+                            $name::new_empty_optional()?
+                        };
                     )*
-                    *pos = heap_pos;
+                    src.consume_trailing_optional(fixed_pos, heap_pos, last_empty)?;
                     Ok(($($name,)*))
                 }
 
                 #[allow(unused_mut)]
-                fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-                    let fixed_size = u16::unpack(src, pos)?;
-                    let mut heap_pos = *pos + fixed_size as u32;
-                    if heap_pos < *pos {
-                        return Err(Error::BadOffset);
-                    }
+                fn verify(src: &mut FracInputStream) -> Result<()> {
+                    let fixed_size = u16::unpack(src)?;
+                    let mut fixed_pos = src.advance(fixed_size as u32)?;
+                    let heap_pos = src.pos;
+                    let mut last_empty = false;
+                    let _trailing_optional_index = [$(<$name as Unpack>::IS_OPTIONAL,)*].iter().rposition(|is_optional: &bool| !is_optional).map_or(0, |idx| idx + 1);
                     $(
-                        $name::embedded_unpack(src, pos, &mut heap_pos)?;
+                        if $n < _trailing_optional_index || fixed_pos < heap_pos {
+                            last_empty = <$name as Unpack>::is_empty_optional(src, &mut fixed_pos.clone())?;
+                            $name::embedded_verify(src, &mut fixed_pos)?;
+                        }
                     )*
-                    *pos = heap_pos;
+                    src.consume_trailing_optional(fixed_pos, heap_pos, last_empty)?;
                     Ok(())
                 }
             }

--- a/rust/fracpack/src/fracpack.rs
+++ b/rust/fracpack/src/fracpack.rs
@@ -432,6 +432,11 @@ pub trait Unpack<'a>: Sized {
             return Err(Error::ReadPastEnd);
         };
         src.set_pos(new_pos)?;
+        if Self::new_empty_container().is_ok() {
+            if src.unpack_at::<u32>(&mut src.pos.clone())? == 0 {
+                return Err(Error::PtrEmptyList);
+            }
+        }
         Self::verify(src)
     }
 

--- a/rust/fracpack/src/nested.rs
+++ b/rust/fracpack/src/nested.rs
@@ -1,0 +1,63 @@
+use crate::{Pack, Result, Unpack, UnpackOwned};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::marker::PhantomData;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Nested<T> {
+    data: Vec<u8>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Nested<T> {
+    pub fn new(data: Vec<u8>) -> Self {
+        Self {
+            data,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: Pack> Pack for Nested<T> {
+    const FIXED_SIZE: u32 = 4;
+    const VARIABLE_SIZE: bool = true;
+
+    fn is_empty_container(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    fn pack(&self, dest: &mut Vec<u8>) {
+        self.data.pack(dest)
+    }
+}
+
+impl<'a, T: Unpack<'a>> Unpack<'a> for Nested<T> {
+    const FIXED_SIZE: u32 = 4;
+    const VARIABLE_SIZE: bool = true;
+    fn new_empty_container() -> Result<Self> {
+        let data = b"";
+        T::verify_no_extra(data)?;
+        Ok(Self::new(data.to_vec()))
+    }
+
+    fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
+        let data = <&[u8]>::unpack(src, pos)?;
+        T::verify_no_extra(&data)?;
+        Ok(Self::new(data.to_owned()))
+    }
+    fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
+        let data = <&[u8]>::unpack(src, pos)?;
+        T::verify_no_extra(data)
+    }
+}
+
+impl<T: Serialize + UnpackOwned> Serialize for Nested<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        T::unpacked(&self.data).unwrap().serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de> + Pack> Deserialize<'de> for Nested<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        Ok(Self::new(T::deserialize(deserializer)?.packed()))
+    }
+}

--- a/rust/fracpack/src/nested.rs
+++ b/rust/fracpack/src/nested.rs
@@ -1,4 +1,4 @@
-use crate::{Pack, Result, Unpack, UnpackOwned};
+use crate::{FracInputStream, Pack, Result, Unpack, UnpackOwned};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::marker::PhantomData;
 
@@ -39,13 +39,13 @@ impl<'a, T: Unpack<'a>> Unpack<'a> for Nested<T> {
         Ok(Self::new(data.to_vec()))
     }
 
-    fn unpack(src: &'a [u8], pos: &mut u32) -> Result<Self> {
-        let data = <&[u8]>::unpack(src, pos)?;
+    fn unpack(src: &mut FracInputStream<'a>) -> Result<Self> {
+        let data = <&[u8]>::unpack(src)?;
         T::verify_no_extra(&data)?;
         Ok(Self::new(data.to_owned()))
     }
-    fn verify(src: &'a [u8], pos: &mut u32) -> Result<()> {
-        let data = <&[u8]>::unpack(src, pos)?;
+    fn verify(src: &mut FracInputStream) -> Result<()> {
+        let data = <&[u8]>::unpack(src)?;
         T::verify_no_extra(data)
     }
 }

--- a/rust/fracpack/src/schema.rs
+++ b/rust/fracpack/src/schema.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Pack, Unpack};
+use crate::{consume_trailing_optional, Error, FracInputStream, Pack, Unpack};
 use indexmap::IndexMap;
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
@@ -542,78 +542,14 @@ tuple_impl!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13);
 tuple_impl!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14);
 tuple_impl!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
 
-#[derive(Debug)]
-struct FracInputStream<'a> {
-    data: &'a [u8],
-    pos: u32,
-    has_unknown: bool,
-    known_end: bool,
-}
-
-impl<'a> FracInputStream<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        FracInputStream {
-            data,
-            pos: 0,
-            has_unknown: false,
-            known_end: true,
-        }
-    }
-    fn read_fixed(&mut self, len: u32) -> Result<Self, Error> {
-        assert!(self.known_end);
-        let Some(pos) = self.pos.checked_add(len) else {
-            return Err(Error::ReadPastEnd);
-        };
-        if pos as usize > self.data.len() {
-            return Err(Error::ReadPastEnd);
-        }
-        let result = FracInputStream {
-            data: &self.data[0..pos as usize],
-            pos: self.pos,
-            has_unknown: false,
-            known_end: true,
-        };
-        self.pos = pos;
-        Ok(result)
-    }
-    fn set_pos(&mut self, pos: u32) -> Result<(), Error> {
-        if self.known_end {
-            if self.pos != pos {
-                return Err(Error::BadOffset);
-            }
-        } else {
-            if self.pos > pos {
-                return Err(Error::BadOffset);
-            }
-            if pos > self.data.len() as u32 {
-                return Err(Error::BadOffset);
-            }
-            self.pos = pos;
-            self.known_end = true;
-        }
-        Ok(())
-    }
-    fn remaining(&self) -> u32 {
-        self.data.len() as u32 - self.pos
-    }
-    fn finish(&self) -> Result<(), Error> {
-        if self.known_end {
-            if self.pos != self.data.len() as u32 {
-                return Err(Error::ExtraData);
-            }
-        }
-        Ok(())
-    }
-}
-
 pub trait CustomHandler {
     fn matches(&self, schema: &CompiledSchema, ty: &CompiledType) -> bool;
     fn frac2json(
         &self,
         schema: &CompiledSchema,
         ty: &CompiledType,
-        src: &[u8],
-        pos: &mut u32,
+        src: &mut FracInputStream,
+        allow_empty_container: bool,
     ) -> Result<serde_json::Value, Error>;
     fn json2frac(
         &self,
@@ -651,10 +587,10 @@ impl<'a> CustomTypes<'a> {
         id: usize,
         schema: &CompiledSchema,
         ty: &CompiledType,
-        src: &[u8],
-        pos: &mut u32,
+        src: &mut FracInputStream,
+        allow_empty_container: bool,
     ) -> Result<serde_json::Value, Error> {
-        self.handlers[id].frac2json(schema, ty, src, pos)
+        self.handlers[id].frac2json(schema, ty, src, allow_empty_container)
     }
     fn json2frac(
         &self,
@@ -687,10 +623,10 @@ impl CustomHandler for CustomBool {
         &self,
         _schema: &CompiledSchema,
         _ty: &CompiledType,
-        src: &[u8],
-        pos: &mut u32,
+        src: &mut FracInputStream,
+        _allow_empty_container: bool,
     ) -> Result<serde_json::Value, Error> {
-        Ok(bool::unpack(src, pos)?.into())
+        Ok(bool::unpack(src)?.into())
     }
     fn json2frac(
         &self,
@@ -721,10 +657,15 @@ impl CustomHandler for CustomString {
         &self,
         _schema: &CompiledSchema,
         _ty: &CompiledType,
-        src: &[u8],
-        pos: &mut u32,
+        src: &mut FracInputStream,
+        allow_empty_container: bool,
     ) -> Result<serde_json::Value, Error> {
-        Ok(String::unpack(src, pos)?.into())
+        let result = String::unpack(src)?;
+        if !allow_empty_container && result.is_empty() {
+            Err(Error::PtrEmptyList)
+        } else {
+            Ok(result.into())
+        }
     }
     fn json2frac(
         &self,
@@ -755,18 +696,20 @@ impl CustomHandler for CustomHex {
         &self,
         _schema: &CompiledSchema,
         ty: &CompiledType,
-        src: &[u8],
-        pos: &mut u32,
+        src: &mut FracInputStream,
+        allow_empty_container: bool,
     ) -> Result<serde_json::Value, Error> {
         let len = if ty.is_variable_size() {
-            u32::unpack(src, pos)?
+            u32::unpack(src)?
         } else {
             ty.fixed_size()
         };
-        let start = *pos;
-        let end = *pos + len;
-        *pos = end;
-        Ok(hex::encode_upper(&src[start as usize..end as usize]).into())
+        if !allow_empty_container && len == 0 && ty.is_variable_size() {
+            return Err(Error::PtrEmptyList);
+        }
+        let start = src.advance(len)?;
+        let end = src.pos;
+        Ok(hex::encode_upper(&src.data[start as usize..end as usize]).into())
     }
     fn json2frac(
         &self,
@@ -817,13 +760,10 @@ impl CustomHandler for CustomMap {
         &self,
         schema: &CompiledSchema,
         ty: &CompiledType,
-        src: &[u8],
-        pos: &mut u32,
+        src: &mut FracInputStream,
+        allow_empty_container: bool,
     ) -> Result<serde_json::Value, Error> {
-        let mut stream = FracInputStream::new(src);
-        stream.pos = *pos;
-        let mut result = frac2json_impl(schema, ty, &mut stream, true)?;
-        *pos = stream.pos;
+        let mut result = frac2json_impl(schema, ty, src, allow_empty_container)?;
         use serde_json::{
             Map, Value,
             Value::{Array, Object},
@@ -1374,16 +1314,13 @@ impl CompiledType {
         match self {
             List(_) => Ok(serde_json::Value::Array(Vec::new())),
             FracPack(nested) => frac2json(schema, schema.get_by_id(*nested), &[]),
-            Custom { repr, id, .. } => {
-                let mut pos = 0;
-                schema.custom.frac2json(
-                    *id,
-                    schema,
-                    schema.get_by_id(*repr),
-                    &[0, 0, 0, 0],
-                    &mut pos,
-                )
-            }
+            Custom { repr, id, .. } => schema.custom.frac2json(
+                *id,
+                schema,
+                schema.get_by_id(*repr),
+                &mut FracInputStream::new(&[0, 0, 0, 0]),
+                true,
+            ),
             _ => Err(Error::BadOffset),
         }
     }
@@ -1430,7 +1367,7 @@ fn frac2json_embedded(
     match ty {
         CompiledType::Option(t) => {
             let orig_pos = fixed_stream.pos;
-            let offset = u32::unpack(fixed_stream.data, &mut fixed_stream.pos)?;
+            let offset = u32::unpack(fixed_stream)?;
             if offset == 1 {
                 *empty_optional = true;
                 return Ok(serde_json::Value::Null);
@@ -1440,37 +1377,13 @@ fn frac2json_embedded(
         _ => {
             if ty.is_variable_size() {
                 let orig_pos = fixed_stream.pos;
-                let offset = u32::unpack(fixed_stream.data, &mut fixed_stream.pos)?;
+                let offset = u32::unpack(fixed_stream)?;
                 frac2json_pointer(schema, ty, stream, orig_pos, offset)
             } else {
                 frac2json_impl(schema, ty, fixed_stream, true)
             }
         }
     }
-}
-
-fn consume_trailing_optional(
-    fixed_stream: &mut FracInputStream,
-    stream: &mut FracInputStream,
-    mut last_empty: bool,
-) -> Result<(), Error> {
-    while fixed_stream.remaining() > 0 {
-        let orig_pos = fixed_stream.pos;
-        let offset = u32::unpack(fixed_stream.data, &mut fixed_stream.pos)?;
-        last_empty = offset == 1;
-        if offset > 1 {
-            let Some(new_pos) = orig_pos.checked_add(offset) else {
-                return Err(Error::ReadPastEnd);
-            };
-            stream.set_pos(new_pos)?;
-            stream.known_end = false;
-        }
-        stream.has_unknown = true;
-    }
-    if last_empty {
-        return Err(Error::ExtraEmptyOptional);
-    }
-    Ok(())
 }
 
 fn frac2json(
@@ -1516,7 +1429,7 @@ fn frac2json_impl(
         }
         Object { children, .. } => {
             let mut result = serde_json::Map::with_capacity(children.len());
-            let fixed_size = u16::unpack(stream.data, &mut stream.pos)? as u32;
+            let fixed_size = u16::unpack(stream)? as u32;
             let mut fixed_stream = stream.read_fixed(fixed_size)?;
             let mut at_end = false;
             let mut last_empty = false;
@@ -1567,7 +1480,7 @@ fn frac2json_impl(
             Ok(result.into())
         }
         List(child) => {
-            let fixed_size = u32::unpack(stream.data, &mut stream.pos)?;
+            let fixed_size = u32::unpack(stream)?;
             if fixed_size == 0 && !allow_empty_container {
                 return Err(Error::PtrEmptyList);
             }
@@ -1597,8 +1510,8 @@ fn frac2json_impl(
             frac2json_embedded(schema, ty, &mut fixed_stream, stream, &mut last_empty)
         }
         Variant(alternatives) => {
-            let index = u8::unpack(stream.data, &mut stream.pos)?;
-            let len = u32::unpack(stream.data, &mut stream.pos)?;
+            let index = u8::unpack(stream)?;
+            let len = u32::unpack(stream)?;
             if index as usize >= alternatives.len() {
                 return Err(Error::BadEnumIndex);
             }
@@ -1617,7 +1530,7 @@ fn frac2json_impl(
         }
         Tuple(children) => {
             let mut result = Vec::with_capacity(children.len());
-            let fixed_size = u16::unpack(stream.data, &mut stream.pos)? as u32;
+            let fixed_size = u16::unpack(stream)? as u32;
             let mut fixed_stream = stream.read_fixed(fixed_size)?;
             let mut at_end = false;
             let mut last_empty = false;
@@ -1650,7 +1563,7 @@ fn frac2json_impl(
             bits: 1,
             is_signed: false,
         } => {
-            let result = u8::unpack(stream.data, &mut stream.pos)?;
+            let result = u8::unpack(stream)?;
             if result != 0 && result != 1 {
                 Err(Error::BadScalar)?
             }
@@ -1660,7 +1573,7 @@ fn frac2json_impl(
             bits: 1,
             is_signed: true,
         } => {
-            let result = i8::unpack(stream.data, &mut stream.pos)?;
+            let result = i8::unpack(stream)?;
             if result != 0 && result != -1 {
                 Err(Error::BadScalar)?
             }
@@ -1669,40 +1582,40 @@ fn frac2json_impl(
         Int {
             bits: 8,
             is_signed: false,
-        } => Ok(u8::unpack(stream.data, &mut stream.pos)?.into()),
+        } => Ok(u8::unpack(stream)?.into()),
         Int {
             bits: 8,
             is_signed: true,
-        } => Ok(i8::unpack(stream.data, &mut stream.pos)?.into()),
+        } => Ok(i8::unpack(stream)?.into()),
         Int {
             bits: 16,
             is_signed: false,
-        } => Ok(u16::unpack(stream.data, &mut stream.pos)?.into()),
+        } => Ok(u16::unpack(stream)?.into()),
         Int {
             bits: 16,
             is_signed: true,
-        } => Ok(i16::unpack(stream.data, &mut stream.pos)?.into()),
+        } => Ok(i16::unpack(stream)?.into()),
         Int {
             bits: 32,
             is_signed: false,
-        } => Ok(u32::unpack(stream.data, &mut stream.pos)?.into()),
+        } => Ok(u32::unpack(stream)?.into()),
         Int {
             bits: 32,
             is_signed: true,
-        } => Ok(i32::unpack(stream.data, &mut stream.pos)?.into()),
+        } => Ok(i32::unpack(stream)?.into()),
         Int {
             bits: 64,
             is_signed: false,
-        } => Ok(u64::unpack(stream.data, &mut stream.pos)?.into()),
+        } => Ok(u64::unpack(stream)?.into()),
         Int {
             bits: 64,
             is_signed: true,
-        } => Ok(i64::unpack(stream.data, &mut stream.pos)?.into()),
+        } => Ok(i64::unpack(stream)?.into()),
         Float {
             exp: 8,
             mantissa: 24,
         } => {
-            let result = f32::unpack(stream.data, &mut stream.pos)?;
+            let result = f32::unpack(stream)?;
             if result.is_finite() {
                 Ok(result.into())
             } else {
@@ -1713,7 +1626,7 @@ fn frac2json_impl(
             exp: 11,
             mantissa: 53,
         } => {
-            let result = f64::unpack(stream.data, &mut stream.pos)?;
+            let result = f64::unpack(stream)?;
             if result.is_finite() {
                 Ok(result.into())
             } else {
@@ -1721,7 +1634,7 @@ fn frac2json_impl(
             }
         }
         FracPack(nested) => {
-            let len = u32::unpack(stream.data, &mut stream.pos)?;
+            let len = u32::unpack(stream)?;
             if len == 0 && !allow_empty_container {
                 return Err(Error::PtrEmptyList);
             }
@@ -1734,12 +1647,11 @@ fn frac2json_impl(
         }
         Custom { id, repr, .. } => {
             let repr = schema.get_by_id(*repr);
-            let mut pos = stream.pos;
             // Use the underlying type for verification
-            fracpack_verify_impl(schema, repr, stream, allow_empty_container)?;
+            //fracpack_verify_impl(schema, repr, stream, allow_empty_container)?;
             schema
                 .custom
-                .frac2json(*id, schema, repr, stream.data, &mut pos)
+                .frac2json(*id, schema, repr, stream, allow_empty_container)
         }
         _ => {
             unimplemented!();
@@ -2152,7 +2064,7 @@ fn fracpack_verify_embedded(
     match ty {
         CompiledType::Option(t) => {
             let orig_pos = fixed_stream.pos;
-            let offset = u32::unpack(fixed_stream.data, &mut fixed_stream.pos)?;
+            let offset = u32::unpack(fixed_stream)?;
             if offset == 1 {
                 *empty_optional = true;
                 return Ok(());
@@ -2162,7 +2074,7 @@ fn fracpack_verify_embedded(
         _ => {
             if ty.is_variable_size() {
                 let orig_pos = fixed_stream.pos;
-                let offset = u32::unpack(fixed_stream.data, &mut fixed_stream.pos)?;
+                let offset = u32::unpack(fixed_stream)?;
                 fracpack_verify_pointer(schema, ty, stream, orig_pos, offset)
             } else {
                 fracpack_verify_impl(schema, ty, fixed_stream, true)
@@ -2197,7 +2109,7 @@ fn fracpack_verify_impl(
             }
         }
         Object { children, .. } => {
-            let fixed_size = u16::unpack(stream.data, &mut stream.pos)? as u32;
+            let fixed_size = u16::unpack(stream)? as u32;
             let mut fixed_stream = stream.read_fixed(fixed_size)?;
             let mut at_end = false;
             let mut last_empty = false;
@@ -2234,7 +2146,7 @@ fn fracpack_verify_impl(
             }
         }
         List(child) => {
-            let fixed_size = u32::unpack(stream.data, &mut stream.pos)?;
+            let fixed_size = u32::unpack(stream)?;
             if fixed_size == 0 && !allow_empty_container {
                 return Err(Error::PtrEmptyList);
             }
@@ -2256,8 +2168,8 @@ fn fracpack_verify_impl(
             fracpack_verify_embedded(schema, ty, &mut fixed_stream, stream, &mut last_empty)?
         }
         Variant(alternatives) => {
-            let index = u8::unpack(stream.data, &mut stream.pos)?;
-            let len = u32::unpack(stream.data, &mut stream.pos)?;
+            let index = u8::unpack(stream)?;
+            let len = u32::unpack(stream)?;
             if index as usize >= alternatives.len() {
                 return Err(Error::BadEnumIndex);
             }
@@ -2269,7 +2181,7 @@ fn fracpack_verify_impl(
             substream.finish()?;
         }
         Tuple(children) => {
-            let fixed_size = u16::unpack(stream.data, &mut stream.pos)? as u32;
+            let fixed_size = u16::unpack(stream)? as u32;
             let mut fixed_stream = stream.read_fixed(fixed_size)?;
             let mut at_end = false;
             let mut last_empty = false;
@@ -2299,7 +2211,7 @@ fn fracpack_verify_impl(
             bits: 1,
             is_signed: false,
         } => {
-            let result = u8::unpack(stream.data, &mut stream.pos)?;
+            let result = u8::unpack(stream)?;
             if result != 0 && result != 1 {
                 Err(Error::BadScalar)?
             }
@@ -2308,7 +2220,7 @@ fn fracpack_verify_impl(
             bits: 1,
             is_signed: true,
         } => {
-            let result = i8::unpack(stream.data, &mut stream.pos)?;
+            let result = i8::unpack(stream)?;
             if result != 0 && result != -1 {
                 Err(Error::BadScalar)?
             }
@@ -2316,45 +2228,45 @@ fn fracpack_verify_impl(
         Int {
             bits: 8,
             is_signed: false,
-        } => u8::verify(stream.data, &mut stream.pos)?,
+        } => u8::verify(stream)?,
         Int {
             bits: 8,
             is_signed: true,
-        } => i8::verify(stream.data, &mut stream.pos)?,
+        } => i8::verify(stream)?,
         Int {
             bits: 16,
             is_signed: false,
-        } => u16::verify(stream.data, &mut stream.pos)?,
+        } => u16::verify(stream)?,
         Int {
             bits: 16,
             is_signed: true,
-        } => i16::verify(stream.data, &mut stream.pos)?,
+        } => i16::verify(stream)?,
         Int {
             bits: 32,
             is_signed: false,
-        } => u32::verify(stream.data, &mut stream.pos)?,
+        } => u32::verify(stream)?,
         Int {
             bits: 32,
             is_signed: true,
-        } => i32::verify(stream.data, &mut stream.pos)?,
+        } => i32::verify(stream)?,
         Int {
             bits: 64,
             is_signed: false,
-        } => u64::verify(stream.data, &mut stream.pos)?,
+        } => u64::verify(stream)?,
         Int {
             bits: 64,
             is_signed: true,
-        } => i64::verify(stream.data, &mut stream.pos)?,
+        } => i64::verify(stream)?,
         Float {
             exp: 8,
             mantissa: 24,
-        } => f32::verify(stream.data, &mut stream.pos)?,
+        } => f32::verify(stream)?,
         Float {
             exp: 11,
             mantissa: 53,
-        } => f64::verify(stream.data, &mut stream.pos)?,
+        } => f64::verify(stream)?,
         FracPack(nested) => {
-            let len = u32::unpack(stream.data, &mut stream.pos)?;
+            let len = u32::unpack(stream)?;
             if len == 0 && !allow_empty_container {
                 return Err(Error::PtrEmptyList);
             }

--- a/rust/fracpack/src/schema.rs
+++ b/rust/fracpack/src/schema.rs
@@ -24,6 +24,22 @@ impl Schema {
     }
 }
 
+impl IntoIterator for Schema {
+    type Item = <IndexMap<String, AnyType> as IntoIterator>::Item;
+    type IntoIter = <IndexMap<String, AnyType> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Schema {
+    type Item = <&'a IndexMap<String, AnyType> as IntoIterator>::Item;
+    type IntoIter = <&'a IndexMap<String, AnyType> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Pack, Unpack, PartialEq, Eq)]
 #[fracpack(fracpack_mod = "crate")]
 pub enum AnyType {

--- a/rust/psibase/src/db.rs
+++ b/rust/psibase/src/db.rs
@@ -1,4 +1,4 @@
-use fracpack::{Pack, ToSchema, Unpack};
+use fracpack::{FracInputStream, Pack, ToSchema, Unpack};
 use serde::{Deserialize, Serialize};
 
 /// Identify database to operate on
@@ -165,8 +165,8 @@ impl<'a> Unpack<'a> for DbId {
 
     const VARIABLE_SIZE: bool = false;
 
-    fn unpack(src: &'a [u8], pos: &mut u32) -> fracpack::Result<Self> {
-        let u32_form = u32::unpack(src, pos)?;
+    fn unpack(src: &mut FracInputStream<'a>) -> fracpack::Result<Self> {
+        let u32_form = u32::unpack(src)?;
         if u32_form >= DbId::NumChainDatabases as u32
             && !(BEGIN_INDEPENDENT..(DbId::EndIndependent as u32)).contains(&u32_form)
         {
@@ -175,8 +175,8 @@ impl<'a> Unpack<'a> for DbId {
         Ok(unsafe { std::mem::transmute(u32_form) })
     }
 
-    fn verify(src: &'a [u8], pos: &mut u32) -> fracpack::Result<()> {
-        DbId::unpack(src, pos)?;
+    fn verify(src: &mut FracInputStream) -> fracpack::Result<()> {
+        DbId::unpack(src)?;
         Ok(())
     }
 }

--- a/rust/psibase/src/graph_ql.rs
+++ b/rust/psibase/src/graph_ql.rs
@@ -225,7 +225,7 @@ impl<Key: ToKey, Record: TableRecord + OutputType> TableQuery<Key, Record> {
         if self.index.is_secondary {
             kv_get(self.index.db_id, &RawKey::new(bytes)).unwrap()
         } else {
-            Some(Record::unpack(&bytes[..], &mut 0).unwrap())
+            Some(Record::unpacked(&bytes[..]).unwrap())
         }
     }
 

--- a/rust/psibase/src/hex.rs
+++ b/rust/psibase/src/hex.rs
@@ -1,6 +1,6 @@
 use crate::ToKey;
 use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType};
-use fracpack::{AnyType, SchemaBuilder, ToSchema};
+use fracpack::{AnyType, FracInputStream, SchemaBuilder, ToSchema};
 use std::convert::AsRef;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
@@ -151,46 +151,41 @@ where
     const FIXED_SIZE: u32 = <T as crate::fracpack::Unpack>::FIXED_SIZE;
     const VARIABLE_SIZE: bool = <T as crate::fracpack::Unpack>::VARIABLE_SIZE;
     const IS_OPTIONAL: bool = <T as crate::fracpack::Unpack>::IS_OPTIONAL;
-    fn unpack(src: &'a [u8], pos: &mut u32) -> crate::fracpack::Result<Self> {
-        let value = <T as crate::fracpack::Unpack>::unpack(src, pos)?;
+    fn unpack(src: &mut FracInputStream<'a>) -> crate::fracpack::Result<Self> {
+        let value = <T as crate::fracpack::Unpack>::unpack(src)?;
         Ok(Self(value))
     }
-    fn verify(src: &'a [u8], pos: &mut u32) -> crate::fracpack::Result<()> {
-        <T as crate::fracpack::Unpack>::verify(src, pos)
+    fn verify(src: &mut FracInputStream) -> crate::fracpack::Result<()> {
+        <T as crate::fracpack::Unpack>::verify(src)
     }
     fn new_empty_container() -> crate::fracpack::Result<Self> {
         Ok(Self(<T as crate::fracpack::Unpack>::new_empty_container()?))
     }
     fn embedded_variable_unpack(
-        src: &'a [u8],
+        src: &mut FracInputStream<'a>,
         fixed_pos: &mut u32,
-        heap_pos: &mut u32,
     ) -> crate::fracpack::Result<Self> {
-        let value =
-            <T as crate::fracpack::Unpack>::embedded_variable_unpack(src, fixed_pos, heap_pos)?;
+        let value = <T as crate::fracpack::Unpack>::embedded_variable_unpack(src, fixed_pos)?;
         Ok(Self(value))
     }
     fn embedded_unpack(
-        src: &'a [u8],
+        src: &mut FracInputStream<'a>,
         fixed_pos: &mut u32,
-        heap_pos: &mut u32,
     ) -> crate::fracpack::Result<Self> {
-        let value = <T as crate::fracpack::Unpack>::embedded_unpack(src, fixed_pos, heap_pos)?;
+        let value = <T as crate::fracpack::Unpack>::embedded_unpack(src, fixed_pos)?;
         Ok(Self(value))
     }
     fn embedded_variable_verify(
-        src: &'a [u8],
+        src: &mut FracInputStream,
         fixed_pos: &mut u32,
-        heap_pos: &mut u32,
     ) -> crate::fracpack::Result<()> {
-        <T as crate::fracpack::Unpack>::embedded_variable_verify(src, fixed_pos, heap_pos)
+        <T as crate::fracpack::Unpack>::embedded_variable_verify(src, fixed_pos)
     }
     fn embedded_verify(
-        src: &'a [u8],
+        src: &mut FracInputStream,
         fixed_pos: &mut u32,
-        heap_pos: &mut u32,
     ) -> crate::fracpack::Result<()> {
-        <T as crate::fracpack::Unpack>::embedded_verify(src, fixed_pos, heap_pos)
+        <T as crate::fracpack::Unpack>::embedded_verify(src, fixed_pos)
     }
 }
 

--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -125,7 +125,7 @@ pub fn get_current_action_bytes() -> Vec<u8> {
 /// Note: The above only applies if the contract uses [crate::native_raw::call].
 pub fn get_current_action() -> crate::Action {
     let bytes = get_current_action_bytes();
-    <crate::Action>::unpack(&bytes[..], &mut 0).unwrap() // unwrap won't panic
+    <crate::Action>::unpacked(&bytes[..]).unwrap() // unwrap won't panic
 }
 
 /// Get the currently-executing action and pass it to `f`.
@@ -141,7 +141,7 @@ pub fn get_current_action() -> crate::Action {
 /// Note: The above only applies if the contract uses [crate::native_raw::call].
 pub fn with_current_action<R, F: Fn(crate::SharedAction) -> R>(f: F) -> R {
     let bytes = get_current_action_bytes();
-    let act = <crate::SharedAction>::unpack(&bytes[..], &mut 0).unwrap(); // unwrap won't panic
+    let act = <crate::SharedAction>::unpacked(&bytes[..]).unwrap(); // unwrap won't panic
     f(act)
 }
 
@@ -249,7 +249,7 @@ pub fn kv_greater_equal<K: ToKey, V: UnpackOwned>(
     match_key_size: u32,
 ) -> Option<V> {
     let bytes = kv_greater_equal_bytes(db_id, &key.to_key(), match_key_size);
-    bytes.map(|v| V::unpack(&v[..], &mut 0).unwrap())
+    bytes.map(|v| V::unpacked(&v[..]).unwrap())
 }
 
 /// Get the key-value pair immediately-before provided key
@@ -274,7 +274,7 @@ pub fn kv_less_than<K: ToKey, V: UnpackOwned>(
     match_key_size: u32,
 ) -> Option<V> {
     let bytes = kv_less_than_bytes(db_id, &key.to_key(), match_key_size);
-    bytes.map(|v| V::unpack(&v[..], &mut 0).unwrap())
+    bytes.map(|v| V::unpacked(&v[..]).unwrap())
 }
 
 /// Get the maximum key-value pair which has key as a prefix
@@ -290,7 +290,7 @@ pub fn kv_max_bytes(db: DbId, key: &[u8]) -> Option<Vec<u8>> {
 /// If one is found, then returns the value. Use [get_key_bytes] to get the found key.
 pub fn kv_max<K: ToKey, V: UnpackOwned>(db_id: DbId, key: &K) -> Option<V> {
     let bytes = kv_max_bytes(db_id, &key.to_key());
-    bytes.map(|v| V::unpack(&v[..], &mut 0).unwrap())
+    bytes.map(|v| V::unpacked(&v[..]).unwrap())
 }
 
 pub fn get_sequential_bytes(db_id: DbId, id: u64) -> Option<Vec<u8>> {

--- a/rust/psibase/src/schema.rs
+++ b/rust/psibase/src/schema.rs
@@ -1,7 +1,7 @@
 use crate::{AccountNumber, DbId, MethodNumber};
 use fracpack::{
-    AnyType, CompiledSchema, CompiledType, CustomHandler, CustomTypes, FunctionType, Pack,
-    SchemaBuilder, ToSchema, Unpack, VisitTypes,
+    AnyType, CompiledSchema, CompiledType, CustomHandler, CustomTypes, FracInputStream,
+    FunctionType, Pack, SchemaBuilder, ToSchema, Unpack, VisitTypes,
 };
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -180,12 +180,10 @@ impl CustomHandler for CustomAccountNumber {
         &self,
         _schema: &CompiledSchema,
         _ty: &CompiledType,
-        src: &[u8],
-        pos: &mut u32,
+        src: &mut FracInputStream,
+        _allow_empty_container: bool,
     ) -> Result<serde_json::Value, fracpack::Error> {
-        Ok(AccountNumber::new(u64::unpack(src, pos)?)
-            .to_string()
-            .into())
+        Ok(AccountNumber::new(u64::unpack(src)?).to_string().into())
     }
     fn json2frac(
         &self,
@@ -217,10 +215,10 @@ impl CustomHandler for CustomMethodNumber {
         &self,
         _schema: &CompiledSchema,
         _ty: &CompiledType,
-        src: &[u8],
-        pos: &mut u32,
+        src: &mut FracInputStream,
+        _allow_empty_container: bool,
     ) -> Result<serde_json::Value, fracpack::Error> {
-        Ok(MethodNumber::new(u64::unpack(src, pos)?).to_string().into())
+        Ok(MethodNumber::new(u64::unpack(src)?).to_string().into())
     }
     fn json2frac(
         &self,

--- a/rust/psibase/src/table.rs
+++ b/rust/psibase/src/table.rs
@@ -310,7 +310,7 @@ impl<Key: ToKey, Record: TableRecord> TableIndex<Key, Record> {
         if self.is_secondary {
             kv_get(self.db_id, &RawKey::new(bytes)).unwrap()
         } else {
-            Some(Record::unpack(&bytes[..], &mut 0).unwrap())
+            Some(Record::unpacked(&bytes[..]).unwrap())
         }
     }
 }

--- a/rust/test_fracpack/Cargo.toml
+++ b/rust/test_fracpack/Cargo.toml
@@ -11,9 +11,13 @@ publish = false
 cxx = "1.0"
 fracpack = { version = "0.19.0", path = "../fracpack" }
 hex = "0.3.1"
+indexmap = { version = "2.2.6", features = ["std", "serde"] }
+psibase = { version = "0.19.0", path = "../psibase" }
 psibase_macros = { version = "0.19.0", path = "../psibase_macros" }
+serde-aux = "4.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+test_fracpack_macros = { version = "0.19.0", path = "../test_fracpack_macros" }
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/rust/test_fracpack/tests/test.rs
+++ b/rust/test_fracpack/tests/test.rs
@@ -280,7 +280,7 @@ fn round_trip_field<T: Pack + UnpackOwned + PartialEq + std::fmt::Debug>(
 
     T::verify_no_extra(&packed[..]).unwrap();
 
-    let unpacked = T::unpack(&packed[..], &mut 0).unwrap();
+    let unpacked = T::unpacked(&packed[..]).unwrap();
     assert_eq!(*field, unpacked);
     test_fracpack::bridge::ffi::round_trip_outer_struct_field(index, field_name, &packed[..]);
     unpacked
@@ -337,8 +337,8 @@ fn t1() -> Result<()> {
         round_trip_fields(i, t);
         let mut packed = Vec::<u8>::new();
         t.pack(&mut packed);
-        OuterStruct::verify(&packed[..], &mut 0)?;
-        let unpacked = OuterStruct::unpack(&packed[..], &mut 0)?;
+        OuterStruct::verify_no_extra(&packed[..])?;
+        let unpacked = OuterStruct::unpacked(&packed[..])?;
         assert_eq!(*t, unpacked);
         test_fracpack::bridge::ffi::round_trip_outer_struct(i, &packed[..]);
         // TODO: optionals after fixed-data portion ends
@@ -888,8 +888,8 @@ where
     T: PartialEq<T>,
     T: std::fmt::Debug,
 {
-    T::verify(bytes, &mut 0).unwrap();
-    let unpacked = T::unpack(bytes, &mut 0).unwrap();
+    T::verify_no_extra(bytes).unwrap();
+    let unpacked = T::unpacked(bytes).unwrap();
     assert_eq!(*src_struct, unpacked);
 }
 

--- a/rust/test_fracpack/tests/test.rs
+++ b/rust/test_fracpack/tests/test.rs
@@ -892,3 +892,7 @@ where
     let unpacked = T::unpack(bytes, &mut 0).unwrap();
     assert_eq!(*src_struct, unpacked);
 }
+
+test_fracpack_macros::include_tests!(
+    "${CARGO_MANIFEST_DIR}/../../libraries/psio/tests/fracpack-tests.json"
+);

--- a/rust/test_fracpack_macros/Cargo.toml
+++ b/rust/test_fracpack_macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test_fracpack_macros"
+version = "0.19.0"
+edition = "2021"
+license = "MIT"
+description = "Macros to support psibase development"
+repository = "https://github.com/gofractally/psibase"
+homepage = "https://psibase.io"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+anyhow = "1.0"
+fracpack = { version = "0.19.0", path = "../fracpack" }
+hex = "0.3.1"
+proc-macro-error = "1.0.4"
+proc-macro2 = "1.0.36"
+quote = "1.0.15"
+regex = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+syn = { version = "1.0.86", features = ["full"] }

--- a/rust/test_fracpack_macros/src/lib.rs
+++ b/rust/test_fracpack_macros/src/lib.rs
@@ -1,0 +1,401 @@
+use anyhow::Context;
+use fracpack::{AnyType, Schema};
+use proc_macro2::{Span, TokenStream};
+use proc_macro_error::abort;
+use proc_macro_error::proc_macro_error;
+use quote::quote;
+use regex::{Captures, Regex};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use syn::{parse_macro_input, Ident, LitByteStr, LitStr};
+
+#[derive(Serialize, Deserialize)]
+struct SchemaTestCase {
+    #[serde(rename = "type")]
+    type_: String,
+    #[serde(default)]
+    json: Option<serde_json::Value>,
+    fracpack: String,
+    #[serde(default)]
+    error: bool,
+    #[serde(default)]
+    compat: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SchemaTestFile {
+    schema: fracpack::Schema,
+    values: Vec<SchemaTestCase>,
+}
+
+#[derive(Default)]
+struct DeclBuilder {
+    decls: Vec<TokenStream>,
+    next_id: u32,
+    type_names: HashMap<String, String>,
+    used_names: HashSet<String>,
+}
+
+fn resolve_custom<'a>(mut ty: &'a AnyType, schema: &'a Schema) -> &'a AnyType {
+    use AnyType::*;
+    loop {
+        match ty {
+            Type(name) => ty = schema.get(name.as_str()).unwrap(),
+            Custom { type_, .. } => ty = type_,
+            _ => break,
+        }
+    }
+    ty
+}
+
+impl DeclBuilder {
+    fn emit_named(&mut self, name: Option<String>, t: TokenStream) -> TokenStream {
+        if let Some(name) = name {
+            let name = self.generate_name(Some(name));
+            self.decls.push(quote! { type #name = #t; });
+            quote! { #name }
+        } else {
+            t
+        }
+    }
+
+    fn unnamed(&mut self) -> String {
+        let result = format!("unnamed{}", self.next_id);
+        self.next_id += 1;
+        result
+    }
+
+    fn generate_name(&mut self, name: Option<String>) -> Ident {
+        let s = if let Some(name) = name {
+            if let Some(existing) = self.type_names.get(&name) {
+                existing.clone()
+            } else {
+                let re = Regex::new("[^a-zA-Z0-9_]").unwrap();
+                let result = re.replace_all(&name, "_");
+                let mut result = match &*result {
+                    "f32" | "f64" | "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64"
+                    | "bool" | "str" | "String" => result.to_string() + "_",
+                    _ => result.to_string(),
+                };
+                if self.used_names.contains(&result) {
+                    result = self.unnamed()
+                }
+                self.used_names.insert(result.clone());
+                self.type_names.insert(name.clone(), result.clone());
+                result
+            }
+        } else {
+            self.unnamed()
+        };
+        Ident::new(&s, Span::call_site())
+    }
+
+    fn emit_number_type(&mut self, name: Option<String>, builtin: TokenStream) -> TokenStream {
+        let name = self.generate_name(name);
+        self.decls.push(quote! {
+            #[derive(Debug, fracpack::Pack, fracpack::Unpack, serde::Serialize, PartialEq)]
+            struct #name(#builtin);
+            impl<'de> serde::Deserialize<'de> for #name {
+                fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                    Ok(#name(serde_aux::field_attributes::deserialize_number_from_string(deserializer)?))
+                }
+            }
+        });
+        quote! { #name }
+    }
+
+    fn emit_type(&mut self, name: Option<String>, t: &AnyType, schema: &Schema) -> TokenStream {
+        use AnyType::*;
+        match t {
+            Struct(fields) => {
+                let name = self.generate_name(name);
+                let mut all_fields = quote! {};
+                for (name, ty) in fields {
+                    let ty = self.emit_type(None, ty, schema);
+                    let name = Ident::new(&*name, Span::call_site());
+                    all_fields = quote! {
+                        #all_fields
+                        pub #name: #ty,
+                    }
+                }
+                self.decls.push(quote!{
+                    #[derive(Debug, fracpack::Pack, fracpack::Unpack, serde::Serialize, serde::Deserialize, PartialEq)]
+                    #[fracpack(definition_will_not_change)]
+                    struct #name {
+                        #all_fields
+                    }
+                });
+                quote! { #name }
+            }
+            Object(fields) => {
+                let name = self.generate_name(name);
+                let mut all_fields = quote! {};
+                for (name, ty) in fields {
+                    let ty = self.emit_type(None, ty, schema);
+                    let name = Ident::new(&*name, Span::call_site());
+                    all_fields = quote! {
+                        #all_fields
+                        pub #name: #ty,
+                    }
+                }
+                self.decls.push(quote!{
+                    #[derive(Debug, fracpack::Pack, fracpack::Unpack, serde::Serialize, serde::Deserialize, PartialEq)]
+                    struct #name {
+                        #all_fields
+                    }
+                });
+                quote! { #name }
+            }
+            Array { type_, len } => {
+                let item = self.emit_type(None, &*type_, schema);
+                let len = *len as usize;
+                self.emit_named(name, quote! { [#item; #len] })
+            }
+            List(item) => {
+                let item = self.emit_type(None, &*item, schema);
+                self.emit_named(name, quote! { Vec<#item> })
+            }
+            Option(item) => {
+                let item = self.emit_type(None, &*item, schema);
+                self.emit_named(name, quote! { Option<#item> })
+            }
+            Variant(alternatives) => {
+                let name = self.generate_name(name);
+                let mut all_alternatives = quote! {};
+                for (name, ty) in alternatives {
+                    let ty = self.emit_type(None, ty, schema);
+                    let alt = if name.starts_with("@") {
+                        let name = Ident::new(&name[1..], Span::call_site());
+                        quote! {
+                            #[serde(untagged)]
+                            #name(#ty)
+                        }
+                    } else {
+                        let name = Ident::new(&*name, Span::call_site());
+                        quote! { #name(#ty) }
+                    };
+                    all_alternatives = quote! {
+                        #all_alternatives
+                        #alt,
+                    };
+                }
+                self.decls.push(quote! {
+                    #[derive(Debug, fracpack::Pack, fracpack::Unpack, serde::Serialize, serde::Deserialize, PartialEq)]
+                    enum #name {
+                        #all_alternatives
+                    }
+                });
+                quote! { #name }
+            }
+            Tuple(types) => {
+                if types.is_empty() {
+                    let name = self.generate_name(name);
+                    self.decls.push(quote!{
+                        #[derive(Debug, fracpack::Pack, fracpack::Unpack, serde::Serialize, serde::Deserialize, PartialEq)]
+                        struct #name();
+                    });
+                    quote! { #name }
+                } else {
+                    let mut all_types = quote! {};
+                    for ty in types {
+                        let ty = self.emit_type(None, ty, schema);
+                        all_types = quote! { #all_types #ty, };
+                    }
+                    self.emit_named(name, quote! { ( #all_types ) })
+                }
+            }
+            Int { bits, is_signed } => {
+                let inttype = if *is_signed {
+                    format!("i{}", bits)
+                } else {
+                    format!("u{}", bits)
+                };
+                let inttype = Ident::new(&inttype, Span::call_site());
+                self.emit_number_type(name, quote! { #inttype })
+            }
+            Float {
+                exp: 8,
+                mantissa: 24,
+            } => self.emit_number_type(name, quote! { f32 }),
+            Float {
+                exp: 11,
+                mantissa: 53,
+            } => self.emit_number_type(name, quote! { f64 }),
+            Float { exp, mantissa } => {
+                let ty = format!("f{}_{}", mantissa, exp);
+                self.emit_number_type(name, quote! { #ty })
+            }
+            FracPack(nested) => {
+                // shared_view_ptr isn't implemented in rust
+                let ty = self.emit_type(None, nested, schema);
+                self.emit_named(name, quote! { fracpack::Nested<#ty> })
+            }
+            Custom { type_, id } => match id.as_str() {
+                "bool" => {
+                    if matches!(resolve_custom(type_, schema), Int { bits: 1, .. }) {
+                        self.emit_named(name, quote! { bool })
+                    } else {
+                        self.emit_type(name, type_, schema)
+                    }
+                }
+                "AccountNumber" => {
+                    let ty = resolve_custom(type_, schema);
+                    if let Struct(fields) = ty {
+                        if fields.len() == 1
+                            && matches!(
+                                resolve_custom(&fields[0], schema),
+                                Int {
+                                    bits: 64,
+                                    is_signed: false
+                                }
+                            )
+                        {
+                            self.emit_named(name, quote! { psibase::AccountNumber })
+                        } else {
+                            self.emit_type(name, type_, schema)
+                        }
+                    } else {
+                        self.emit_type(name, type_, schema)
+                    }
+                }
+                "string" => {
+                    if let List(nested) = resolve_custom(type_, schema) {
+                        let item = resolve_custom(nested, schema);
+                        if matches!(item, Int { bits: 8, .. }) {
+                            self.emit_named(name, quote! { String })
+                        } else {
+                            self.emit_type(name, type_, schema)
+                        }
+                    } else {
+                        self.emit_type(name, type_, schema)
+                    }
+                }
+                "hex" => {
+                    let ty = resolve_custom(type_, schema);
+                    if let List(nested) = ty {
+                        let item = resolve_custom(nested, schema);
+                        if matches!(item, Int { bits: 8, .. }) {
+                            self.emit_named(name, quote! { psibase::Hex<Vec<u8>> })
+                        } else {
+                            self.emit_type(name, type_, schema)
+                        }
+                    } else if let Array { type_, len } = ty {
+                        let item = resolve_custom(type_, schema);
+                        if matches!(item, Int { bits: 8, .. }) {
+                            let len = *len as usize;
+                            self.emit_named(name, quote! { psibase::Hex<[u8; #len]> })
+                        } else {
+                            self.emit_type(name, type_, schema)
+                        }
+                    } else if let FracPack(..) = ty {
+                        self.emit_named(name, quote! { psibase::Hex<Vec<u8>> })
+                    } else {
+                        self.emit_type(name, type_, schema)
+                    }
+                }
+                "map" => {
+                    if let List(nested) = resolve_custom(type_, schema) {
+                        match resolve_custom(nested, schema) {
+                            Tuple(fields) if fields.len() == 2 => {
+                                let key = self.emit_type(None, &fields[0], schema);
+                                let value = self.emit_type(None, &fields[1], schema);
+                                self.emit_named(name, quote! { indexmap::IndexMap<#key, #value> })
+                            }
+                            Object(fields) if fields.len() == 2 => {
+                                let key = self.emit_type(None, &fields[0], schema);
+                                let value = self.emit_type(None, &fields[1], schema);
+                                self.emit_named(name, quote! { indexmap::IndexMap<#key, #value> })
+                            }
+                            _ => self.emit_type(name, type_, schema),
+                        }
+                    } else {
+                        self.emit_type(name, type_, schema)
+                    }
+                }
+                _ => self.emit_type(name, type_, schema),
+            },
+            Type(alias) => {
+                let alias = self.generate_name(Some(alias.to_string()));
+                self.emit_named(name, quote! { #alias })
+            }
+        }
+    }
+
+    fn emit_test(&mut self, test: &SchemaTestCase) -> TokenStream {
+        let json_test = serde_json::to_string(test).unwrap();
+        if let Some(expected) = &test.json {
+            let fracpack =
+                LitByteStr::new(&hex::decode(&test.fracpack).unwrap(), Span::call_site());
+            let json = serde_json::to_string(expected).unwrap();
+            let ty = self.generate_name(Some(test.type_.clone()));
+            quote! {
+                println!("Running test: {}", #json_test);
+                let bin = #fracpack;
+                let fracpack_value = <#ty as fracpack::Unpack>::unpacked(bin).unwrap();
+                let json_value: #ty = serde_json::from_str(#json).unwrap();
+                let packed1 = <#ty as fracpack::Pack>::packed(&fracpack_value);
+                let packed2 = <#ty as fracpack::Pack>::packed(&json_value);
+                // NaNs interfere with regular comparison
+                assert_eq!(format!("{fracpack_value:?}"), format!("{json_value:?}"));
+                assert_eq!(packed1, bin);
+                assert_eq!(packed2, bin);
+            }
+        } else {
+            quote! {}
+        }
+    }
+}
+
+fn generate_tests_impl(json: String) -> proc_macro2::TokenStream {
+    let all_tests: Vec<SchemaTestFile> = serde_json::from_str(&json).unwrap();
+    let mut result = Vec::new();
+    for (i, tests) in all_tests.into_iter().enumerate() {
+        let mut builder = DeclBuilder::default();
+        for (name, t) in &tests.schema {
+            builder.emit_type(Some(name.to_string()), t, &tests.schema);
+        }
+        let test_body: TokenStream = tests
+            .values
+            .iter()
+            .map(|value| builder.emit_test(&value))
+            .collect();
+        let mod_name = Ident::new(&format!("generated_test{}", i), Span::call_site());
+        let decls: TokenStream = builder.decls.into_iter().collect();
+        result.push(quote! {
+        #[allow(non_camel_case_types)]
+        mod #mod_name {
+            #decls
+            #[test]
+            fn run_tests() {
+                #test_body
+            }
+        } })
+    }
+    let r = result.into_iter().collect();
+    r
+}
+
+fn include_tests_impl(filename_lit: LitStr) -> proc_macro2::TokenStream {
+    let var = Regex::new(r"\$\{(\w+)\}").unwrap();
+    let filename = filename_lit.value();
+    let filename = var.replace_all(&filename, |captures: &Captures| {
+        std::env::var(captures.get(1).unwrap().as_str()).unwrap()
+    });
+    generate_tests_impl(
+        std::fs::read_to_string(&*filename)
+            .with_context(|| format!("Cannot open {filename}"))
+            .unwrap_or_else(|e| abort!(filename_lit, e.to_string())),
+    )
+}
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn generate_tests(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    generate_tests_impl(parse_macro_input!(input as LitStr).value()).into()
+}
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn include_tests(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    include_tests_impl(parse_macro_input!(input as LitStr)).into()
+}


### PR DESCRIPTION
It had a lot of small bugs, mostly related to optionals.

Add a proc macro that generates code from fracpack-tests.json.
