### PR TITLE
More registry cleanup

### DIFF
--- a/packages/user/Registry/plugin/src/lib.rs
+++ b/packages/user/Registry/plugin/src/lib.rs
@@ -5,39 +5,29 @@ use bindings::*;
 mod types;
 
 use ::registry::action_structs::*;
-use bindings::registry::plugin::types::{AccountId, AppMetadata};
+use bindings::registry::plugin::types::AppMetadata;
 use exports::registry::plugin::developer::Guest as Developer;
-use host::types::types::Error;
-use psibase::{fracpack::Pack, AccountNumber};
+use psibase::fracpack::Pack;
 use transact::plugin::intf as Transact;
 
 struct RegistryPlugin;
 
 impl Developer for RegistryPlugin {
-    fn set_app_metadata(metadata: AppMetadata) -> Result<(), Error> {
+    fn set_metadata(metadata: AppMetadata) {
         Transact::add_action_to_transaction(
             setMetadata::ACTION_NAME,
             &setMetadata::from(metadata).packed(),
         )
         .unwrap();
-        Ok(())
     }
 
-    fn publish_app(account: AccountId) -> Result<(), Error> {
-        let account_id: AccountNumber = account.parse().unwrap();
-        Transact::add_action_to_transaction(publish::ACTION_NAME, &publish { account_id }.packed())
+    fn publish() {
+        Transact::add_action_to_transaction(publish::ACTION_NAME, &publish {}.packed()).unwrap();
+    }
+
+    fn unpublish() {
+        Transact::add_action_to_transaction(unpublish::ACTION_NAME, &unpublish {}.packed())
             .unwrap();
-        Ok(())
-    }
-
-    fn unpublish_app(account: AccountId) -> Result<(), Error> {
-        let account_id: AccountNumber = account.parse().unwrap();
-        Transact::add_action_to_transaction(
-            unpublish::ACTION_NAME,
-            &unpublish { account_id }.packed(),
-        )
-        .unwrap();
-        Ok(())
     }
 }
 

--- a/packages/user/Registry/plugin/src/types.rs
+++ b/packages/user/Registry/plugin/src/types.rs
@@ -13,7 +13,6 @@ impl From<AppMetadata> for setMetadata {
             privacy_policy_subpage: metadata.privacy_policy_subpage,
             app_homepage_subpage: metadata.app_homepage_subpage,
             tags: metadata.tags,
-            redirect_uris: metadata.redirect_uris,
         }
     }
 }

--- a/packages/user/Registry/plugin/src/types.rs
+++ b/packages/user/Registry/plugin/src/types.rs
@@ -9,9 +9,6 @@ impl From<AppMetadata> for setMetadata {
             long_description: metadata.long_desc,
             icon: metadata.icon,
             icon_mime_type: metadata.icon_mime_type,
-            tos_subpage: metadata.tos_subpage,
-            privacy_policy_subpage: metadata.privacy_policy_subpage,
-            app_homepage_subpage: metadata.app_homepage_subpage,
             tags: metadata.tags,
         }
     }

--- a/packages/user/Registry/plugin/wit/world.wit
+++ b/packages/user/Registry/plugin/wit/world.wit
@@ -14,11 +14,15 @@ interface types {
     }
 }
 
