### PR TITLE
Move setting of CORS headers to WASM

### DIFF
--- a/libraries/psibase/common/include/psibase/Rpc.hpp
+++ b/libraries/psibase/common/include/psibase/Rpc.hpp
@@ -124,6 +124,7 @@ namespace psibase
 
    std::vector<HttpHeader> allowCors(std::string_view origin = "*");
    std::vector<HttpHeader> allowCors(const HttpRequest& req, AccountNumber account);
+   std::vector<HttpHeader> allowCorsSubdomains(const HttpRequest& req);
 
    using HttpReply = BasicHttpReply<std::vector<char>>;
 

--- a/libraries/psibase/common/include/psibase/Rpc.hpp
+++ b/libraries/psibase/common/include/psibase/Rpc.hpp
@@ -122,6 +122,8 @@ namespace psibase
       PSIO_REFLECT(BasicHttpReply, status, contentType, body, headers)
    };
 
+   std::vector<HttpHeader> allowCors(std::string_view methods = {});
+
    using HttpReply = BasicHttpReply<std::vector<char>>;
 
    template <typename T>

--- a/libraries/psibase/common/include/psibase/Rpc.hpp
+++ b/libraries/psibase/common/include/psibase/Rpc.hpp
@@ -122,7 +122,8 @@ namespace psibase
       PSIO_REFLECT(BasicHttpReply, status, contentType, body, headers)
    };
 
-   std::vector<HttpHeader> allowCors(std::string_view methods = {});
+   std::vector<HttpHeader> allowCors(std::string_view origin = "*");
+   std::vector<HttpHeader> allowCors(const HttpRequest& req, AccountNumber account);
 
    using HttpReply = BasicHttpReply<std::vector<char>>;
 

--- a/libraries/psibase/common/include/psibase/serveActionTemplates.hpp
+++ b/libraries/psibase/common/include/psibase/serveActionTemplates.hpp
@@ -81,6 +81,7 @@ namespace psibase
          return HttpReply{
              .contentType = "application/json",
              .body        = generateActionJsonTemplate<Service>(),
+             .headers     = allowCors(),
          };
       }
       return std::nullopt;

--- a/libraries/psibase/common/include/psibase/serveGraphQL.hpp
+++ b/libraries/psibase/common/include/psibase/serveGraphQL.hpp
@@ -41,6 +41,7 @@ namespace psibase
          return HttpReply{
              .contentType = "application/json",
              .body        = {result.data(), result.data() + result.size()},  // TODO: avoid copy
+             .headers     = allowCors(),
          };
       };
 
@@ -55,7 +56,8 @@ namespace psibase
          auto result = psio::get_gql_schema<std::remove_cvref_t<QueryRoot>>();
          return HttpReply{
              .contentType = "text",                                          // TODO
-             .body        = {result.data(), result.data() + result.size()},  // TODO: avoid copy
+             .body        = {result.data(), result.data() + result.size()},  // TODO: avoid copy,
+             .headers     = allowCors(),
          };
       }
       else if (request.method == "POST")

--- a/libraries/psibase/common/include/psibase/servePackAction.hpp
+++ b/libraries/psibase/common/include/psibase/servePackAction.hpp
@@ -86,6 +86,7 @@ namespace psibase
                return HttpReply{
                    .contentType = "application/octet-stream",
                    .body        = std::move(*result),
+                   .headers     = allowCors(),
                };
             }
          }

--- a/libraries/psibase/common/include/psibase/serveSimpleUI.hpp
+++ b/libraries/psibase/common/include/psibase/serveSimpleUI.hpp
@@ -37,6 +37,7 @@ namespace psibase
          return HttpReply{
              .contentType = "text/html",
              .body        = {simpleUIMainPage, simpleUIMainPage + strlen(simpleUIMainPage)},
+             .headers     = allowCors(),
          };
       }
       return std::nullopt;

--- a/libraries/psibase/common/src/Rpc.cpp
+++ b/libraries/psibase/common/src/Rpc.cpp
@@ -48,6 +48,35 @@ namespace
       auto size = static_cast<std::size_t>(std::ranges::distance(r));
       return std::string_view{data, size};
    }
