### PR TITLE
Track WasmConfig used for verify services in the block header

### DIFF
--- a/libraries/net/test/test_bft_consensus.cpp
+++ b/libraries/net/test/test_bft_consensus.cpp
@@ -276,7 +276,6 @@ TEST_CASE("truncated fork switch", "[bft]")
    TEST_START(logger);
    SingleNode<node_type> node({"a", "b", "c", "d"});
    //
-   auto state   = JointConsensus{.current = {.data = bft("a", "b", "c", "d")}};
    auto root    = node.headState();
    auto block1a = makeBlock(root, "b", 4);
    auto block1b = makeBlock(block1a, "b", 4);

--- a/libraries/net/test/test_util.cpp
+++ b/libraries/net/test/test_util.cpp
@@ -232,8 +232,9 @@ TestBlock makeBlock(const BlockInfo&                   info,
          {
             using param_tuple =
                 psio::make_param_value_tuple<decltype(&Producers::setConsensus)>::type;
-            auto params                        = psio::view<const param_tuple>(act.rawData());
-            newBlock.block.header.newConsensus = Consensus{get<0>(params), {}};
+            auto params = psio::view<const param_tuple>(act.rawData());
+            newBlock.block.header.newConsensus =
+                Consensus{get<0>(params), newState.current.services, newState.current.wasmConfig};
             check(!newState.next, "Joint consensus is already running");
             newState.next = {*newBlock.block.header.newConsensus, newBlock.block.header.blockNum};
          }

--- a/libraries/psibase/common/include/psibase/Actor.hpp
+++ b/libraries/psibase/common/include/psibase/Actor.hpp
@@ -593,6 +593,7 @@ namespace psibase
    {
       using base = typename psio::reflect<T>::template proxy<action_builder_proxy>;
       using base::base;
+      transactor() : base(T::service, T::service) {}
 
       auto from(AccountNumber other) const
       {

--- a/libraries/psibase/common/include/psibase/block.hpp
+++ b/libraries/psibase/common/include/psibase/block.hpp
@@ -173,8 +173,8 @@ namespace psibase
 
    struct BlockHeaderWasmConfig
    {
-      uint32_t    numExecutionMemories;
-      VMOptions   vmOptions;
+      uint32_t    numExecutionMemories = 0;
+      VMOptions   vmOptions            = {0, 0, 0, 0};
       friend bool operator==(const BlockHeaderWasmConfig&, const BlockHeaderWasmConfig&) = default;
       PSIO_REFLECT(BlockHeaderWasmConfig, numExecutionMemories, vmOptions)
    };

--- a/libraries/psibase/common/include/psibase/block.hpp
+++ b/libraries/psibase/common/include/psibase/block.hpp
@@ -142,6 +142,43 @@ namespace psibase
       PSIO_REFLECT(BlockHeaderAuthAccount, codeNum, codeHash, vmType, vmVersion);
    };
 
+   // The existing eos-vm implementation limits are:
+   // - branch offsets, and stack offsets must fit in a signed 32-bit int
+   // - The total compiled module size must be < 1 GB (note that this
+   //   implies that 32-bit branches are okay.) The maximum amplification
+   //   factor is currently 79, if we round up to 128, that means that
+   //   wasms up to 8 MB are safe, which is coincidentally the db maxValueSize.
+   //
+   struct VMOptions
+   {
+      // This is a safe value that is larger than any reasonable stack size
+      static constexpr std::uint32_t max_func_local_bytes = 128 * 1024 * 1024;
+      static constexpr bool          enable_simd          = true;
+      static constexpr bool          enable_bulk_memory   = true;
+      static constexpr std::uint32_t stack_usage_for_call = 4096;
+
+      std::uint32_t max_mutable_global_bytes = 1024;
+      std::uint32_t max_pages                = 512;  // 32 MiB
+      std::uint32_t max_table_elements       = 8192;
+      // This is the total across all modules
+      std::uint32_t max_stack_bytes = 1024 * 1024;
+
+      friend auto operator<=>(const VMOptions&, const VMOptions&) = default;
+      PSIO_REFLECT(VMOptions,
+                   max_mutable_global_bytes,
+                   max_pages,
+                   max_table_elements,
+                   max_stack_bytes)
+   };
+
+   struct BlockHeaderWasmConfig
+   {
+      uint32_t    numExecutionMemories;
+      VMOptions   vmOptions;
+      friend bool operator==(const BlockHeaderWasmConfig&, const BlockHeaderWasmConfig&) = default;
+      PSIO_REFLECT(BlockHeaderWasmConfig, numExecutionMemories, vmOptions)
+   };
+
    struct Producer
    {
       AccountNumber name;
@@ -176,8 +213,9 @@ namespace psibase
    {
       ConsensusData                       data;
       std::vector<BlockHeaderAuthAccount> services;
+      BlockHeaderWasmConfig               wasmConfig;
       friend bool                         operator==(const Consensus&, const Consensus&) = default;
-      PSIO_REFLECT(Consensus, data, services)
+      PSIO_REFLECT(Consensus, data, services, wasmConfig)
    };
 
    struct BlockHeaderCode

--- a/libraries/psibase/common/include/psibase/headerValidation.hpp
+++ b/libraries/psibase/common/include/psibase/headerValidation.hpp
@@ -107,21 +107,35 @@ namespace psibase
    }
 
    template <typename Database>
+   void writeWasmConfig(Database& dest, const BlockHeaderWasmConfig& wasmConfig)
+   {
+      WasmConfigRow row{.numExecutionMemories = wasmConfig.numExecutionMemories,
+                        .vmOptions            = wasmConfig.vmOptions};
+      dest.kvPut(WasmConfigRow::db, row.key(proofWasmConfigTable), row);
+   }
+
+   template <typename Database>
    void copyServices(Database&                                  dest,
                      Database&                                  src,
-                     const std::vector<BlockHeaderAuthAccount>& services)
+                     const std::vector<BlockHeaderAuthAccount>& services,
+                     const BlockHeaderWasmConfig&               wasmConfig)
    {
       copyCodeByHash(dest, src, services);
       writeCode(dest, services);
+      writeWasmConfig(dest, wasmConfig);
    }
 
    template <typename Database>
    void updateServices(Database&                                  db,
                        const std::vector<BlockHeaderAuthAccount>& oldServices,
+                       const BlockHeaderWasmConfig&               oldWasmConfig,
                        const std::vector<BlockHeaderAuthAccount>& newServices,
+                       const BlockHeaderWasmConfig&               newWasmConfig,
                        const std::vector<BlockHeaderCode>&        authCode)
    {
       updateCodeByHash(db, oldServices, newServices, authCode);
       updateCode(db, oldServices, newServices);
+      if (oldWasmConfig != newWasmConfig)
+         writeWasmConfig(db, newWasmConfig);
    }
 }  // namespace psibase

