### PR TITLE
integrate permissions plugin with package-template

### DIFF
--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/Cargo.toml.liquid
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/Cargo.toml.liquid
@@ -9,7 +9,7 @@ edition = "2021"
 publish = false
 
 [package]
-name = "{{project-name}}-pkg"   # Crate name
+name = "{{project-name}}-pkg"                      # Crate name
 description = "{{description}}"
 version.workspace = true
 rust-version.workspace = true
@@ -30,6 +30,7 @@ services = ["{{project-name}}"]
 [package.metadata.psibase.dependencies]
 HttpServer = "{{version}}"
 Sites = "{{version}}"
+Permissions = "{{version}}"
 
 [lib]
 crate-type = ["rlib"]

--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/plugin/Cargo.toml.liquid
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/plugin/Cargo.toml.liquid
@@ -24,4 +24,4 @@ world = "impl"
 [package.metadata.component.target.dependencies]
 "host:common" = { path = "../../Host/plugin/common/wit/world.wit" }
 "transact:plugin" = { path = "../../../system/Transact/plugin/wit/world.wit" }
-"sites:plugin" = { path = "../../Sites/plugin/wit/world.wit" }
+"permissions:plugin" = { path = "../../Permissions/plugin/wit/world.wit" }

--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/plugin/src/lib.rs
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/plugin/src/lib.rs
@@ -7,17 +7,38 @@ use bindings::host::common::server as CommonServer;
 use bindings::host::common::types::Error;
 use bindings::transact::plugin::intf::add_action_to_transaction;
 
+use psibase::define_trust;
 use psibase::fracpack::Pack;
 
 mod errors;
 use errors::ErrorType;
 
+define_trust! {
+    descriptions {
+        Low => "
+        Low trust grants these abilities:
+            - Reading the value of the example-thing
+        ",
+        Medium => "",
+        High => "
+        High trust grants the abilities of all lower trust levels, plus these abilities:
+            - Setting the example thing
+        ",
+    }
+    functions {
+        Low => [get_example_thing],
+        High => [set_example_thing],
+    }
+}
+
 struct {{project-name | upper_camel_case}}Plugin;
 
 impl Api for {{project-name | upper_camel_case}}Plugin {
-    fn set_example_thing(thing: String) {
+    fn set_example_thing(thing: String) -> Result<(), Error> {
+        trust::authorize(trust::FunctionName::set_example_thing)?;
         let packed_example_thing_args = {{project-name | snake_case}}::action_structs::setExampleThing { thing }.packed();
         add_action_to_transaction("setExampleThing", &packed_example_thing_args).unwrap();
+        Ok(())
     }
 }
 
@@ -34,14 +55,16 @@ struct ExampleThingResponse {
 
 impl Queries for {{project-name | upper_camel_case}}Plugin {
     fn get_example_thing() -> Result<String, Error> {
+        trust::authorize(trust::FunctionName::get_example_thing)?;
+
         let graphql_str = "query { exampleThing }";
 
         let examplething_val = serde_json::from_str::<ExampleThingResponse>(
             &CommonServer::post_graphql_get_json(&graphql_str)?,
         );
 
-        let examplething_val = examplething_val
-            .map_err(|err| ErrorType::QueryResponseParseError(err.to_string()))?;
+        let examplething_val = 
+            examplething_val.map_err(|err| ErrorType::QueryResponseParseError(err.to_string()))?;
 
         Ok(examplething_val.data.example_thing)
     }

--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/plugin/wit/impl.wit
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/plugin/wit/impl.wit
@@ -3,7 +3,7 @@ package {{project-name}}:plugin;
 world impl {
     include host:common/imports;
     include transact:plugin/imports;
-    include sites:plugin/imports;
+    include permissions:plugin/imports;
 
     export api;
     export queries;

--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/plugin/wit/world.wit
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/plugin/wit/world.wit
@@ -1,7 +1,8 @@
 package {{project-name}}:plugin;
 
 interface api {
-    set-example-thing: func(thing: string);
+    use host:common/types.{error};
+    set-example-thing: func(thing: string) -> result<_, error>;
 }
 
 interface queries {


### PR DESCRIPTION
Adds example usage of the `permissions` plugin to manage prompting the user to authorize third-party usage of a plugin on the user's behalf