+
+   struct Origin
+   {
+      std::string_view scheme;
+      std::string_view host;
+
+      Origin(std::string_view url)
+      {
+         auto pos = url.find("://");
+         if (pos != std::string_view::npos)
+         {
+            scheme = url.substr(0, pos);
+            host   = url.substr(pos + 3);
+            pos    = host.rfind(':');
+            if (pos != std::string_view::npos && host.find(pos, ']') == std::string_view::npos)
+               host = host.substr(0, pos);
+         }
+      }
+
+      bool isSecure() const
+      {
+         return scheme == "https" || host == "localhost" || host.ends_with(".localhost");
+      }
+
+      bool isService(const std::string& rootHost, psibase::AccountNumber account)
+      {
+         return isSecure() && account.str() + '.' + rootHost == host;
+      }
+   };
 }  // namespace
 
 namespace psibase
@@ -177,15 +206,28 @@ namespace psibase
       return false;
    }
 
-   std::vector<HttpHeader> allowCors(std::string_view methods)
+   std::vector<HttpHeader> allowCors(std::string_view origin)
    {
-      std::vector<HttpHeader> result;
-      result.push_back({"Access-Control-Allow-Origin", "*"});
-      result.push_back(
-          {"Access-Control-Allow-Methods",
-           methods.empty() ? std::string("POST, GET, OPTIONS, HEAD") : std::string(methods)});
-      result.push_back({"Access-Control-Allow-Headers", "*"});
-      return result;
+      return {
+          {"Access-Control-Allow-Origin", std::string(origin)},
+          {"Access-Control-Allow-Methods", "POST, GET, OPTIONS, HEAD"},
+          {"Access-Control-Allow-Headers", "*"},
+      };
+   }
+
+   std::vector<HttpHeader> allowCors(const HttpRequest& req, AccountNumber account)
+   {
+      if (auto origin = req.getHeader("origin");
+          origin && Origin(*origin).isService(req.rootHost, account))
+      {
+         return allowCors(*origin);
+         return {
+             {"Access-Control-Allow-Origin", std::string(*origin)},
+             {"Access-Control-Allow-Methods", "POST, GET, OPTIONS, HEAD"},
+             {"Access-Control-Allow-Headers", "*"},
+         };
+      }
+      return {};
    }
 
 }  // namespace psibase

--- a/libraries/psibase/common/src/Rpc.cpp
+++ b/libraries/psibase/common/src/Rpc.cpp
@@ -76,6 +76,11 @@ namespace
       {
          return isSecure() && account.str() + '.' + rootHost == host;
       }
+
+      bool isSubdomain(const std::string& rootHost)
+      {
+         return isSecure() && host == rootHost || host.ends_with('.' + rootHost);
+      }
    };
 }  // namespace
 
@@ -221,11 +226,16 @@ namespace psibase
           origin && Origin(*origin).isService(req.rootHost, account))
       {
          return allowCors(*origin);
-         return {
-             {"Access-Control-Allow-Origin", std::string(*origin)},
-             {"Access-Control-Allow-Methods", "POST, GET, OPTIONS, HEAD"},
-             {"Access-Control-Allow-Headers", "*"},
-         };
+      }
+      return {};
+   }
+
+   std::vector<HttpHeader> allowCorsSubdomains(const HttpRequest& req)
+   {
+      if (auto origin = req.getHeader("origin");
+          origin && Origin(*origin).isSubdomain(req.rootHost))
+      {
+         return allowCors(*origin);
       }
       return {};
    }

--- a/libraries/psibase/common/src/Rpc.cpp
+++ b/libraries/psibase/common/src/Rpc.cpp
@@ -176,4 +176,16 @@ namespace psibase
 
       return false;
    }
+
+   std::vector<HttpHeader> allowCors(std::string_view methods)
+   {
+      std::vector<HttpHeader> result;
+      result.push_back({"Access-Control-Allow-Origin", "*"});
+      result.push_back(
+          {"Access-Control-Allow-Methods",
+           methods.empty() ? std::string("POST, GET, OPTIONS, HEAD") : std::string(methods)});
+      result.push_back({"Access-Control-Allow-Headers", "*"});
+      return result;
+   }
+
 }  // namespace psibase