--- a/libraries/psibase/common/include/psibase/nativeTables.hpp
+++ b/libraries/psibase/common/include/psibase/nativeTables.hpp
@@ -51,35 +51,6 @@ namespace psibase
       PSIO_REFLECT(ConfigRow, maxKeySize, maxValueSize)
    };
 
-   // The existing eos-vm implementation limits are:
-   // - branch offsets, and stack offsets must fit in a signed 32-bit int
-   // - The total compiled module size must be < 1 GB (note that this
-   //   implies that 32-bit branches are okay.) The maximum amplification
-   //   factor is currently 79, if we round up to 128, that means that
-   //   wasms up to 8 MB are safe, which is coincidentally the db maxValueSize.
-   //
-   struct VMOptions
-   {
-      // This is a safe value that is larger than any reasonable stack size
-      static constexpr std::uint32_t max_func_local_bytes = 128 * 1024 * 1024;
-      static constexpr bool          enable_simd          = true;
-      static constexpr bool          enable_bulk_memory   = true;
-      static constexpr std::uint32_t stack_usage_for_call = 4096;
-
-      std::uint32_t max_mutable_global_bytes = 1024;
-      std::uint32_t max_pages                = 512;  // 32 MiB
-      std::uint32_t max_table_elements       = 8192;
-      // This is the total across all modules
-      std::uint32_t max_stack_bytes = 1024 * 1024;
-
-      friend auto operator<=>(const VMOptions&, const VMOptions&) = default;
-      PSIO_REFLECT(VMOptions,
-                   max_mutable_global_bytes,
-                   max_pages,
-                   max_table_elements,
-                   max_stack_bytes)
-   };
-
    struct WasmConfigRow
    {
       uint32_t  numExecutionMemories = 32;

--- a/libraries/psibase/tester/src/tester.cpp
+++ b/libraries/psibase/tester/src/tester.cpp
@@ -264,6 +264,12 @@ void psibase::TestChain::finishBlock()
       runAll();
 }
 
