### PR TITLE
Add dynamic service hooks

### DIFF
--- a/packages/system/AuthSig/plugin/src/lib.rs
+++ b/packages/system/AuthSig/plugin/src/lib.rs
@@ -24,7 +24,7 @@ use psibase::services::auth_sig::action_structs as MyService;
 // Third-party crates
 use p256::ecdsa::{signature::hazmat::PrehashSigner, Signature, SigningKey, VerifyingKey};
 use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
-use psibase::fracpack::Pack;
+use psibase::{fracpack::Pack, ActionMeta};
 use rand_core::OsRng;
 
 psibase::define_trust! {

--- a/packages/system/Producers/plugin/src/lib.rs
+++ b/packages/system/Producers/plugin/src/lib.rs
@@ -9,9 +9,7 @@ use transact::plugin::intf::add_action_to_transaction;
 use exports::producers::plugin::api::Guest as Api;
 use producers::plugin::types::*;
 
-use psibase::fracpack::Pack;
-use psibase::services;
-use psibase::AccountNumber;
+use psibase::{fracpack::Pack, services, AccountNumber, ActionMeta};
 use services::producers::action_structs as Actions;
 
 struct ProducersPlugin;

--- a/packages/system/SetCode/plugin/src/lib.rs
+++ b/packages/system/SetCode/plugin/src/lib.rs
@@ -4,7 +4,7 @@ mod bindings;
 use bindings::*;
 use exports::setcode::plugin::api::Guest as Api;
 use psibase::services::setcode::action_structs::{setCode, stageCode};
-use psibase::AccountNumber;
+use psibase::{AccountNumber, ActionMeta};
 use transact::plugin::intf::add_action_to_transaction;
 
 use psibase::fracpack::Pack;

--- a/packages/system/StagedTx/plugin/src/lib.rs
+++ b/packages/system/StagedTx/plugin/src/lib.rs
@@ -12,7 +12,7 @@ use host::common::{client as Client, server as Server};
 use host::types::types::Error;
 use psibase::fracpack::Pack;
 use psibase::services::staged_tx::action_structs::propose;
-use psibase::{AccountNumber, Checksum256, Hex, MethodNumber};
+use psibase::{AccountNumber, ActionMeta, Checksum256, Hex, MethodNumber};
 use staged_tx::action_structs::*;
 use transact::plugin::{hooks::*, intf::add_action_to_transaction};
 mod db;

--- a/packages/system/StagedTx/service/src/policy.rs
+++ b/packages/system/StagedTx/service/src/policy.rs
@@ -1,6 +1,6 @@
 use psibase::services::accounts::Wrapper as Accounts;
 use psibase::services::transact::auth_interface::auth_action_structs;
-use psibase::{AccountNumber, Caller, MethodNumber, ServiceCaller};
+use psibase::{AccountNumber, ActionMeta, Caller, MethodNumber, ServiceCaller};
 
 use crate::service::Wrapper;
 

--- a/packages/user/Evaluations/plugin/src/helpers.rs
+++ b/packages/user/Evaluations/plugin/src/helpers.rs
@@ -7,7 +7,7 @@ use crate::key_table;
 use crate::types;
 use bindings::host::common::client as Client;
 use ecies::{decrypt, encrypt};
-use psibase::{fracpack::Pack, AccountNumber};
+use psibase::{fracpack::Pack, AccountNumber, ActionMeta};
 
 use crate::bindings::host::types::types::Error;
 use crate::graphql::{fetch_and_decode, fetch_key_history, fetch_user_settings};

--- a/packages/user/Evaluations/plugin/src/lib.rs
+++ b/packages/user/Evaluations/plugin/src/lib.rs
@@ -6,7 +6,7 @@ use bindings::exports::evaluations::plugin::user::Guest as User;
 use bindings::host::types::types::Error;
 use bindings::transact::plugin::intf::add_action_to_transaction;
 
-use psibase::fracpack::Pack;
+use psibase::{fracpack::Pack, ActionMeta};
 
 pub mod consensus;
 mod errors;

--- a/packages/user/Evaluations/service/src/db.rs
+++ b/packages/user/Evaluations/service/src/db.rs
@@ -95,7 +95,10 @@ pub mod impls {
     use crate::helpers::{
         calculate_results, get_current_time_seconds, EvaluationStatus, GroupResult,
     };
-    use psibase::services::evaluations::Hooks::hooks_wrapper as EvalHooks;
+    use psibase::services::{
+        evaluations::Hooks::hooks_structs as EvalHooks, hook_handler::call_hook,
+    };
+
     use psibase::services::subgroups::Wrapper as Subgroups;
     use psibase::{AccountNumber, Table};
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -173,11 +176,14 @@ pub mod impls {
             );
 
             if use_hook {
-                EvalHooks::call_to(self.owner).on_attest(
-                    self.evaluation_id,
-                    self.group_number.unwrap(),
-                    self.user,
-                    attestation.clone(),
+                call_hook(
+                    self.owner,
+                    EvalHooks::on_attest {
+                        evaluation_id: self.evaluation_id,
+                        group_number: self.group_number.unwrap(),
+                        user: self.user,
+                        attestation: attestation.clone(),
+                    },
                 );
             }
 
@@ -251,13 +257,25 @@ pub mod impls {
 
         fn notify_register(&self, registrant: AccountNumber) {
             if self.use_hooks {
-                EvalHooks::call_to(self.owner).on_ev_reg(self.id, registrant);
+                call_hook(
+                    self.owner,
+                    EvalHooks::on_ev_reg {
+                        evaluation_id: self.id,
+                        account: registrant,
+                    },
+                );
             }
         }
 
         fn notify_unregister(&self, registrant: AccountNumber) {
             if self.use_hooks {
-                EvalHooks::call_to(self.owner).on_ev_unreg(self.id, registrant);
+                call_hook(
+                    self.owner,
+                    EvalHooks::on_ev_unreg {
+                        evaluation_id: self.id,
+                        account: registrant,
+                    },
+                );
             }
         }
 
@@ -483,10 +501,13 @@ pub mod impls {
             let parent_eval = Evaluation::get(self.owner, self.evaluation_id);
 
             if parent_eval.use_hooks {
-                EvalHooks::call_to(self.owner).on_grp_fin(
-                    self.evaluation_id,
-                    self.number,
-                    result.clone(),
+                call_hook(
+                    self.owner,
+                    EvalHooks::on_grp_fin {
+                        evaluation_id: self.evaluation_id,
+                        group_number: self.number,
+                        result: result.clone(),
+                    },
                 );
             }
 

--- a/packages/user/Evaluations/service/src/lib.rs
+++ b/packages/user/Evaluations/service/src/lib.rs
@@ -6,7 +6,9 @@ mod helpers;
 pub mod service {
     pub use crate::db::tables::*;
     use crate::helpers::{self, EvaluationStatus};
-    use psibase::services::evaluations::Hooks::hooks_wrapper as EvalHooks;
+    use psibase::services::{
+        evaluations::Hooks::hooks_structs as EvalHooks, hook_handler::call_hook,
+    };
     use psibase::*;
 
     #[event(history)]
@@ -201,7 +203,7 @@ pub mod service {
         // we delete all groups + evaluation so that any users of this service
         // have an oppurtunity to read any table data before it's dropped.
         if evaluation.use_hooks {
-            EvalHooks::call_to(evaluation.owner).on_eval_fin(evaluation_id);
+            call_hook(evaluation.owner, EvalHooks::on_eval_fin { evaluation_id });
         }
 
         evaluation.get_groups().iter().for_each(|group| {

--- a/packages/user/Fractals/plugin/src/lib.rs
+++ b/packages/user/Fractals/plugin/src/lib.rs
@@ -9,11 +9,9 @@ use bindings::exports::fractals::plugin::user::Guest as User;
 use bindings::host::types::types::Error;
 use bindings::transact::plugin::intf::add_action_to_transaction;
 
-use psibase::fracpack::Pack;
-
 mod errors;
 mod helpers;
-use psibase::AccountNumber;
+use psibase::{fracpack::Pack, AccountNumber, ActionMeta};
 
 use bindings::evaluations::plugin::admin::close;
 use bindings::evaluations::plugin::user::{

--- a/packages/user/Invite/plugin/src/lib.rs
+++ b/packages/user/Invite/plugin/src/lib.rs
@@ -36,6 +36,7 @@ use invite::plugin::{invitee::Guest as Invitee, inviter::Guest as Inviter};
 use psibase::{
     fracpack::Pack,
     services::invite::{self as InviteService, action_structs::*},
+    ActionMeta,
 };
 use rand::Rng;
 use transact::plugin::{hooks::*, intf as Transact};

--- a/packages/user/Invite/plugin_AuthInvite/src/lib.rs
+++ b/packages/user/Invite/plugin_AuthInvite/src/lib.rs
@@ -12,7 +12,7 @@ use bindings::host::common::client as Client;
 use bindings::host::types::types::Error;
 use bindings::invite::plugin::advanced::deserialize;
 use bindings::transact::plugin::{hooks::*, types::*};
-use psibase::services::invite as Invite;
+use psibase::{services::invite as Invite, ActionMeta};
 
 // Exported interfaces/types
 use bindings::exports::auth_invite::plugin::intf::Guest as Intf;

--- a/packages/user/Packages/plugin/src/lib.rs
+++ b/packages/user/Packages/plugin/src/lib.rs
@@ -24,8 +24,9 @@ use psibase::fracpack::{Pack, Unpack};
 use psibase::services::packages::PackageSource;
 use psibase::{
     get_essential_packages, make_refs, method, solve_dependencies, AccountNumber, Action,
-    EssentialServices, InstalledPackageInfo, PackageDisposition, PackageManifest, PackagedService,
-    SchemaMap, SignedTransaction, StagedUpload, Tapos, Transaction, TransactionBuilder,
+    ActionMeta, EssentialServices, InstalledPackageInfo, PackageDisposition, PackageManifest,
+    PackagedService, SchemaMap, SignedTransaction, StagedUpload, Tapos, Transaction,
+    TransactionBuilder,
 };
 
 use psibase::services::{

--- a/packages/user/Profiles/plugin/src/lib.rs
+++ b/packages/user/Profiles/plugin/src/lib.rs
@@ -1,23 +1,17 @@
 #[allow(warnings)]
 mod bindings;
 
-use bindings::exports::profiles::plugin::api::Guest as Api;
-use bindings::exports::profiles::plugin::contacts::Guest as Contacts;
-
-use bindings::exports::profiles::plugin::contacts::Contact;
-
-use bindings::profiles::plugin::types::Profile as PluginProfile;
-
-use bindings::profiles::plugin::types::Avatar;
-
-use bindings::sites::plugin::types::File;
-
 use bindings::accounts::plugin::api::{get_account, get_current_user};
+use bindings::exports::profiles::plugin::{
+    api::Guest as Api, contacts::Contact, contacts::Guest as Contacts,
+};
 use bindings::host::common::client as Client;
 use bindings::host::types::types::Error;
+use bindings::profiles::plugin::types::{Avatar, Profile as PluginProfile};
+use bindings::sites::plugin::types::File;
 use bindings::transact::plugin::intf::add_action_to_transaction;
 
-use psibase::fracpack::Pack;
+use psibase::{fracpack::Pack, ActionMeta};
 
 mod errors;
 use errors::ErrorType;

--- a/packages/user/Registry/plugin/src/lib.rs
+++ b/packages/user/Registry/plugin/src/lib.rs
@@ -8,7 +8,8 @@ use ::registry::action_structs::*;
 use bindings::registry::plugin::types::{AccountId, AppMetadata};
 use exports::registry::plugin::developer::Guest as Developer;
 use host::types::types::Error;
-use psibase::{fracpack::Pack, AccountNumber};
+use psibase::{fracpack::Pack, AccountNumber, ActionMeta};
+
 use transact::plugin::intf as Transact;
 
 struct RegistryPlugin;

--- a/packages/user/Tokens/plugin/src/lib.rs
+++ b/packages/user/Tokens/plugin/src/lib.rs
@@ -16,7 +16,7 @@ use psibase::fracpack::Pack;
 mod errors;
 use errors::ErrorType;
 use psibase::services::tokens::quantity::Quantity;
-use psibase::AccountNumber;
+use psibase::{AccountNumber, ActionMeta};
 use tokens::helpers::{identify_token_type, TokenType};
 
 pub mod query {

--- a/rust/psibase/src/service.rs
+++ b/rust/psibase/src/service.rs
@@ -83,6 +83,10 @@ pub trait WithActionStruct {
     fn with_action_struct<P: ProcessActionStruct>(action: &str, process: P) -> Option<P::Output>;
 }
 
+pub trait ActionMeta {
+    const ACTION_NAME: &'static str;
+}
+
 pub trait Caller: Clone {
     type ReturnsNothing;
     type ReturnType<T: UnpackOwned>;

--- a/rust/psibase/src/services/hook_handler.rs
+++ b/rust/psibase/src/services/hook_handler.rs
@@ -1,3 +1,66 @@
+#[macro_export]
+macro_rules! define_service_hooks {
+    ($(($parent_service:expr, $($hook_name:ident),*)),*) => {
+        #[allow(non_camel_case_types)]
+        enum ServiceHook {
+            $(
+                $(
+                    $hook_name {
+                        hook: $crate::MethodNumber,
+                        data: action_structs::$hook_name,
+                    },
+                )*
+            )*
+            Unknown,
+        }
+
+        impl ServiceHook {
+            fn new(hook_name: &str, data: &[u8]) -> Self {
+                use $crate::fracpack::Unpack;
+
+                match hook_name {
+                    $(
+                        $(
+                            action_structs::$hook_name::ACTION_NAME => {
+                                ServiceHook::$hook_name {
+                                    hook: $crate::MethodNumber::from(action_structs::$hook_name::ACTION_NAME),
+                                    data: action_structs::$hook_name::unpacked(data).unwrap(),
+                                }
+                            },
+                        )*
+                    )*
+                    _ => {
+                        ServiceHook::Unknown
+                    }
+                }
+            }
+
+            fn execute(self) {
+                let my_service = get_service();
+                let s = ServiceCaller {
+                    sender: my_service,
+                    service: my_service,
+                };
+
+                match self {
+                    $(
+                        $(
+                            ServiceHook::$hook_name { hook, data } => {
+                                $crate::check(get_sender() == $parent_service, "Invalid sender");
+                                s.call_returns_nothing(hook, data);
+                            },
+                        )*
+                    )*
+                    ServiceHook::Unknown => {
+                        // No-op instead of panic for unrecognized hooks
+                        // This allows the parent service to add new hook types without breaking child apps
+                    }
+                }
+            }
+        }
+    };
+}
+
 #[crate::service(
     name = "hook-handler",
     actions = "hook_handler_actions",

--- a/rust/psibase/src/services/hook_handler.rs
+++ b/rust/psibase/src/services/hook_handler.rs
@@ -1,0 +1,25 @@
+#[crate::service(
+    name = "hook-handler",
+    actions = "hook_handler_actions",
+    wrapper = "hook_handler_wrapper",
+    structs = "hook_handler_structs",
+    dispatch = false,
+    pub_constant = false,
+    psibase_mod = "crate"
+)]
+#[allow(non_snake_case, unused_variables)]
+pub mod HookHandler {
+    #[action]
+    fn handle_hook(hook_name: String, hook_data: Vec<u8>) {
+        unimplemented!()
+    }
+}
+
+/// Syntactic sugar for calling dynamic hooks
+pub fn call_hook<T>(service: crate::AccountNumber, data: T)
+where
+    T: fracpack::Pack + crate::ActionMeta,
+{
+    let hook_name = T::ACTION_NAME.to_string();
+    hook_handler_wrapper::call_to(service).handle_hook(hook_name, data.packed());
+}

--- a/rust/psibase/src/services/mod.rs
+++ b/rust/psibase/src/services/mod.rs
@@ -11,6 +11,7 @@ pub mod cpu_limit;
 pub mod evaluations;
 pub mod events;
 pub mod fractals;
+pub mod hook_handler;
 pub mod http_server;
 #[allow(non_snake_case)]
 pub mod invite;

--- a/rust/psibase_macros/psibase-macros-lib/src/service_macro/actions.rs
+++ b/rust/psibase_macros/psibase-macros-lib/src/service_macro/actions.rs
@@ -108,8 +108,8 @@ pub fn process_action_args(
             #struct_members
         }
 
-        impl #fn_name {
-            pub const ACTION_NAME: &'static str = stringify!(#fn_name);
+        impl #psibase_mod::ActionMeta for #fn_name {
+            const ACTION_NAME: &'static str = stringify!(#fn_name);
         }
     };
 


### PR DESCRIPTION
# Background

Sometimes a service (aka "parent service") defines a contract fulfilled by another service (aka "child service") that registers with the parent. It can then call actions defined by that interface on arbitrary child services. This could be called the "service hooks" pattern.

The issue is that once such hooks are defined, adding a new hook to the contractual interface and incorporating it into the parent service will break all child services, because the new hook has not yet been added to the child services.

The goal here is to allow for service hooks to be dynamic, so that a contractual hook interface can be updated over time without breaking children. Attempting to call a hook on a child service that is not defined should be a no-op instead of a tx failure.

# Implementation

If there was an intrinsic for checking whether an action exists on a service then I could make a special `ServiceCaller` that no-opped when the specified action dne, which I like mainly because then when the hook is called, the `getSender` would still be the parent service.

Without such an intrinsic, I think I have no choice but to call a well-known, `handle_hook` action, and pass a packed payload, and essentially implement an internal dispatcher within the `handle_hook` action that dispatches (or no-ops) to the actions defined by the hook interface. 

The main downside is that when the actual hook action is called, the caller is the child service:
```
user@parent_service->some_action
parent_service@child_service->handle_hook
child_service@child_service->hook // caller of the hook is the child_service
```

Another way to workaround this issue is if we enabled services to `run_as` their current caller as long as they are calling their own actions, but we are waiting for enabling that until after billing is implemented to ensure that doesn't introduce a vulnerability.