### PR TITLE
Fix passing nullptr to memcmp

### DIFF
--- a/libraries/psibase/native/src/useTriedent.cpp
+++ b/libraries/psibase/native/src/useTriedent.cpp
@@ -929,7 +929,7 @@ namespace psibase
              auto found = session.get_greater_equal(impl->db(revision, db), key.string_view(),
                                                     &impl->keyBuffer, &impl->valueBuffer, nullptr);
              if (found && (impl->keyBuffer.size() < matchKeySize ||
-                           memcmp(impl->keyBuffer.data(), key.pos, matchKeySize)))
+                           (matchKeySize && memcmp(impl->keyBuffer.data(), key.pos, matchKeySize))))
                 found = false;
 
              if (auto* changes = impl->getChangeSet(db))
@@ -956,7 +956,7 @@ namespace psibase
              auto found = session.get_less_than(impl->db(revision, db), key.string_view(),
                                                 &impl->keyBuffer, &impl->valueBuffer, nullptr);
              if (found && (impl->keyBuffer.size() < matchKeySize ||
-                           memcmp(impl->keyBuffer.data(), key.pos, matchKeySize)))
+                           (matchKeySize && memcmp(impl->keyBuffer.data(), key.pos, matchKeySize))))
                 found = false;
 
              if (auto* changes = impl->getChangeSet(db))


### PR DESCRIPTION
WASM can never pass a null pointer, because what wasm considers a null pointer is seen as the beginning of its address space by native. However, the database is used directly by native as well, and the snapshot sending code does in fact use an empty key.