+void psibase::TestChain::setSignature(BlockNum blockNum, std::vector<char> sig)
+{
+   kvPut(DbId::blockProof, blockNum, std::move(sig));
+   tester::raw::commitState(id);
+}
+
 void psibase::TestChain::fillTapos(Transaction& t, uint32_t expire_sec) const
 {
    ScopedSelectChain s{id};

--- a/programs/psinode/tests/test_block_signing.py
+++ b/programs/psinode/tests/test_block_signing.py
@@ -39,7 +39,7 @@ class TestBlockSigning(unittest.TestCase):
     @testutil.psinode_test
     def test_verify_wasm_config_pass(self, cluster):
         a = cluster.make_node('a', start=False)
-        subprocess.run(["./psitest", "./generate_verify_with_call.wasm", a.dir, '32', '33'], check=True)
+        testutil.run_test_wasm(["generate_verify_with_call.wasm", a.dir, '32', '33'])
         b = cluster.make_node('b')
         a.start()
         b.connect(a)
@@ -48,7 +48,7 @@ class TestBlockSigning(unittest.TestCase):
     @testutil.psinode_test
     def test_verify_wasm_config_fail(self, cluster):
         a = cluster.make_node('a', start=False)
-        subprocess.run(["./psitest", "./generate_verify_with_call.wasm", a.dir, '16', '16'], check=True)
+        testutil.run_test_wasm(["generate_verify_with_call.wasm", a.dir, '16', '16'])
         b = cluster.make_node('b')
         a.start()
         b.connect(a)

--- a/programs/psinode/tests/testutil.py
+++ b/programs/psinode/tests/testutil.py
@@ -7,6 +7,7 @@ import time
 import math
 import os
 import shutil
+import subprocess
 import requests
 
 def psinode_test(f):
@@ -77,6 +78,20 @@ def libsofthsm2():
         result = 'libsofthsm2.so'
     return result
 
+def run_test_wasm(command):
+    dirname = os.path.dirname(args.psinode)
+    if dirname == '':
+        psitest = 'psitest'
+    elif os.path.exists(os.path.join(dirname, 'psitest')):
+        psitest = os.path.join(dirname, 'psitest')
+    else:
+        psitest = 'psitest'
+
+    test_wasms = args.test_wasms
+    if test_wasms is None:
+        test_wasms = dirname
+    return subprocess.run([psitest, os.path.join(test_wasms, command[0])] + command[1:], check=True)
+
 def main(argv=sys.argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("--psinode", default="psinode", help="The path to the psinode executable")
@@ -85,6 +100,7 @@ def main(argv=sys.argv):
     parser.add_argument('--print-logs', metavar='NODE', action='append', help="Nodes whose logs should be printed")
     parser.add_argument('--test-packages', metavar='DIRECTORY', help="Directory containing test packages")
     parser.add_argument('--libsofthsm2', metavar='PATH', help="Path to libsofthsm.so")
+    parser.add_argument('--test-wasms', metavar='PATH', help="Directory containing wasm programs used by the test suite")
     global args
     (args, remaining) = parser.parse_known_args(argv)
     unittest.main(argv=remaining)

--- a/programs/psitest/main.cpp
+++ b/programs/psitest/main.cpp
@@ -392,7 +392,7 @@ struct test_chain
       // These are not the correct values if we want the chain to actually
       // sync correctly, but it's sufficient for the tester to test services.
       auto term      = status ? status->current.term : 0;
-      auto commitNum = status ? status->current.blockNum : 0;
+      auto commitNum = status ? status->head.value().header.blockNum : 0;
 
       blockContext->start(time, producer, term, commitNum);
       blockContext->callStartBlock();

--- a/programs/snapshot/LightValidator.hpp
+++ b/programs/snapshot/LightValidator.hpp
@@ -128,13 +128,13 @@ namespace psibase
       {
          if (status)
          {
-            state     = status->consensus;
-            stateHash = sha256(state);
-            const auto& services =
-                state.next ? state.next->consensus.services : status->consensus.current.services;
+            state                 = status->consensus;
+            stateHash             = sha256(state);
+            const auto& consensus = state.next ? state.next->consensus : status->consensus.current;
             check(!!status->head, "Missing head");
             current = status->head->header;
-            psibase::copyServices(authServices.base(), handle, services);
+            psibase::copyServices(authServices.base(), handle, consensus.services,
+                                  consensus.wasmConfig);
          }
       }
       // Writes the current set of auth services to prevAuthServices.
@@ -269,7 +269,8 @@ namespace psibase
       }
       void updateVerifyState()
       {
-         updateServices(authServices.base(), state.current.services, state.next->consensus.services,
+         updateServices(authServices.base(), state.current.services, state.current.wasmConfig,
+                        state.next->consensus.services, state.next->consensus.wasmConfig,
                         pendingCode);
          pendingCode.clear();
       }

--- a/services/psibase_tests/CMakeLists.txt
+++ b/services/psibase_tests/CMakeLists.txt
@@ -22,6 +22,7 @@ function(add suffix)
     service(RemoveCode "${suffix}" src/RemoveCode.cpp)
     service(SubjectiveDb "${suffix}" src/SubjectiveDb.cpp)
     service(NotifyService "${suffix}" src/NotifyService.cpp)
+    service(SetWasmConfig "${suffix}" src/SetWasmConfig.cpp)
 
     set(TEST_GENERATE_SCHEMA 1)
     service(MockCpuLimit "${suffix}" src/MockCpuLimit.cpp)
@@ -31,6 +32,7 @@ function(add suffix)
     service(SubjectiveCounterService "${suffix}" src/SubjectiveCounterService.cpp)
     service(KeepSocketService "${suffix}" src/KeepSocketService.cpp)
     service(SocketListService "${suffix}" src/SocketListService.cpp)
+    service(VerifyWithCall "${suffix}" src/VerifyWithCall.cpp)
 endfunction(add)
 
 add_library(services_test INTERFACE)
@@ -41,5 +43,6 @@ if(DEFINED IS_WASM)
 endif()
 
 add_subdirectory(test)
+add_subdirectory(programs)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)

--- a/services/psibase_tests/include/services/test/SetWasmConfig.hpp
+++ b/services/psibase_tests/include/services/test/SetWasmConfig.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <psibase/Service.hpp>
+#include <psibase/nativeTables.hpp>
+
+namespace TestService
+{
+   struct SetWasmConfig : psibase::Service
+   {
+      static constexpr auto service = psibase::AccountNumber{"wasm-config"};
+      static constexpr auto flags   = psibase::CodeRow::allowWriteNative;
+      void                  setWasmCfg(psibase::NativeTableNum table, psibase::WasmConfigRow row);
+   };
+   PSIO_REFLECT(SetWasmConfig, method(setWasmCfg, table, row))
+}  // namespace TestService

--- a/services/psibase_tests/include/services/test/VerifyWithCall.hpp
+++ b/services/psibase_tests/include/services/test/VerifyWithCall.hpp
@@ -13,5 +13,5 @@ namespace TestService
                                       psibase::Claim       claim,
                                       std::vector<char>    proof);
    };
