### PR TITLE
Fix accounts app redirect url bug

### DIFF
--- a/services/system/Accounts/ui/src/hooks/useLoginDirect.ts
+++ b/services/system/Accounts/ui/src/hooks/useLoginDirect.ts
@@ -24,7 +24,8 @@ export const useLoginDirect = () =>
             console.log("returned queryToken:", queryToken);
 
             window.location.href = siblingUrl(
-                app === "homepage" ? undefined : app,
+                null,
+                app === "homepage" ? null : app,
             );
         },
     });


### PR DESCRIPTION
I broke logging in to apps other than the homepage in https://github.com/gofractally/psibase/pull/1345/files#diff-6909d350f27953d45988dce459bd487af7ff24ec0a0466c6913ffb2545ccca13

This PR fixes that.