--- a/libraries/psibase_http/handle_request.cpp
+++ b/libraries/psibase_http/handle_request.cpp
@@ -354,9 +354,9 @@ namespace psibase::http
 
       const auto set_cors = [&server](auto& res, bool allow_cors)
       {
-         if (!server.http_config->allow_origin.empty() && allow_cors)
+         if (allow_cors)
          {
-            res.set(bhttp::field::access_control_allow_origin, server.http_config->allow_origin);
+            res.set(bhttp::field::access_control_allow_origin, "*");
             res.set(bhttp::field::access_control_allow_methods, "POST, GET, OPTIONS, HEAD");
             res.set(bhttp::field::access_control_allow_headers, "*");
          }

--- a/libraries/psibase_http/handle_request.cpp
+++ b/libraries/psibase_http/handle_request.cpp
@@ -815,8 +815,7 @@ namespace psibase::http
 
             auto socket = makeHttpSocket(
                 send,
-                [req_version, set_cors, set_keep_alive,
-                 allow_cors = service == AccountNumber{}](HttpReply&& reply)
+                [req_version, set_keep_alive](HttpReply&& reply)
                 {
                    bhttp::response<bhttp::vector_body<char>> res{
                        bhttp::int_to_status(static_cast<std::uint16_t>(reply.status)), req_version};
@@ -824,7 +823,6 @@ namespace psibase::http
                    for (auto& h : reply.headers)
                       res.set(h.name, h.value);
                    res.set(bhttp::field::content_type, reply.contentType);
-                   set_cors(res, allow_cors);
                    set_keep_alive(res);
                    res.body() = std::move(reply.body);
                    res.prepare_payload();

--- a/libraries/psibase_http/handle_request.cpp
+++ b/libraries/psibase_http/handle_request.cpp
@@ -728,11 +728,6 @@ namespace psibase::http
                }
             }
 
-            if (req.method() == bhttp::verb::options)
-            {
-               return send(ok_no_content(service == AccountNumber{}));
-            }
-
             auto        startTime = steady_clock::now();
             HttpRequest data;
             for (auto iter = req.begin(); iter != req.end(); ++iter)
@@ -756,6 +751,8 @@ namespace psibase::http
                data.method = "PUT";
             else if (req.method() == bhttp::verb::delete_)
                data.method = "DELETE";
+            else if (req.method() == bhttp::verb::options)
+               data.method = "OPTIONS";
             else
                return send(method_not_allowed(req.target(), req.method_string(),
                                               "GET, POST, OPTIONS", true));

--- a/libraries/psibase_http/include/psibase/http.hpp
+++ b/libraries/psibase_http/include/psibase/http.hpp
@@ -295,7 +295,6 @@ namespace psibase::http
       uint32_t                 num_threads      = {};
       uint32_t                 max_request_size = {};
       std::atomic<int64_t>     idle_timeout_us  = {};
-      std::string              allow_origin     = {};
       std::vector<listen_spec> listen           = {};
       std::vector<std::string> hosts            = {};
 #ifdef PSIBASE_ENABLE_SSL

--- a/packages/psibase_tests/src/AsyncQueryService.cpp
+++ b/packages/psibase_tests/src/AsyncQueryService.cpp
@@ -36,8 +36,8 @@ struct AsyncQueryService : psibase::Service
    using Subjective              = psibase::SubjectiveTables<AsyncResponseTable, CounterTable>;
    static constexpr auto service = psibase::AccountNumber{"as-query"};
    void                  onBlock();
-   auto                  serveSys(const HttpRequest&          req,
-                                  std::optional<std::int32_t> socket) -> std::optional<HttpReply>;
+   auto                  serveSys(const HttpRequest& req, std::optional<std::int32_t> socket)
+       -> std::optional<HttpReply>;
 };
 PSIO_REFLECT(AsyncQueryService, method(onBlock), method(serveSys, request, socket))
 PSIBASE_REFLECT_TABLES(AsyncQueryService, AsyncQueryService::Subjective)