-   PSIO_REFLECT(VerifyWithCall, method(verifySys, claim, proof))
+   PSIO_REFLECT(VerifyWithCall, method(verifySys, transactionHash, claim, proof))
 }  // namespace TestService

--- a/services/psibase_tests/include/services/test/VerifyWithCall.hpp
+++ b/services/psibase_tests/include/services/test/VerifyWithCall.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <psibase/Service.hpp>
+#include <psibase/nativeTables.hpp>
+
+namespace TestService
+{
+   struct VerifyWithCall : psibase::Service
+   {
+      static constexpr auto service = psibase::AccountNumber{"verify-call"};
+      static constexpr auto flags   = psibase::CodeRow::isAuthService;
+      void                  verifySys(psibase::Checksum256 transactionHash,
+                                      psibase::Claim       claim,
+                                      std::vector<char>    proof);
+   };
+   PSIO_REFLECT(VerifyWithCall, method(verifySys, claim, proof))
+}  // namespace TestService

--- a/services/psibase_tests/programs/CMakeLists.txt
+++ b/services/psibase_tests/programs/CMakeLists.txt
@@ -1,0 +1,11 @@
+function(add suffix)
+    add_executable(generate_verify_with_call${suffix} generate_verify_with_call.cpp)
+    target_link_libraries(generate_verify_with_call${suffix} services_system${suffix} services_user${suffix} services_test psitestlib${suffix})
+    set_target_properties(generate_verify_with_call${suffix} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
+endfunction(add)
+
+if(DEFINED IS_WASM)
+    conditional_add()
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)

