### PR TITLE
Set cookie from plugin

### DIFF
--- a/services/system/Accounts/plugin/accounts/src/interfaces/admin.rs
+++ b/services/system/Accounts/plugin/accounts/src/interfaces/admin.rs
@@ -3,11 +3,15 @@ use crate::plugin::AccountsPlugin;
 use crate::bindings::accounts::account_tokens::api::*;
 use crate::bindings::exports::accounts::plugin::admin::{AppDetails, Guest as Admin};
 use crate::bindings::exports::accounts::plugin::api::Guest as API;
+use crate::bindings::host::common::admin as HostAdmin;
 use crate::bindings::host::common::client as Client;
+use crate::bindings::host::common::types::{BodyTypes, PostRequest};
 use crate::bindings::transact::plugin::auth as TransactAuthApi;
 use crate::db::apps_table::*;
 use crate::db::user_table::*;
 use crate::helpers::*;
+
+use serde::Serialize;
 
 // Asserts that the caller is the active app, and that it's the `accounts` app.
 fn get_assert_caller_admin(context: &str) -> String {
@@ -30,8 +34,13 @@ fn assert_valid_account(account: &str) {
     assert!(account_details.is_some(), "Invalid account name");
 }
 
+#[derive(Serialize, Debug)]
+struct SetAuthCookieReqPayload {
+    accessToken: String,
+}
+
 impl Admin for AccountsPlugin {
-    fn login_direct(app: AppDetails, user: String) -> Option<String> {
+    fn login_direct(app: AppDetails, user: String) {
         assert_caller_admin("login_direct");
 
         assert_valid_account(&user);
@@ -40,10 +49,19 @@ impl Admin for AccountsPlugin {
             TransactAuthApi::get_query_token(&Client::my_service_account(), &user).unwrap();
 
         let app = app.app.unwrap();
+
+        let payload = SetAuthCookieReqPayload {
+            accessToken: query_token.to_string(),
+        };
+
+        let req: PostRequest = PostRequest {
+            endpoint: String::from("/common/set-auth-cookie"),
+            body: BodyTypes::Json(serde_json::to_string(&payload).unwrap()),
+        };
+        HostAdmin::post(&app, &req).unwrap();
+
         AppsTable::new(&app).login(&user);
         UserTable::new(&user).add_connected_app(&app);
-
-        Some(query_token)
     }
 
     fn decode_connection_token(token: String) -> Option<AppDetails> {

--- a/services/system/Accounts/plugin/accounts/wit/impl.wit
+++ b/services/system/Accounts/plugin/accounts/wit/impl.wit
@@ -6,7 +6,7 @@ interface admin {
 
     /// Logs the specified user into the specified app without any user interaction.
     /// This function is only callable by the accounts app itself.
-    login-direct: func(app: app-details, user: string) -> option<string>;
+    login-direct: func(app: app-details, user: string);
 
     /// Gets app details
     decode-connection-token: func(token: string) -> option<app-details>;

--- a/services/system/Accounts/ui/src/hooks/useLoginDirect.ts
+++ b/services/system/Accounts/ui/src/hooks/useLoginDirect.ts
@@ -16,7 +16,7 @@ export const useLoginDirect = () =>
         mutationFn: async (params) => {
             const { accountName, app, origin } = LoginParams.parse(params);
 
-            const queryToken = await supervisor.functionCall({
+            await supervisor.functionCall({
                 method: "loginDirect",
                 params: [
                     {
@@ -28,7 +28,6 @@ export const useLoginDirect = () =>
                 service: "accounts",
                 intf: "admin",
             });
-            console.log("returned queryToken:", queryToken);
 
             window.location.href = origin;
         },

--- a/services/user/CommonApi/src/CommonApi.cpp
+++ b/services/user/CommonApi/src/CommonApi.cpp
@@ -109,7 +109,7 @@ namespace SystemService
             headers.push_back({"Set-Cookie", cookieValue});
 
             return HttpReply{.status      = HttpStatus::ok,
-                             .contentType = "application/json",
+                             .contentType = "text/plain",
                              .body        = {},
                              .headers     = headers};
          }

--- a/services/user/Supervisor/ui/src/hostInterface.ts
+++ b/services/user/Supervisor/ui/src/hostInterface.ts
@@ -18,7 +18,7 @@ export interface HttpRequest {
 export interface HttpResponse {
     status: number;
     headers: { key: string; value: string }[];
-    body: BodyType;
+    body: BodyType | null;
 }
 
 export interface BodyType {

--- a/services/user/Supervisor/ui/src/plugin/pluginHost.ts
+++ b/services/user/Supervisor/ui/src/plugin/pluginHost.ts
@@ -127,13 +127,16 @@ export class PluginHost implements HostInterface {
                 });
             const contentType = xhr.getResponseHeader("content-type") || "";
             const tag = this.getBodyTagFromContentType(contentType);
+
             return {
                 status: xhr.status,
                 headers: convertBack(headers),
-                body: {
-                    tag,
-                    val: body,
-                },
+                body: body
+                    ? {
+                          tag,
+                          val: body,
+                      }
+                    : null,
             };
         } catch (err: any) {
             if (


### PR DESCRIPTION
Accounts app was setting query-token. That's now incorporated into the Accounts plugin's login_direct() function for better encapsulation.

This PR is a follow on to #1291. Once that's merged, the commit history on this PR will be *very* short