@@ -101,7 +101,8 @@ std::optional<HttpReply> AsyncQueryService::serveSys(const HttpRequest&         
 {
    check(getSender() == HttpServer::service, "Wrong sender");
    check(socket.has_value(), "Missing socket");
-   auto reply         = HttpReply{.contentType = request.contentType, .body = request.body};
+   auto reply =
+       HttpReply{.contentType = request.contentType, .body = request.body, .headers = allowCors()};
    auto [path, delay] = parseQuery(request.target);
    if (path == "/send")
    {

--- a/packages/psibase_tests/src/ParallelSubjectiveService.cpp
+++ b/packages/psibase_tests/src/ParallelSubjectiveService.cpp
@@ -65,7 +65,7 @@ T convert_from_json(const std::vector<char>& data)
 template <typename T>
 HttpReply json_reply(const T& body)
 {
-   HttpReply           response{.contentType = "application/json"};
+   HttpReply           response{.contentType = "application/json", .headers = allowCors()};
    psio::vector_stream stream{response.body};
    psio::to_json(body, stream);
    return response;

--- a/packages/psibase_tests/src/SubjectiveCounterService.cpp
+++ b/packages/psibase_tests/src/SubjectiveCounterService.cpp
@@ -59,7 +59,7 @@ std::optional<HttpReply> SubjectiveCounterService::serveSys(const HttpRequest& r
          if (auto row = table.get(std::string("")))
             value = row->value;
       }
-      HttpReply           result{.contentType = "application/json"};
+      HttpReply           result{.contentType = "application/json", .headers = allowCors()};
       psio::vector_stream stream{result.body};
       psio::to_json(value, stream);
       return result;

--- a/packages/psibase_tests/src/SubjectiveDb.cpp
+++ b/packages/psibase_tests/src/SubjectiveDb.cpp
@@ -146,7 +146,7 @@ std::optional<HttpReply> SubjectiveDb::serveSys(const HttpRequest& req)
       {
          Tables{}.open<SubjectiveTable>().put(row);
       }
-      return HttpReply{};
+      return HttpReply{.headers = allowCors()};
    }
    else if (req.target == "/read")
    {
@@ -158,7 +158,7 @@ std::optional<HttpReply> SubjectiveDb::serveSys(const HttpRequest& req)
          if (auto row = Tables{}.open<SubjectiveTable>().getIndex<0>().get(key))
             result = row->value;
       }
-      HttpReply           response{.contentType = "application/json"};
+      HttpReply           response{.contentType = "application/json", .headers = allowCors()};
       psio::vector_stream stream{response.body};
       psio::to_json(result, stream);
       return response;

--- a/packages/psibase_tests/src/XSudo.cpp
+++ b/packages/psibase_tests/src/XSudo.cpp
@@ -8,7 +8,7 @@ using namespace TestService;
 std::optional<HttpReply> XSudo::serveSys(HttpRequest req)
 {
    call(psio::from_frac<Action>(req.body));
-   return HttpReply{};
+   return HttpReply{.headers = allowCors()};
 }
 
 PSIBASE_DISPATCH(XSudo)

--- a/packages/system/HttpServer/include/services/system/HttpServer.hpp
+++ b/packages/system/HttpServer/include/services/system/HttpServer.hpp
@@ -61,7 +61,7 @@ namespace SystemService
       /// Can be called inside `PSIBASE_SUBJECTIVE_TX`
       void claimReply(std::int32_t socket);
       /// Sends a reply
-      void sendReply(std::int32_t socket, const psibase::HttpReply& response);
+      void sendReply(std::int32_t socket, psibase::HttpReply response);
 
       /// Register sender's subdomain
       ///

--- a/packages/system/HttpServer/src/HttpServer.cpp
+++ b/packages/system/HttpServer/src/HttpServer.cpp
@@ -231,6 +231,10 @@ namespace SystemService
          {
             sendReplyImpl(server, sock, std::move(*result));
          }
+         else if (req.method == "OPTIONS")
+         {
+            sendReplyImpl(server, sock, {.status = HttpStatus::ok});
+         }
          else
          {
             std::string msg = "The resource '" + req.target + "' was not found";

--- a/packages/system/HttpServer/src/HttpServer.cpp
+++ b/packages/system/HttpServer/src/HttpServer.cpp
@@ -91,10 +91,14 @@ namespace SystemService
 
    namespace
    {
-      constexpr std::string_view allowedHeaders[] = {"Cache-Control",            //
-                                                     "Content-Encoding",         //
-                                                     "Content-Security-Policy",  //
-                                                     "ETag", "Set-Cookie"};
+      constexpr std::string_view allowedHeaders[] = {"Access-Control-Allow-Headers",  //
+                                                     "Access-Control-Allow-Methods",  //
+                                                     "Access-Control-Allow-Origin",   //
+                                                     "Cache-Control",                 //
+                                                     "Content-Encoding",              //
+                                                     "Content-Security-Policy",       //
+                                                     "ETag",
+                                                     "Set-Cookie"};
 
       void sendReplyImpl(AccountNumber service, std::int32_t socket, HttpReply&& result)
       {
@@ -106,10 +110,6 @@ namespace SystemService
                             header.name);
             }
          }
-
-         result.headers.push_back({"Access-Control-Allow-Origin", "*"});
-         result.headers.push_back({"Access-Control-Allow-Methods", "POST, GET, OPTIONS, HEAD"});
-         result.headers.push_back({"Access-Control-Allow-Headers", "*"});
 
          to<XHttp>().sendReply(socket, result);
       }
@@ -237,7 +237,7 @@ namespace SystemService
          }
          else if (req.method == "OPTIONS")
          {
-            sendReplyImpl(server, sock, {.status = HttpStatus::ok});
+            sendReplyImpl(server, sock, {.status = HttpStatus::ok, .headers = allowCors()});
          }
          else
          {
@@ -245,7 +245,8 @@ namespace SystemService
             sendReplyImpl(server, sock,
                           {.status      = HttpStatus::notFound,
                            .contentType = "text/html",
-                           .body        = std::vector(msg.begin(), msg.end())});
+                           .body        = std::vector(msg.begin(), msg.end()),
+                           .headers     = allowCors()});
          }
       }
    }  // serve()