+/// This is a library that can be used by some top-level app to interact with the app registry.
+/// To avoid attempting to login and submit transactions as the registry app itself, the top level
+///   app should use the StagedTx plugin to allow the user to propose transactions on behalf of an
+///   app account.
 interface developer {
     use host:types/types.{error};
     use types.{account-id, app-metadata};
 
-    /// Set the metadata for an app
+    /// Set the metadata for the caller app
     /// 
     /// Initially the app is set to draft status, but if the app is already published,
     /// it stays published, unless one of the fields in the metadata does not conform
@@ -32,21 +36,21 @@ interface developer {
     /// * `icon-mime-type` must be a valid MIME type for an icon (e.g. png, jpeg, svg, x-icon, vnd.microsoft.icon)
     /// * only three tags are allowed, and they must be lowercase alphanumeric with dashes
     /// * all the fields are optional if the app is not published
-    set-app-metadata: func(metadata: app-metadata) -> result<_, error>;
+    set-metadata: func(metadata: app-metadata);
 
-    /// Set an app to published status
+    /// Set caller app to published status
     /// 
     /// All of the metadata fields are validated, all fields are required, except for the icon.
     /// 
     /// * If the app is already published, the transaction will fail
-    publish-app: func(account: account-id) -> result<_, error>;
+    publish: func();
 
-    /// Set an app to unpublished status
+    /// Set caller app to unpublished status
     /// 
     /// No fields are validated.
     /// 
     /// * If the app is not published, the transaction will fail
-    unpublish-app: func(account: account-id) -> result<_, error>;
+    unpublish: func();
 }
 
 world imports {

--- a/packages/user/Registry/plugin/wit/world.wit
+++ b/packages/user/Registry/plugin/wit/world.wit
@@ -9,10 +9,7 @@ interface types {
         short-desc: string,
         long-desc: string,
         icon: base64-str,
-        icon-mime-type: string, 
-        tos-subpage: string,
-        privacy-policy-subpage: string,
-        app-homepage-subpage: string,
+        icon-mime-type: string,
         tags: list<string>,
     }
 }
@@ -33,7 +30,6 @@ interface developer {
     /// * `short-desc` must be between 1 and 100 characters
     /// * `long-desc` must be between 1 and 1000 characters
     /// * `icon-mime-type` must be a valid MIME type for an icon (e.g. png, jpeg, svg, x-icon, vnd.microsoft.icon)
-    /// * subpages must start with "/"
     /// * only three tags are allowed, and they must be lowercase alphanumeric with dashes
     /// * all the fields are optional if the app is not published
     set-app-metadata: func(metadata: app-metadata) -> result<_, error>;

--- a/packages/user/Registry/plugin/wit/world.wit
+++ b/packages/user/Registry/plugin/wit/world.wit
@@ -13,7 +13,6 @@ interface types {
         tos-subpage: string,
         privacy-policy-subpage: string,
         app-homepage-subpage: string,
-        redirect-uris: list<string>,
         tags: list<string>,
     }
 }

--- a/packages/user/Registry/service/src/lib.rs
+++ b/packages/user/Registry/service/src/lib.rs
@@ -36,15 +36,13 @@ pub mod service {
     }
 
     #[action]
-    fn publish(account_id: AccountNumber) {
-        check(account_id == get_sender(), "Unauthorized");
-        AppMetadata::get_assert(account_id).publish();
+    fn publish() {
+        AppMetadata::get_assert(get_sender()).publish();
     }
 
     #[action]
-    fn unpublish(account_id: AccountNumber) {
-        check(account_id == get_sender(), "Unauthorized");
-        AppMetadata::get_assert(account_id).unpublish();
+    fn unpublish() {
+        AppMetadata::get_assert(get_sender()).unpublish();
     }
 
     #[event(history)]

--- a/packages/user/Registry/service/src/lib.rs
+++ b/packages/user/Registry/service/src/lib.rs
@@ -25,7 +25,6 @@ pub mod service {
         privacy_policy_subpage: String,
         app_homepage_subpage: String,
         tags: Vec<String>,
-        redirect_uris: Vec<String>,
     ) {
         let app_metadata = AppMetadata::upsert(
             name,
@@ -36,7 +35,6 @@ pub mod service {
             tos_subpage,
             privacy_policy_subpage,
             app_homepage_subpage,
-            redirect_uris,
         );
 
         let mut tags = tags;

--- a/packages/user/Registry/service/src/lib.rs
+++ b/packages/user/Registry/service/src/lib.rs
@@ -21,9 +21,6 @@ pub mod service {
         long_description: String,
         icon: String,
         icon_mime_type: String,
-        tos_subpage: String,
-        privacy_policy_subpage: String,
-        app_homepage_subpage: String,
         tags: Vec<String>,
     ) {
         let app_metadata = AppMetadata::upsert(
@@ -32,9 +29,6 @@ pub mod service {
             long_description,
             icon,
             icon_mime_type,
-            tos_subpage,
-            privacy_policy_subpage,
-            app_homepage_subpage,
         );
 
         let mut tags = tags;

--- a/packages/user/Registry/service/src/lib.rs
+++ b/packages/user/Registry/service/src/lib.rs
@@ -44,13 +44,13 @@ pub mod service {
     #[action]
     fn publish(account_id: AccountNumber) {
         check(account_id == get_sender(), "Unauthorized");
-        AppMetadata::get(account_id).publish();
+        AppMetadata::get_assert(account_id).publish();
     }
 
     #[action]
     fn unpublish(account_id: AccountNumber) {
         check(account_id == get_sender(), "Unauthorized");
-        AppMetadata::get(account_id).unpublish();
+        AppMetadata::get_assert(account_id).unpublish();
     }
 
     #[event(history)]

--- a/packages/user/Registry/service/src/tables.rs
+++ b/packages/user/Registry/service/src/tables.rs
@@ -43,9 +43,6 @@ pub mod tables {
 
         /// The timestamp of when the app was created
         pub created_at: psibase::BlockTime,
-
-        /// The redirect URIs for the app
-        pub redirect_uris: Vec<String>,
     }
 
     #[table(name = "NextIdTable", index = 1)]
@@ -154,7 +151,6 @@ pub mod impls {
     use async_graphql::*;
     use psibase::services::transact;
     use psibase::*;
-    use url::Url;
 
     impl NextId {
         pub fn get() -> u32 {
@@ -333,13 +329,6 @@ pub mod impls {
                     "Unsupported icon MIME type",
                 );
             }
-
-            for uri in &self.redirect_uris {
-                check(
-                    Url::parse(uri).is_ok(),
-                    format!("Invalid redirect URI format: {}", uri).as_str(),
-                );
-            }
         }
 
         pub fn get(account_id: AccountNumber) -> Self {
@@ -356,7 +345,6 @@ pub mod impls {
             tos_subpage: String,
             privacy_policy_subpage: String,
             app_homepage_subpage: String,
-            redirect_uris: Vec<String>,
         ) -> Self {
             let app_metadata_table = AppMetadataTable::new();
 
@@ -379,7 +367,6 @@ pub mod impls {
             } else {
                 metadata.status
             };
-            metadata.redirect_uris = redirect_uris;
 
             if is_new_app {
                 let created_at = transact::Wrapper::call().currentBlock().time;

--- a/packages/user/Registry/service/src/tables.rs
+++ b/packages/user/Registry/service/src/tables.rs
@@ -331,9 +331,15 @@ pub mod impls {
             }
         }
 
-        pub fn get(account_id: AccountNumber) -> Self {
+        pub fn get(account_id: AccountNumber) -> Option<Self> {
             let app_metadata_table = AppMetadataTable::new();
-            app_metadata_table.get_index_pk().get(&account_id).unwrap()
+            app_metadata_table.get_index_pk().get(&account_id)
+        }
+
+        pub fn get_assert(account_id: AccountNumber) -> Self {
+            let record = Self::get(account_id);
+            check(record.is_some(), "App metadata not found");
+            record.unwrap()
         }
 
         pub fn upsert(

--- a/packages/user/Registry/service/src/tables.rs
+++ b/packages/user/Registry/service/src/tables.rs
@@ -28,15 +28,6 @@ pub mod tables {
         /// The MIME type of the icon
         pub icon_mime_type: String,
 
-        /// The subpage for Terms of Service
-        pub tos_subpage: String,
-
-        /// The subpage for Privacy Policy
-        pub privacy_policy_subpage: String,
-
-        /// The subpage for the app's homepage
-        pub app_homepage_subpage: String,
-
         /// The status of the app (DRAFT, PUBLISHED, or UNPUBLISHED)
         #[graphql(skip)]
         pub status: u32,
@@ -238,13 +229,6 @@ pub mod impls {
         );
     }
 
-    fn validate_subpath(subpath_name: &str, subpath: &str) {
-        check(
-            subpath.starts_with("/"),
-            format!("{} path must start with /", subpath_name).as_str(),
-        );
-    }
-
     fn set_diff<T>(a: &[T], b: &[T]) -> Vec<T>
     where
         T: Copy + PartialEq,
@@ -313,10 +297,6 @@ pub mod impls {
             validate_length("Short description", &self.short_desc, MAX_SHORT_DESC_SIZE);
             validate_length("Long description", &self.long_desc, MAX_LONG_DESC_SIZE);
 
-            validate_subpath("TOS", &self.tos_subpage);
-            validate_subpath("Privacy policy", &self.privacy_policy_subpage);
-            validate_subpath("Homepage", &self.app_homepage_subpage);
-
             // Validate icon
             if self.icon.len() > 0 {
                 check(
@@ -348,9 +328,6 @@ pub mod impls {
             long_desc: String,
             icon: String,
             icon_mime_type: String,
-            tos_subpage: String,
-            privacy_policy_subpage: String,
-            app_homepage_subpage: String,
         ) -> Self {
             let app_metadata_table = AppMetadataTable::new();
 
@@ -365,9 +342,6 @@ pub mod impls {
             metadata.long_desc = long_desc;
             metadata.icon = icon;
             metadata.icon_mime_type = icon_mime_type;
-            metadata.tos_subpage = tos_subpage;
-            metadata.privacy_policy_subpage = privacy_policy_subpage;
-            metadata.app_homepage_subpage = app_homepage_subpage;
             metadata.status = if is_new_app {
                 app_status::DRAFT
             } else {
@@ -423,16 +397,10 @@ pub mod impls {
                 ("name", &self.name),
                 ("short_description", &self.short_desc),
                 ("long_description", &self.long_desc),
-                ("tos_subpage", &self.tos_subpage),
-                ("privacy_policy_subpage", &self.privacy_policy_subpage),
-                ("app_homepage_subpage", &self.app_homepage_subpage),
             ];
             for (name, v) in required_fields {
                 check(v.len() > 0, &format!("{} required to publish", name));
             }
-
-            // TODO: check each of those subpages exist
-            // in the caller's namespace in sites (or it must be an SPA)
 
             self.status = app_status::PUBLISHED;
             AppMetadataTable::new().put(&self).unwrap();

--- a/packages/user/Registry/service/src/tests.rs
+++ b/packages/user/Registry/service/src/tests.rs
@@ -18,9 +18,6 @@ mod tests {
             long_desc: "Super cooking app".to_string(),
             icon: "icon-as-base64".to_string(),
             icon_mime_type: "image/png".to_string(),
-            tos_subpage: "/tos".to_string(),
-            privacy_policy_subpage: "/privacy-policy".to_string(),
-            app_homepage_subpage: "/".to_string(),
         }
     }
 
@@ -43,9 +40,6 @@ mod tests {
             metadata.long_desc,
             metadata.icon,
             metadata.icon_mime_type,
-            metadata.tos_subpage,
-            metadata.privacy_policy_subpage,
-            metadata.app_homepage_subpage,
             tags,
         );
         chain.finish_block();
@@ -71,9 +65,6 @@ mod tests {
                         longDesc,
                         icon,
                         iconMimeType,
-                        tosSubpage,
-                        privacyPolicySubpage,
-                        appHomepageSubpage,
                         status,
                         createdAt,
                         tags
@@ -93,9 +84,6 @@ mod tests {
                     "longDesc": "Super cooking app",
                     "icon": "icon-as-base64",
                     "iconMimeType": "image/png",
-                    "tosSubpage": "/tos",
-                    "privacyPolicySubpage": "/privacy-policy",
-                    "appHomepageSubpage": "/",
                     "status": "Draft",
                     "createdAt": "1970-01-01T00:00:04+00:00",
                     "tags": [

--- a/packages/user/Registry/service/src/tests.rs
+++ b/packages/user/Registry/service/src/tests.rs
@@ -13,7 +13,6 @@ mod tests {
             account_id: account!("cooking"),
             status: app_status::DRAFT,
             created_at: TimePointUSec::from(0),
-            redirect_uris: vec!["http://localhost:3000/callback".to_string()],
             name: "Super Cooking App".to_string(),
             short_desc: "Alice's Cooking App".to_string(),
             long_desc: "Super cooking app".to_string(),
@@ -48,7 +47,6 @@ mod tests {
             metadata.privacy_policy_subpage,
             metadata.app_homepage_subpage,
             tags,
-            metadata.redirect_uris,
         );
         chain.finish_block();
         res
@@ -77,7 +75,6 @@ mod tests {
                         privacyPolicySubpage,
                         appHomepageSubpage,
                         status,
-                        redirectUris,
                         createdAt,
                         tags
                     }}
@@ -100,7 +97,6 @@ mod tests {
                     "privacyPolicySubpage": "/privacy-policy",
                     "appHomepageSubpage": "/",
                     "status": "Draft",
-                    "redirectUris": ["http://localhost:3000/callback"],
                     "createdAt": "1970-01-01T00:00:04+00:00",
                     "tags": [
                         "cozy",

--- a/packages/user/Workshop/plugin/src/lib.rs
+++ b/packages/user/Workshop/plugin/src/lib.rs
@@ -12,82 +12,66 @@ use exports::workshop::plugin::{
 use host::types::types::Error;
 use staged_tx::plugin::proposer::set_propose_latch;
 
-struct ProposeLatch;
-
-impl ProposeLatch {
-    fn new(app: &str) -> Self {
-        set_propose_latch(Some(app)).unwrap();
-        Self
-    }
-}
-
-impl Drop for ProposeLatch {
-    fn drop(&mut self) {
-        set_propose_latch(None).unwrap();
-    }
-}
-
 struct WorkshopPlugin;
 
 impl App for WorkshopPlugin {
     fn upload(app: String, file: File, compression_quality: u8) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
-
+        set_propose_latch(Some(&app)).unwrap();
         sites::plugin::api::upload(&file, compression_quality)
     }
 
     fn upload_tree(app: String, files: Vec<File>, compression_quality: u8) -> Result<u16, Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
 
         sites::plugin::api::upload_tree(&files, compression_quality)
     }
 
     fn enable_spa(app: String, enable: bool) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
 
         sites::plugin::api::enable_spa(enable)
     }
 
     fn set_csp(app: String, path: String, csp: String) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
         sites::plugin::api::set_csp(&path, &csp)
     }
 
     fn set_cache_mode(app: String, enable: bool) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
         sites::plugin::api::set_cache_mode(enable)
     }
 
     fn set_service_code(app: String, code: Vec<u8>) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
         setcode::plugin::api::set_service_code(&app, &code);
         Ok(())
     }
 
     fn delete_csp(app: String, path: String) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
         sites::plugin::api::delete_csp(&path)
     }
 
     fn remove(app: String, path: String) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
         sites::plugin::api::remove(&path)
     }
 }
 
 impl Mail for WorkshopPlugin {
     fn send(app: String, receiver: String, subject: String, body: String) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
         chainmail::plugin::api::send(&receiver, &subject, &body)
     }
 
     fn archive(app: String, msg_id: u64) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
         chainmail::plugin::api::archive(msg_id)
     }
 
     fn save(app: String, msg_id: u64) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
+        set_propose_latch(Some(&app)).unwrap();
         chainmail::plugin::api::save(msg_id)
     }
 }
@@ -98,19 +82,19 @@ impl Registry for WorkshopPlugin {
         Ok(())
     }
 
-    fn set_app_metadata(app: String, metadata: AppMetadata) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
-        registry::plugin::developer::set_app_metadata(&metadata)
+    fn set_app_metadata(app: String, metadata: AppMetadata) {
+        set_propose_latch(Some(&app)).unwrap();
+        registry::plugin::developer::set_metadata(&metadata);
     }
 
-    fn publish_app(app: String) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
-        registry::plugin::developer::publish_app(&app)
+    fn publish_app(app: String) {
+        set_propose_latch(Some(&app)).unwrap();
+        registry::plugin::developer::publish();
     }
 
-    fn unpublish_app(app: String) -> Result<(), Error> {
-        let _latch = ProposeLatch::new(&app);
-        registry::plugin::developer::unpublish_app(&app)
+    fn unpublish_app(app: String) {
+        set_propose_latch(Some(&app)).unwrap();
+        registry::plugin::developer::unpublish();
     }
 }
 

--- a/packages/user/Workshop/plugin/wit/world.wit
+++ b/packages/user/Workshop/plugin/wit/world.wit
@@ -9,13 +9,13 @@ interface registry {
     create-app: func(app: string) -> result<_, error>;
 
     /// Set the metadata for the specified app
-    set-app-metadata: func(app: string, metadata: app-metadata) -> result<_, error>;
+    set-app-metadata: func(app: string, metadata: app-metadata);
 
     /// Publish the specified app
-    publish-app: func(app: string) -> result<_, error>;
+    publish-app: func(app: string);
 
     /// Unpublish specified app
-    unpublish-app: func(app: string) -> result<_, error>;
+    unpublish-app: func(app: string);
 }
 
 interface app {

--- a/packages/user/Workshop/ui/src/components/metadata-form.tsx
+++ b/packages/user/Workshop/ui/src/components/metadata-form.tsx
@@ -37,9 +37,6 @@ const formSchema = z.object({
     longDesc: z.string(),
     icon: z.string(),
     iconMimeType: z.string(), // MIME type of the icon
-    tosSubpage: z.string(),
-    privacyPolicySubpage: z.string(),
-    appHomepageSubpage: z.string(),
     tags: z.string().array(), // List of tags
 });
 
@@ -56,9 +53,6 @@ const blankDefaultValues = formSchema.parse({
     longDesc: "",
     icon: "",
     iconMimeType: "",
-    tosSubpage: "",
-    privacyPolicySubpage: "",
-    appHomepageSubpage: "",
     tags: [],
 });
 
@@ -76,9 +70,6 @@ export const MetaDataForm = ({ existingValues, onSubmit }: Props) => {
             toast("Saving...");
             await onSubmit({
                 ...data,
-                tosSubpage: data.tosSubpage || "/",
-                appHomepageSubpage: data.appHomepageSubpage || "/",
-                privacyPolicySubpage: data.privacyPolicySubpage || "/",
             });
             form.reset(data);
             toast("Success", { description: `Saved changes.` });
@@ -266,66 +257,6 @@ export const MetaDataForm = ({ existingValues, onSubmit }: Props) => {
                             )}
                         />
                         <Separator />
-                        <div className="space-y-4">
-                            <h3 className="text-lg font-medium">App Pages</h3>
-                            <div className="grid gap-4 md:grid-cols-3">
-                                <FormField
-                                    control={form.control}
-                                    name="tosSubpage"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabel>
-                                                Terms of Service
-                                            </FormLabel>
-                                            <FormControl>
-                                                <Input
-                                                    required
-                                                    placeholder="/terms-of-service"
-                                                    {...field}
-                                                />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                                <FormField
-                                    control={form.control}
-                                    name="privacyPolicySubpage"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabel>
-                                                Privacy Policy
-                                            </FormLabel>
-                                            <FormControl>
-                                                <Input
-                                                    required
-                                                    placeholder="/privacy-policy"
-                                                    {...field}
-                                                />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                                <FormField
-                                    control={form.control}
-                                    name="appHomepageSubpage"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabel>App Home</FormLabel>
-                                            <FormControl>
-                                                <Input
-                                                    required
-                                                    placeholder="/"
-                                                    {...field}
-                                                />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                            </div>
-                        </div>
                         <div className="flex justify-end">
                             <Button
                                 type="submit"

--- a/packages/user/Workshop/ui/src/components/metadata-form.tsx
+++ b/packages/user/Workshop/ui/src/components/metadata-form.tsx
@@ -40,7 +40,6 @@ const formSchema = z.object({
     tosSubpage: z.string(),
     privacyPolicySubpage: z.string(),
     appHomepageSubpage: z.string(),
-    redirectUris: z.string().array(), // List of redirect URIs
     tags: z.string().array(), // List of tags
 });
 
@@ -60,7 +59,6 @@ const blankDefaultValues = formSchema.parse({
     tosSubpage: "",
     privacyPolicySubpage: "",
     appHomepageSubpage: "",
-    redirectUris: [],
     tags: [],
 });
 

--- a/packages/user/Workshop/ui/src/hooks/useAppMetadata.ts
+++ b/packages/user/Workshop/ui/src/hooks/useAppMetadata.ts
@@ -22,7 +22,6 @@ export const MetadataResponse = z.object({
             appHomepageSubpage: z.string(),
             status: z.string(),
             createdAt: z.string(),
-            redirectUris: z.array(z.string()),
             tags: z.array(z.string()),
         })
         .or(z.null()),
@@ -51,7 +50,6 @@ export const fetchMetadata = async (account: string) => {
             appHomepageSubpage
             status
             createdAt
-            redirectUris
             tags
           }
         }

--- a/packages/user/Workshop/ui/src/hooks/useAppMetadata.ts
+++ b/packages/user/Workshop/ui/src/hooks/useAppMetadata.ts
@@ -17,9 +17,6 @@ export const MetadataResponse = z.object({
             longDesc: z.string(),
             icon: z.string(),
             iconMimeType: z.string(),
-            tosSubpage: z.string(),
-            privacyPolicySubpage: z.string(),
-            appHomepageSubpage: z.string(),
             status: z.string(),
             createdAt: z.string(),
             tags: z.array(z.string()),
@@ -45,9 +42,6 @@ export const fetchMetadata = async (account: string) => {
             longDesc
             icon
             iconMimeType
-            tosSubpage
-            privacyPolicySubpage
-            appHomepageSubpage
             status
             createdAt
             tags

--- a/packages/user/Workshop/ui/src/lib/zodTypes.ts
+++ b/packages/user/Workshop/ui/src/lib/zodTypes.ts
@@ -24,15 +24,6 @@ export const Metadata = z.object({
     longDesc: z.string().max(1000),
     icon: z.string(), // Base64 string
     iconMimeType: z.string(), // MIME type of the icon
-    tosSubpage: z
-        .string()
-        .refine((val) => val.startsWith("/"), { message: "Must start with /" }),
-    privacyPolicySubpage: z
-        .string()
-        .refine((val) => val.startsWith("/"), { message: "Must start with /" }),
-    appHomepageSubpage: z
-        .string()
-        .refine((val) => val.startsWith("/"), { message: "Must start with /" }),
     tags: z.string().array().max(3),
 });
 

--- a/packages/user/Workshop/ui/src/lib/zodTypes.ts
+++ b/packages/user/Workshop/ui/src/lib/zodTypes.ts
@@ -33,7 +33,6 @@ export const Metadata = z.object({
     appHomepageSubpage: z
         .string()
         .refine((val) => val.startsWith("/"), { message: "Must start with /" }),
-    redirectUris: z.string().array(),
     tags: z.string().array().max(3),
 });
 

--- a/packages/user/Workshop/ui/src/pages/Settings.tsx
+++ b/packages/user/Workshop/ui/src/pages/Settings.tsx
@@ -66,7 +66,6 @@ export const Settings = () => {
                                           metadata.privacyPolicySubpage,
                                       appHomepageSubpage:
                                           metadata.appHomepageSubpage,
-                                      redirectUris: metadata.redirectUris,
                                       tags: metadata.tags,
                                   }
                                 : undefined

--- a/packages/user/Workshop/ui/src/pages/Settings.tsx
+++ b/packages/user/Workshop/ui/src/pages/Settings.tsx
@@ -61,11 +61,6 @@ export const Settings = () => {
                                       longDesc: metadata.longDesc,
                                       icon: metadata.icon,
                                       iconMimeType: metadata.iconMimeType,
-                                      tosSubpage: metadata.tosSubpage,
-                                      privacyPolicySubpage:
-                                          metadata.privacyPolicySubpage,
-                                      appHomepageSubpage:
-                                          metadata.appHomepageSubpage,
                                       tags: metadata.tags,
                                   }
                                 : undefined

--- a/rust/psibase/src/services/mod.rs
+++ b/rust/psibase/src/services/mod.rs
@@ -19,6 +19,7 @@ pub mod nft;
 pub mod packages;
 pub mod producers;
 pub mod r_events;
+pub mod registry;
 pub mod setcode;
 pub mod sites;
 pub mod staged_tx;

--- a/rust/psibase/src/services/registry.rs
+++ b/rust/psibase/src/services/registry.rs
@@ -8,6 +8,11 @@ mod service {
         name: String,
         short_description: String,
         long_description: String,
+        icon: String,
+        icon_mime_type: String,
+        tos_subpage: String,
+        privacy_policy_subpage: String,
+        app_homepage_subpage: String,
         tags: Vec<String>,
     ) {
         unimplemented!()

--- a/rust/psibase/src/services/registry.rs
+++ b/rust/psibase/src/services/registry.rs
@@ -1,0 +1,25 @@
+#[crate::service(name = "registry", dispatch = false, psibase_mod = "crate")]
+#[allow(non_snake_case, unused_variables)]
+mod service {
+    use crate::AccountNumber;
+
+    #[action]
+    fn setMetadata(
+        name: String,
+        short_description: String,
+        long_description: String,
+        tags: Vec<String>,
+    ) {
+        unimplemented!()
+    }
+
+    #[action]
+    fn publish(account_id: AccountNumber) {
+        unimplemented!()
+    }
+
+    #[action]
+    fn unpublish(account_id: AccountNumber) {
+        unimplemented!()
+    }
+}

--- a/rust/psibase/src/services/registry.rs
+++ b/rust/psibase/src/services/registry.rs
@@ -1,8 +1,6 @@
 #[crate::service(name = "registry", dispatch = false, psibase_mod = "crate")]
 #[allow(non_snake_case, unused_variables)]
 mod service {
-    use crate::AccountNumber;
-
     #[action]
     fn setMetadata(
         name: String,
@@ -16,12 +14,12 @@ mod service {
     }
 
     #[action]
-    fn publish(account_id: AccountNumber) {
+    fn publish() {
         unimplemented!()
     }
 
     #[action]
-    fn unpublish(account_id: AccountNumber) {
+    fn unpublish() {
         unimplemented!()
     }
 }

--- a/rust/psibase/src/services/registry.rs
+++ b/rust/psibase/src/services/registry.rs
@@ -10,9 +10,6 @@ mod service {
         long_description: String,
         icon: String,
         icon_mime_type: String,
-        tos_subpage: String,
-        privacy_policy_subpage: String,
-        app_homepage_subpage: String,
         tags: Vec<String>,
     ) {
         unimplemented!()


### PR DESCRIPTION
* Removes platform-specific items from the registry - I left icon-related items because that's useful on most platforms anyway.
  * tos-subpage
  * privacy-policy-subpage
  * app-homepage-subpage
  * redirect-uris
* Added the registry service rust bindings to psidk
* Refactored the `publish`/`unpublish` actions to assume the sender is the app being updated (same assumptions as `set-metadata`), and propagated this change to the plugin
* Couple other minor api cleanups