### PR TITLE
Add localstorage manager to supervisor

### DIFF
--- a/packages/user/Supervisor/ui/src/localStorageManager.tsx
+++ b/packages/user/Supervisor/ui/src/localStorageManager.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+
+import { chainIdPromise } from "./utils";
+
+export function LocalStorageManager() {
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [ids, setIds] = useState<string[]>([]);
+    const [currentChainId, setCurrentChainId] = useState<string | null>(null);
+
+    const getUniqueIds = (): string[] => {
+        const keys = Object.keys(localStorage);
+        const uniqueIds = new Set<string>();
+
+        keys.forEach((key) => {
+            const parts = key.split(":");
+            if (parts.length >= 1) {
+                uniqueIds.add(parts[0]);
+            }
+        });
+
+        return Array.from(uniqueIds).sort();
+    };
+
+    const toggleIdSelection = (id: string): void => {
+        setSelectedIds((prev) => {
+            const newSet = new Set(prev);
+            if (newSet.has(id)) {
+                newSet.delete(id);
+            } else {
+                newSet.add(id);
+            }
+            return newSet;
+        });
+    };
+
+    const deleteSelectedIds = (): void => {
+        const keysToDelete = Object.keys(localStorage).filter((key) => {
+            const parts = key.split(":");
+            return parts.length >= 1 && selectedIds.has(parts[0]);
+        });
+
+        keysToDelete.forEach((key) => localStorage.removeItem(key));
+        setSelectedIds(new Set());
+        setIds(getUniqueIds());
+    };
+
+    const selectAll = (): void => {
+        const idsToSelect = ids.filter((id) => id !== currentChainId);
+        setSelectedIds(new Set(idsToSelect));
+    };
+
+    const selectNone = (): void => {
+        setSelectedIds(new Set());
+    };
+
+    useEffect(() => {
+        setIds(getUniqueIds());
+    }, []);
+
+    useEffect(() => {
+        chainIdPromise.then((chainId) => {
+            setCurrentChainId(chainId);
+        });
+    }, []);
+
+    return (
+        <div style={{ padding: "20px", fontFamily: "monospace" }}>
+            <div style={{ marginBottom: "20px", display: "flex", gap: "8px" }}>
+                <button
+                    onClick={selectAll}
+                    style={{
+                        padding: "8px 16px",
+                        background: "#007bff",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "4px",
+                        cursor: "pointer",
+                    }}
+                >
+                    Select All Except Current Chain
+                </button>
+                <button
+                    onClick={selectNone}
+                    style={{
+                        padding: "8px 16px",
+                        background: "#6c757d",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "4px",
+                        cursor: "pointer",
+                    }}
+                >
+                    Select None
+                </button>
+                <button
+                    onClick={deleteSelectedIds}
+                    disabled={selectedIds.size === 0}
+                    style={{
+                        padding: "8px 16px",
+                        background: "#dc3545",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "4px",
+                        cursor:
+                            selectedIds.size === 0 ? "not-allowed" : "pointer",
+                    }}
+                >
+                    Delete Selected ({selectedIds.size})
+                </button>
+            </div>
+            <div style={{ display: "grid", gap: "8px" }}>
+                {ids.map((id) => (
+                    <label
+                        key={id}
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px",
+                            padding: "8px",
+                            border: "1px solid #ddd",
+                            borderRadius: "4px",
+                            cursor: "pointer",
+                        }}
+                    >
+                        <input
+                            type="checkbox"
+                            checked={selectedIds.has(id)}
+                            onChange={() => toggleIdSelection(id)}
+                        />
+                        <span
+                            style={{
+                                fontFamily: "monospace",
+                                color:
+                                    currentChainId === id
+                                        ? "#dc3545"
+                                        : "inherit",
+                            }}
+                        >
+                            {id}
+                            {currentChainId === id && (
+                                <span
+                                    style={{
+                                        color: "#dc3545",
+                                        marginLeft: "8px",
+                                        fontWeight: "bold",
+                                    }}
+                                >
+                                    (current chain)
+                                </span>
+                            )}
+                        </span>
+                    </label>
+                ))}
+            </div>
+            {ids.length === 0 && <p>No localStorage keys found</p>}
+        </div>
+    );
+}