--- a/packages/system/HttpServer/src/HttpServer.cpp
+++ b/packages/system/HttpServer/src/HttpServer.cpp
@@ -96,7 +96,7 @@ namespace SystemService
                                                      "Content-Security-Policy",  //
                                                      "ETag", "Set-Cookie"};
 
-      void sendReplyImpl(AccountNumber service, std::int32_t socket, const HttpReply& result)
+      void sendReplyImpl(AccountNumber service, std::int32_t socket, HttpReply&& result)
       {
          for (const auto& header : result.headers)
          {
@@ -106,6 +106,10 @@ namespace SystemService
                             header.name);
             }
          }
+
+         result.headers.push_back({"Access-Control-Allow-Origin", "*"});
+         result.headers.push_back({"Access-Control-Allow-Methods", "POST, GET, OPTIONS, HEAD"});
+         result.headers.push_back({"Access-Control-Allow-Headers", "*"});
 
          to<XHttp>().sendReply(socket, result);
       }
@@ -156,7 +160,7 @@ namespace SystemService
       }
    }
 
-   void HttpServer::sendReply(std::int32_t socket, const HttpReply& result)
+   void HttpServer::sendReply(std::int32_t socket, HttpReply result)
    {
       bool okay   = false;
       auto sender = getSender();
@@ -187,7 +191,7 @@ namespace SystemService
       {
          abortMessage(sender.str() + " cannot send a response on socket " + std::to_string(socket));
       }
-      sendReplyImpl(sender, socket, result);
+      sendReplyImpl(sender, socket, std::move(result));
    }
 
    void HttpServer::serve(std::int32_t sock, HttpRequest req)