--- a/services/psibase_tests/programs/generate_verify_with_call.cpp
+++ b/services/psibase_tests/programs/generate_verify_with_call.cpp
@@ -1,0 +1,80 @@
+#include <psibase/tester.hpp>
+#include <services/system/Accounts.hpp>
+#include <services/system/AuthAny.hpp>
+#include <services/system/Producers.hpp>
+#include <services/system/SetCode.hpp>
+#include <services/test/SetWasmConfig.hpp>
+#include <services/test/VerifyWithCall.hpp>
+#include <services/user/Sites.hpp>
+
+using namespace psibase;
+using namespace SystemService;
+using namespace TestService;
+
+int main(int argc, const char* const* argv)
+{
+   if (argc < 2)
+      return 1;
+   TestChain chain(argv[1]);
+   int       numAccounts = argc < 3 ? 32 : std::atoi(argv[2]);
+   int       numMemories = argc < 4 ? 32 : std::atoi(argv[3]);
+   chain.boot({"Minimal", "Explorer"}, true);
+
+   auto nopCode = readWholeFile("Nop.wasm");
+
+   transactor<Accounts> accounts;
+   transactor<SetCode>  setCode;
+
+   AccountNumber alice{"alice"};
+   chain.to<Accounts>().newAccount(alice, AuthAny::service, true);
+
+   expect(chain.pushTransaction(chain.makeTransaction(
+       {accounts.newAccount(SetWasmConfig::service, AuthAny::service, true),
+        setCode.from(SetWasmConfig::service)
+            .setCode(SetWasmConfig::service, 0, 0, readWholeFile("SetWasmConfig.wasm")),
+        setCode.setFlags(SetWasmConfig::service, SetWasmConfig::flags)})));
+
+   expect(chain.pushTransaction(chain.makeTransaction(
+       {accounts.newAccount(VerifyWithCall::service, AuthAny::service, true),
+        setCode.from(VerifyWithCall::service)
+            .setCode(VerifyWithCall::service, 0, 0, readWholeFile("VerifyWithCall.wasm")),
+        setCode.setFlags(VerifyWithCall::service, VerifyWithCall::flags)})));
+
+   std::vector<Action> sigdata;
+   for (auto i : std::views::iota(0, numAccounts))
+   {
+      AccountNumber account{"nop" + std::to_string(i)};
+
+      transactor<SetCode> setFlags{SetCode::service, SetCode::service};
+
+      expect(chain.pushTransaction(
+          chain.makeTransaction({accounts.newAccount(account, AuthAny::service, true),
+                                 setCode.from(account).setCode(account, 0, 0, nopCode),
+                                 setCode.setFlags(account, VerifyWithCall::flags)})));
+      sigdata.push_back({.sender = VerifyWithCall::service, .service = account});
+   }
+
+   auto sign = [result = psio::to_frac(sigdata)](std::span<const char>) { return result; };
+
+   chain.setAutoBlockStart(false);
+   chain.startBlock();
+   chain.startBlock();
+   auto prod =
+       chain.kvGet<StatusRow>(StatusRow::db, statusKey()).value().head.value().header.producer;
+   expect(chain.to<Producers>()
+              .setProducers(std::vector{Producer{prod, Claim{.service = VerifyWithCall::service}}})
+              .trace());
+   auto wasmConfig =
+       chain.kvGet<WasmConfigRow>(WasmConfigRow::db, WasmConfigRow::key(proofWasmConfigTable))
+           .value_or(WasmConfigRow{});
+   wasmConfig.numExecutionMemories = numMemories;
+   expect(chain.to<SetWasmConfig>().setWasmCfg(proofWasmConfigTable, wasmConfig).trace());
+   chain.startBlock();
+   chain.startBlock();
+   chain.finishBlock(sign);
+   chain.startBlock();
+   std::string_view content{"Lorem ipsum dolor sit amet"};
+   chain.from(alice).to<Sites>().storeSys("/file.txt", "text/plain", std::nullopt,
+                                          std::vector<char>{content.begin(), content.end()});
+   chain.finishBlock();
+}