--- a/packages/user/Supervisor/ui/src/main.ts
+++ b/packages/user/Supervisor/ui/src/main.ts
@@ -1,3 +1,6 @@
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+
 import {
     buildMessageSupervisorInitialized,
     isFunctionCallRequest,
@@ -7,6 +10,7 @@ import {
 import { siblingUrl } from "@psibase/common-lib/rpc";
 
 import { AppInterface } from "./appInterace";
+import { MainPage } from "./mainPage";
 import { Supervisor } from "./supervisor";
 import {
     CallHandler,
@@ -14,11 +18,9 @@ import {
     registerCallHandlers,
 } from "./windowMessaging";
 
-document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
-  <div>
-    Supervisor here
-  </div>
-`;
+const appContainer = document.querySelector<HTMLDivElement>("#app")!;
+const root = createRoot(appContainer);
+root.render(React.createElement(MainPage));
 
 const supervisor: AppInterface = new Supervisor();
 const callHandlers: CallHandler[] = [];

--- a/packages/user/Supervisor/ui/src/mainPage.tsx
+++ b/packages/user/Supervisor/ui/src/mainPage.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+
+import { LocalStorageManager } from "./localStorageManager";
+
+export function MainPage() {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const openModal = () => setIsModalOpen(true);
+    const closeModal = () => setIsModalOpen(false);
+
+    return (
+        <div style={{ padding: "20px", fontFamily: "monospace" }}>
+            <div style={{ marginBottom: "20px" }}>
+                <p
+                    style={{
+                        fontSize: "16px",
+                        lineHeight: "1.5",
+                        color: "#333",
+                    }}
+                >
+                    This app (supervisor) is intended to be embedded into an app
+                    and interacted with via window.postMessage()
+                </p>
+            </div>
+
+            <button
+                onClick={openModal}
+                style={{
+                    padding: "12px 24px",
+                    background: "#007bff",
+                    color: "white",
+                    border: "none",
+                    borderRadius: "6px",
+                    cursor: "pointer",
+                    fontSize: "16px",
+                    fontWeight: "500",
+                }}
+            >
+                LocalStorage Manager
+            </button>
+
+            {isModalOpen && (
+                <div
+                    style={{
+                        position: "fixed",
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        background: "rgba(0, 0, 0, 0.5)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        zIndex: 1000,
+                    }}
+                    onClick={closeModal}
+                >
+                    <div
+                        style={{
+                            background: "white",
+                            borderRadius: "8px",
+                            maxWidth: "90vw",
+                            maxHeight: "90vh",
+                            overflow: "auto",
+                            position: "relative",
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div
+                            style={{
+                                position: "sticky",
+                                top: 0,
+                                background: "white",
+                                padding: "16px 20px",
+                                borderBottom: "1px solid #ddd",
+                                display: "flex",
+                                justifyContent: "space-between",
+                                alignItems: "center",
+                            }}
+                        >
+                            <h2 style={{ margin: 0 }}>LocalStorage Manager</h2>
+                            <button
+                                onClick={closeModal}
+                                style={{
+                                    background: "none",
+                                    border: "none",
+                                    fontSize: "24px",
+                                    cursor: "pointer",
+                                    color: "#666",
+                                }}
+                            >
+                                ×
+                            </button>
+                        </div>
+                        <LocalStorageManager />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
Now at `supervisor.tld` there's a more helpful message than "supervisor here", namely it now says:
"This app (supervisor) is intended to be embedded into an app and interacted with via window.postMessage()"

More importantly, there's also now a button to spawn a modal that helps manage localstorage. You can quickly delete all key/value pairs in localstorage that were from old chains.

<img width="1364" height="1124" alt="image" src="https://github.com/user-attachments/assets/40298253-ab7c-44d8-b507-0c7bf89bfd46" />