--- a/packages/system/HttpServer/src/HttpServer.cpp
+++ b/packages/system/HttpServer/src/HttpServer.cpp
@@ -94,6 +94,7 @@ namespace SystemService
       constexpr std::string_view allowedHeaders[] = {"Access-Control-Allow-Headers",  //
                                                      "Access-Control-Allow-Methods",  //
                                                      "Access-Control-Allow-Origin",   //
+                                                     "Allow",                         //
                                                      "Cache-Control",                 //
                                                      "Content-Encoding",              //
                                                      "Content-Security-Policy",       //

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -1429,7 +1429,8 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest&  reques
          auto                token = encodeJWT(getJWTKey(), LoginTokenData{.sub = sender,
                                                                            .aud = request.rootHost,
                                                                            .exp = exp.time_since_epoch().count()});
-         HttpReply           reply{.contentType = "application/json", .headers = allowCors()};
+         HttpReply           reply{.contentType = "application/json",
+                                   .headers     = allowCors(request, AccountNumber{"supervisor"})};
          psio::vector_stream stream{reply.body};
          to_json(LoginReply{token}, stream);
          return reply;
@@ -1439,8 +1440,9 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest&  reques
    {
       check(user.has_value(), "Unauthorized");
       check(to<XAdmin>().isAdmin(*user), "Forbidden");
-      return HttpReply{
-          .contentType = "application/octet-stream", .body = getJWTKey(), .headers = allowCors()};
+      return HttpReply{.contentType = "application/octet-stream",
+                       .body        = getJWTKey(),
+                       .headers     = allowCors(request, AccountNumber{"supervisor"})};
    }
 
    return {};

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -434,9 +434,9 @@ namespace
 
       if (!jsonClients.empty())
       {
-         JsonHttpReply<TransactionTraceRef&> reply{.contentType = "application/json",
-                                                   .body{pruned}};
-         auto                                action = http.sendReply(0, reply);
+         JsonHttpReply<TransactionTraceRef&> reply{
+             .contentType = "application/json", .body{pruned}, .headers = allowCors()};
+         auto action = http.sendReply(0, reply);
 
          for (auto socket : jsonClients)
          {
@@ -447,9 +447,9 @@ namespace
 
       if (!binClients.empty())
       {
-         FracpackHttpReply<TransactionTraceRef&> reply{.contentType = "application/octet-stream",
-                                                       .body{pruned}};
-         auto                                    action = http.sendReply(0, reply);
+         FracpackHttpReply<TransactionTraceRef&> reply{
+             .contentType = "application/octet-stream", .body{pruned}, .headers = allowCors()};
+         auto action = http.sendReply(0, reply);
 
          for (auto socket : binClients)
          {
@@ -1429,7 +1429,7 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest&  reques
          auto                token = encodeJWT(getJWTKey(), LoginTokenData{.sub = sender,
                                                                            .aud = request.rootHost,
                                                                            .exp = exp.time_since_epoch().count()});
-         HttpReply           reply{.contentType = "application/json"};
+         HttpReply           reply{.contentType = "application/json", .headers = allowCors()};
          psio::vector_stream stream{reply.body};
          to_json(LoginReply{token}, stream);
          return reply;
@@ -1439,7 +1439,8 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest&  reques
    {
       check(user.has_value(), "Unauthorized");
       check(to<XAdmin>().isAdmin(*user), "Forbidden");
-      return HttpReply{.contentType = "application/octet-stream", .body = getJWTKey()};
+      return HttpReply{
+          .contentType = "application/octet-stream", .body = getJWTKey(), .headers = allowCors()};
    }
 
    return {};

--- a/packages/user/Chainmail/service/src/event_query_helpers.rs
+++ b/packages/user/Chainmail/service/src/event_query_helpers.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::helpers::validate_user;
 
 use psibase::services::r_events::Wrapper as REventsSvc;
-use psibase::{Hex, HttpReply, HttpRequest};
+use psibase::{Hex, HttpHeader, HttpReply, HttpRequest};
 
 fn build_query_by_id(params: HashMap<String, String>) -> Option<String> {
     if params.get("id").is_none() {
@@ -111,7 +111,7 @@ pub fn serve_rest_api(request: &HttpRequest) -> Option<HttpReply> {
         return Some(HttpReply {
             status: 200,
             contentType: String::from("application/json"),
-            headers: vec![],
+            headers: HttpHeader::allow_cors(),
             body: Hex(query_response.as_bytes().to_vec()),
         });
     }

--- a/packages/user/CommonApi/src/CommonApi.cpp
+++ b/packages/user/CommonApi/src/CommonApi.cpp
@@ -31,6 +31,7 @@ namespace SystemService
          return HttpReply{
              .contentType = "application/json",
              .body        = {json.begin(), json.end()},
+             .headers     = allowCors(),
          };
       };
 
@@ -58,6 +59,7 @@ namespace SystemService
             return HttpReply{
                 .contentType = "application/json",
                 .body        = {json.begin(), json.end()},
+                .headers     = allowCors(),
             };
          }
          if (request.target == "/common/chainid")
@@ -77,6 +79,7 @@ namespace SystemService
             return HttpReply{
                 .contentType = "application/octet-stream",
                 .body        = psio::convert_to_frac(trx),
+                .headers     = allowCors(),
             };
          }
          if (request.target == "/common/pack/SignedTransaction")
@@ -88,6 +91,7 @@ namespace SystemService
             return HttpReply{
                 .contentType = "application/octet-stream",
                 .body        = psio::convert_to_frac(trx),
+                .headers     = allowCors(),
             };
          }
          if (request.target == "/common/set-auth-cookie")
@@ -96,7 +100,7 @@ namespace SystemService
             psio::json_token_stream jstream{request.body.data()};
             auto                    params = psio::from_json<cookie_data>(jstream);
 
-            std::vector<HttpHeader> headers;
+            std::vector<HttpHeader> headers     = allowCors();
             bool                    isLocalhost = psibase::isLocalhost(request);
             std::string             cookieName  = "__Host-SESSION";
 

--- a/packages/user/CommonApi/src/CommonApi.cpp
+++ b/packages/user/CommonApi/src/CommonApi.cpp
@@ -100,7 +100,7 @@ namespace SystemService
             psio::json_token_stream jstream{request.body.data()};
             auto                    params = psio::from_json<cookie_data>(jstream);
 
-            std::vector<HttpHeader> headers     = allowCors();
+            std::vector<HttpHeader> headers     = allowCors(request, AccountNumber{"supervisor"});
             bool                    isLocalhost = psibase::isLocalhost(request);
             std::string             cookieName  = "__Host-SESSION";
 

--- a/packages/user/Packages/src/RPackages.cpp
+++ b/packages/user/Packages/src/RPackages.cpp
@@ -142,7 +142,10 @@ namespace UserService
             return psibase::HttpReply{
                 .contentType = "application/json",
                 .body        = std::move(result->data),
-                .headers     = {{"Content-Encoding", "gzip"}},
+                .headers     = {{"Content-Encoding", "gzip"},
+                                {"Access-Control-Allow-Origin", "*"},
+                                {"Access-Control-Allow-Methods", "GET, OPTIONS, HEAD"},
+                                {"Access-Control-Allow-Headers", "*"}},
             };
          }
       }
@@ -166,6 +169,7 @@ namespace UserService
          {
             psibase::HttpReply reply{
                 .contentType = "application/json",
+                .headers     = psibase::allowCors(),
             };
             psio::vector_stream stream{reply.body};
             psio::to_json(row->schema, stream);
@@ -178,6 +182,7 @@ namespace UserService
                 .status      = psibase::HttpStatus::notFound,
                 .contentType = "text/html",
                 .body        = {msg.begin(), msg.end()},
+                .headers     = psibase::allowCors(),
             };
          }
       }

