### PR TITLE
BFT: don't get stuck when there is a view change before we unlock our keys

### DIFF
--- a/.github/workflows/ubuntu-builder.yml
+++ b/.github/workflows/ubuntu-builder.yml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2204:9fa50bbacdb05058a0a068964054041a5e8f4eb7"
+          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2204:02411d6f374bc7af37747df7a57e9610c88d5341"
             ubuntu-version: "2204"
-          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2404:9fa50bbacdb05058a0a068964054041a5e8f4eb7"
+          - builder-image: "ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-2404:02411d6f374bc7af37747df7a57e9610c88d5341"
             ubuntu-version: "2404"
     steps:
       - name: Timestamp

--- a/libraries/net/include/psibase/bft.hpp
+++ b/libraries/net/include/psibase/bft.hpp
@@ -926,7 +926,7 @@ namespace psibase::net
       {
          for (std::size_t group : {0, 1})
          {
-            if (active_producers[group])
+            if (active_producers[group] && !producer_views[group].empty())
             {
                if (auto idx = active_producers[group]->getIndex(self))
                {

--- a/libraries/net/include/psibase/bft.hpp
+++ b/libraries/net/include/psibase/bft.hpp
@@ -904,7 +904,7 @@ namespace psibase::net
              });
          if (is_view_outdated())
          {
-            _sync_term_timer.expires_from_now(std::chrono::seconds(30));
+            _sync_term_timer.expires_after(std::chrono::seconds(30));
             _sync_term_timer.async_wait(
                 [this](const std::error_code& ec)
                 {

--- a/libraries/net/include/psibase/bft.hpp
+++ b/libraries/net/include/psibase/bft.hpp
@@ -322,9 +322,11 @@ namespace psibase::net
       TermNum                   _ready_term    = -1;
       std::chrono::milliseconds _timeout       = std::chrono::seconds(10);
       std::chrono::milliseconds _timeout_delta = std::chrono::seconds(5);
+      Timer                     _sync_term_timer;
 
       template <typename ExecutionContext>
-      explicit basic_bft_consensus(ExecutionContext& ctx) : Base(ctx), _new_term_timer(ctx)
+      explicit basic_bft_consensus(ExecutionContext& ctx)
+          : Base(ctx), _new_term_timer(ctx), _sync_term_timer(ctx)
       {
       }
 
@@ -900,6 +902,51 @@ namespace psibase::net
                    PSIBASE_LOG(logger, warning) << "Failed to send update view: " << e.what();
                 }
              });
+         if (is_view_outdated())
+         {
+            _sync_term_timer.expires_from_now(std::chrono::seconds(30));
+            _sync_term_timer.async_wait(
+                [this](const std::error_code& ec)
+                {
+                   if (!ec)
+                   {
+                      PSIBASE_LOG(logger, info) << "Trying to sync current term";
+                      if (is_view_outdated())
+                      {
+                         sync_current_term();
+                      }
+                   }
+                });
+         }
+      }
+
+      // If we were unable to sign for a view change, producer_views
+      // might not match current_term.
+      bool is_view_outdated()
+      {
+         for (std::size_t group : {0, 1})
+         {
+            if (active_producers[group])
+            {
+               if (auto idx = active_producers[group]->getIndex(self))
+               {
+                  if (producer_views[group][*idx].term != current_term)
+                  {
+                     return true;
+                  }
+               }
+            }
+         }
+         return false;
+      }
+
+      void on_key_update()
+      {
+         Base::on_key_update();
+         if (is_view_outdated())
+         {
+            sync_current_term();
+         }
       }
 
       // Skip terms whose leaders have already advanced to a later view

--- a/libraries/net/include/psibase/blocknet.hpp
+++ b/libraries/net/include/psibase/blocknet.hpp
@@ -1311,6 +1311,7 @@ namespace psibase::net
       }
       void     cancel() {}
       void     validate_message() {}
+      void     on_key_update() {}
       BlockNum light_verify(const LightHeaderState&                   state,
                             const BlockInfo&                          info,
                             const psio::shared_view_ptr<SignedBlock>& block)