--- a/services/psibase_tests/src/SetWasmConfig.cpp
+++ b/services/psibase_tests/src/SetWasmConfig.cpp
@@ -1,0 +1,14 @@
+#include <services/test/SetWasmConfig.hpp>
+
+#include <psibase/dispatch.hpp>
+
+using namespace psibase;
+using namespace TestService;
+
+void SetWasmConfig::setWasmCfg(NativeTableNum table, WasmConfigRow row)
+{
+   check(getSender() == getReceiver(), "Wrong sender");
+   psibase::kvPut(WasmConfigRow::db, row.key(table), row);
+}
+
+PSIBASE_DISPATCH(SetWasmConfig)

--- a/services/psibase_tests/src/VerifyWithCall.cpp
+++ b/services/psibase_tests/src/VerifyWithCall.cpp
@@ -1,0 +1,20 @@
+#include <services/test/VerifyWithCall.hpp>
+
+#include <psibase/dispatch.hpp>
+
+using namespace psibase;
+using namespace TestService;
+
+void VerifyWithCall::verifySys(Checksum256 transactionHash, Claim claim, std::vector<char> proof)
+{
+   if (!proof.empty())
+   {
+      auto nested = psio::from_frac<std::vector<Action>>(proof);
+      for (const auto& action : nested)
+      {
+         call(action);
+      }
+   }
+}
+
+PSIBASE_DISPATCH(VerifyWithCall)

--- a/services/system/Producers/src/Producers.cpp
+++ b/services/system/Producers/src/Producers.cpp
@@ -126,7 +126,8 @@ namespace SystemService
       check(!!status, "Missing status row");
       check(!status->consensus.next || status->consensus.next->blockNum == status->current.blockNum,
             "Consensus update pending");
-      status->consensus.next = {{std::move(consensus), status->consensus.current.services},
+      status->consensus.next = {{std::move(consensus), status->consensus.current.services,
+                                 status->consensus.current.wasmConfig},
                                 status->current.blockNum};
       psibase::kvPut(StatusRow::db, StatusRow::key(), *status);
    }
@@ -140,15 +141,16 @@ namespace SystemService
       check(!!status, "Missing status row");
       check(!status->consensus.next || status->consensus.next->blockNum == status->current.blockNum,
             "Consensus update pending");
-      status->consensus.next = {{std::visit(
-                                     [&](auto old)
-                                     {
-                                        old.producers = std::move(prods);
-                                        return ConsensusData{std::move(old)};
-                                     },
-                                     status->consensus.current.data),
-                                 status->consensus.current.services},
-                                status->current.blockNum};
+      status->consensus.next = {
+          {std::visit(
+               [&](auto old)
+               {
+                  old.producers = std::move(prods);
+                  return ConsensusData{std::move(old)};
+               },
+               status->consensus.current.data),
+           status->consensus.current.services, status->consensus.current.wasmConfig},
+          status->current.blockNum};
       psibase::kvPut(StatusRow::db, StatusRow::key(), *status);
    }
 

--- a/services/system/SetCode/src/SetCode.cpp
+++ b/services/system/SetCode/src/SetCode.cpp
@@ -1,5 +1,6 @@
 #include <psibase/dispatch.hpp>
 #include <services/system/SetCode.hpp>
+#include <services/system/Transact.hpp>
 
 using namespace psibase;
 
@@ -44,6 +45,9 @@ namespace SystemService
       {
          if (flags & CodeRow::isAuthService)
          {
+            auto status = getStatus();
+            if (status.consensus.next && status.consensus.next->blockNum != status.current.blockNum)
+               abortMessage("Cannot update verify services while a consensus update is pending");
             auto verifySeq = SetCode{}.open<VerifySequenceTable>();
             auto row       = verifySeq.get({}).value_or(VerifySequenceRow{});
             ++row.seq;

--- a/services/system/Transact/test/Transact-test.cpp
+++ b/services/system/Transact/test/Transact-test.cpp
@@ -370,6 +370,7 @@ TEST_CASE("Test push_transaction")
                            CodeRow::canSetTimeLimit, (CodeRow::isSubjective | CodeRow::allowSocket),
                            (CodeRow::isSubjective | CodeRow::allowNativeSubjective)}));
       INFO("flags: " << std::hex << flags);
+      t.startBlock();
       auto verifyFlags = t.addService(AccountNumber{"verify-flags"}, "VerifyFlagsService.wasm",
                                       flags | CodeRow::isAuthService);
       t.startBlock();


### PR DESCRIPTION
We were using either the default value or the value from the current head block inconsistently, which could cause a consensus failure.