--- a/packages/user/Sites/src/Sites.cpp
+++ b/packages/user/Sites/src/Sites.cpp
@@ -243,6 +243,7 @@ namespace SystemService
              .status      = HttpStatus::notAcceptable,
              .contentType = "text/plain",
              .body        = std::vector<char>(message.begin(), message.end()),
+             .headers     = allowCors(),
          };
       }
 
@@ -386,18 +387,21 @@ namespace SystemService
                // Chrome bug - Devtools still shows 200 status code sometimes
                return HttpReply{
                    .status  = HttpStatus::notModified,
-                   .headers = {{"ETag", etag}},
+                   .headers = {{"ETag", etag},
+                               {"Access-Control-Allow-Origin", "*"},
+                               {"Access-Control-Allow-Methods", "GET, OPTIONS, HEAD"},
+                               {"Access-Control-Allow-Headers", "*"}},
                };
             }
 
             auto reply = HttpReply{
                 .contentType = content->contentType,
-                .headers =
-                    {
-                        {"Content-Security-Policy", cspHeader},
-                        {"Cache-Control", "no-cache"},
-                        {"ETag", etag},
-                    },
+                .headers     = {{"Content-Security-Policy", cspHeader},
+                                {"Cache-Control", "no-cache"},
+                                {"ETag", etag},
+                                {"Access-Control-Allow-Origin", "*"},
+                                {"Access-Control-Allow-Methods", "GET, OPTIONS, HEAD"},
+                                {"Access-Control-Allow-Headers", "*"}},
             };
 
             if (request.method != "HEAD")