--- a/programs/psinode/CMakeLists.txt
+++ b/programs/psinode/CMakeLists.txt
@@ -31,7 +31,7 @@ set_target_properties(psinode PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_
 
 find_package(Python COMPONENTS Interpreter)
 if(Python_Interpreter_FOUND)
-    find_library(LIBSOFTHSM2 libsofthsm2.so)
+    find_library(LIBSOFTHSM2 libsofthsm2.so PATH_SUFFIXES softhsm)
     if(LIBSOFTHSM2)
         set(LIBSOFTHSM2_ARG --libsofthsm2=${LIBSOFTHSM2})
     else()

--- a/programs/psinode/CMakeLists.txt
+++ b/programs/psinode/CMakeLists.txt
@@ -31,10 +31,16 @@ set_target_properties(psinode PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_
 
 find_package(Python COMPONENTS Interpreter)
 if(Python_Interpreter_FOUND)
+    find_library(LIBSOFTHSM2 libsofthsm2.so)
+    if(LIBSOFTHSM2)
+        set(LIBSOFTHSM2_ARG --libsofthsm2=${LIBSOFTHSM2})
+    else()
+        set(LIBSOFTHSM2_ARG)
+    endif()
     function(add_psinode_test name)
         add_test(
             NAME psinode_${name}
-            COMMAND ${Python_EXECUTABLE} ${name}.py --psinode=$<TARGET_FILE:psinode>
+            COMMAND ${Python_EXECUTABLE} ${name}.py --psinode=$<TARGET_FILE:psinode> ${ARGN}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
     endfunction()
     add_test(
@@ -51,7 +57,7 @@ if(Python_Interpreter_FOUND)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
     add_psinode_test(test_routing)
     set_tests_properties(psinode_test_routing PROPERTIES PROCESSORS 7)
-    add_psinode_test(test_crash)
+    add_psinode_test(test_crash ${LIBSOFTHSM2_ARG})
     set_tests_properties(psinode_test_crash PROPERTIES PROCESSORS 4)
     add_psinode_test(test_psibase)
     add_psinode_test(test_subjective)

--- a/programs/psinode/tests/predicates.py
+++ b/programs/psinode/tests/predicates.py
@@ -36,6 +36,18 @@ def new_block():
         return datetime.fromisoformat(timestamp) + timedelta(seconds=1) > now
     return result
 
+def no_new_blocks():
+    print('waiting for block production to stop')
+    def result(node):
+        now = datetime.now(timezone.utc)
+        header = node.get_block_header()
+        timestamp = header['time']
+        print(timestamp)
+        if timestamp.endswith('Z'):
+            timestamp = timestamp[:-1] + '+00:00'
+        return datetime.fromisoformat(timestamp) + timedelta(seconds=2) < now
+    return result
+
 def irreversible(num):
     print("waiting for block %s to be committed" % num)
     def result(node):

--- a/programs/psinode/tests/test_crash.py
+++ b/programs/psinode/tests/test_crash.py
@@ -135,5 +135,40 @@ class TestCrash(unittest.TestCase):
                 self.assertEqual(header['commitNum'] + 2, header['blockNum'])
             time.sleep(1)
 
+    @testutil.psinode_test
+    def test_unlock_bft(self, cluster):
+        prods = cluster.complete(*testutil.generate_names(4), softhsm='libsofthsm2.so')
+        (a, b, c, d) = prods
+        keys = []
+        for p in prods:
+            device = p.unlock_softhsm()
+            with p.post('/native/admin/keys', service='x-admin', json={'service':'verify-sig', 'device': device}) as reply:
+                reply.raise_for_status()
+                keys.append({'name': p.producer, 'auth': reply.json()[0]})
+
+        print(keys)
+        print("booting chain")
+        a.boot(packages=['Minimal', 'Explorer'])
+        print("setting producers")
+        a.set_producers(keys, 'bft')
+        p.wait(producers_are(prods))
+
+        print('stopping nodes')
+        c.shutdown()
+        d.shutdown()
+        a.wait(no_new_blocks())
+        print('restarting nodes')
+        c.start()
+        d.start()
+        c.connect(a)
+        d.connect(a)
+        with self.assertRaises(TimeoutError):
+            a.wait(new_block())
+
+        c.unlock_softhsm()
+        d.unlock_softhsm()
+
+        a.wait(new_block())
+
 if __name__ == '__main__':
     testutil.main()

--- a/programs/psinode/tests/test_crash.py
+++ b/programs/psinode/tests/test_crash.py
@@ -137,7 +137,7 @@ class TestCrash(unittest.TestCase):
 
     @testutil.psinode_test
     def test_unlock_bft(self, cluster):
-        prods = cluster.complete(*testutil.generate_names(4), softhsm='libsofthsm2.so')
+        prods = cluster.complete(*testutil.generate_names(4), softhsm=testutil.libsofthsm2())
         (a, b, c, d) = prods
         keys = []
         for p in prods:

--- a/programs/psinode/tests/testutil.py
+++ b/programs/psinode/tests/testutil.py
@@ -71,6 +71,12 @@ def test_packages():
         result = os.path.join(os.path.dirname(psinode), 'test-packages')
     return result
 
+def libsofthsm2():
+    result = args.libsofthsm2
+    if result is None:
+        result = 'libsofthsm2.so'
+    return result
+
 def main(argv=sys.argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("--psinode", default="psinode", help="The path to the psinode executable")
@@ -78,6 +84,7 @@ def main(argv=sys.argv):
     parser.add_argument('--log-format', metavar='FORMAT', help="Format for log messages")
     parser.add_argument('--print-logs', metavar='NODE', action='append', help="Nodes whose logs should be printed")
     parser.add_argument('--test-packages', metavar='DIRECTORY', help="Directory containing test packages")
+    parser.add_argument('--libsofthsm2', metavar='PATH', help="Path to libsofthsm.so")
     global args
     (args, remaining) = parser.parse_known_args(argv)
     unittest.main(argv=remaining)


### PR DESCRIPTION
Also add a timer loop, when sending a view change fails, because the hardware device might have transient failures and we won't be notified when it's ready again.