--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -1567,7 +1567,6 @@ void run(const std::string&              db_path,
       http_config->num_threads         = 4;
       http_config->max_request_size    = 20 * 1024 * 1024;
       http_config->idle_timeout_us     = http_timeout.duration.count();
-      http_config->allow_origin        = "*";
       http_config->listen              = listen;
       http_config->hosts               = hosts;
       http_config->enable_transactions = !hosts.empty();

--- a/rust/psibase/src/http.rs
+++ b/rust/psibase/src/http.rs
@@ -24,6 +24,22 @@ pub struct HttpHeader {
     pub value: String,
 }
 
+impl HttpHeader {
+    pub fn new(name: &str, value: &str) -> Self {
+        HttpHeader {
+            name: name.to_string(),
+            value: value.to_string(),
+        }
+    }
+    pub fn allow_cors() -> Vec<HttpHeader> {
+        vec![
+            HttpHeader::new("Access-Control-Allow-Origin", "*"),
+            HttpHeader::new("Access-Control-Allow-Methods", "POST, GET, OPTIONS, HEAD"),
+            HttpHeader::new("Access-Control-Allow-Headers", "*"),
+        ]
+    }
+}
+
 /// An HTTP Request
 ///
 /// Most services receive this via their [serveSys](crate::server_interface::ServerActions::serveSys)

--- a/rust/psibase/src/serve_http.rs
+++ b/rust/psibase/src/serve_http.rs
@@ -1,6 +1,6 @@
 use crate::{
-    check, generate_action_templates, HttpReply, HttpRequest, ProcessActionStruct, ToServiceSchema,
-    WithActionStruct,
+    check, generate_action_templates, HttpHeader, HttpReply, HttpRequest, ProcessActionStruct,
+    ToServiceSchema, WithActionStruct,
 };
 use async_graphql::{
     http::{receive_body, GraphiQLSource},
@@ -45,7 +45,7 @@ pub fn serve_simple_index(request: &HttpRequest) -> Option<HttpReply> {
             status: 200,
             contentType: "text/html".into(),
             body: SIMPLE_UI.to_vec().into(),
-            headers: vec![],
+            headers: HttpHeader::allow_cors(),
         })
     } else {
         None
@@ -70,7 +70,7 @@ pub fn serve_action_templates<Wrapper: ToServiceSchema>(
             status: 200,
             contentType: "text/html".into(),
             body: generate_action_templates::<Wrapper>().into(),
-            headers: vec![],
+            headers: HttpHeader::allow_cors(),
         })
     } else {
         None
@@ -108,7 +108,7 @@ pub fn serve_pack_action<Wrapper: WithActionStruct>(request: &HttpRequest) -> Op
                 status: 200,
                 contentType: "application/octet-stream".into(),
                 body: arg_struct_result.unwrap().packed().into(),
-                headers: vec![],
+                headers: HttpHeader::allow_cors(),
             }
         }
     }
@@ -149,14 +149,14 @@ pub fn serve_graphql<Query: async_graphql::ObjectType + 'static>(
                 status: 200,
                 contentType: "application/json".into(),
                 body: serde_json::to_vec(&res).unwrap().into(),
-                headers: vec![],
+                headers: HttpHeader::allow_cors(),
             })
         } else if request.method == "GET" {
             Some(HttpReply {
                 status: 200,
                 contentType: "text".into(), // TODO
                 body: schema.sdl().into_bytes().into(),
-                headers: vec![],
+                headers: HttpHeader::allow_cors(),
             })
         } else if request.contentType == "application/graphql" {
             let res = schema
@@ -166,7 +166,7 @@ pub fn serve_graphql<Query: async_graphql::ObjectType + 'static>(
                 status: 200,
                 contentType: "application/json".into(),
                 body: serde_json::to_vec(&res).unwrap().into(),
-                headers: vec![],
+                headers: HttpHeader::allow_cors(),
             })
         } else {
             let request_result = receive_body(
@@ -185,7 +185,7 @@ pub fn serve_graphql<Query: async_graphql::ObjectType + 'static>(
                 status: 200,
                 contentType: "application/json".into(),
                 body: serde_json::to_vec(&res).unwrap().into(),
-                headers: vec![],
+                headers: HttpHeader::allow_cors(),
             })
         }
     })
@@ -205,7 +205,7 @@ pub fn serve_graphiql(request: &HttpRequest) -> Option<HttpReply> {
             status: 200,
             contentType: "text/html".into(),
             body: GraphiQLSource::build().endpoint("/graphql").finish().into(),
-            headers: vec![],
+            headers: HttpHeader::allow_cors(),
         })
     } else {
         None


### PR DESCRIPTION
Most services get it automatically via serveXXX. Services that have custom endpoints need to add the headers to the response manually.

Restrict CORS for the following endpoints
- `transact/push_transaction`: any subdomain
- `transact/login`: supervisor only
- `transact/jwt_key`: supervisor only
- `/common/set-auth-cookie`: supervisor only
