### PR TITLE
Block deeply-nested permissions requests (by default)

### DIFF
--- a/packages/user/Permissions/plugin/src/errors.rs
+++ b/packages/user/Permissions/plugin/src/errors.rs
@@ -3,4 +3,5 @@ use psibase::plugin_error;
 plugin_error! {
     pub ErrorType
     LoggedInUserDNE(caller: String, callee: String, debug_label: String) => "[{caller} -> {callee}] - {debug_label} - User must be logged in to perform this action",
+    InvalidCaller(caller: String, callee: String, debug_label: String) => "[{caller} -> {callee}] - {debug_label} - Only the active app (or 'allowed callers') can request permission.",
 }

--- a/packages/user/Permissions/plugin/wit/world.wit
+++ b/packages/user/Permissions/plugin/wit/world.wit
@@ -34,6 +34,20 @@ interface api {
     use host:types/types.{error};
     use types.{trust-level, descriptions};
 
+    /// When an app 'A' calls into an app 'B', and B calls into the permissions plugin to authorize the call,
+    ///   app A is known as the "caller" app. This plugin restricts callers so that they are either:
+    ///     * The currently active application, or
+    ///     * An explicitly set "allowed caller"
+    /// This function allows the active app to set the list of allowed callers.
+    /// It can only be called by the active app.
+    /// The list is stored permanently until deleted by the active app.
+    ///   To delete, the active app can call this function with an empty list.
+    ///
+    /// The intention behind this restriction is so that the user is only presented for requests to authorize
+    ///   apps with which they are familiar. That is why the active app is always whitelisted (the user is using
+    ///   the active app, and is therefore familiar with it). 
+    set-allowed-callers: func(callers: list<string>);
+
     /// The caller of this function (the "callee") wants to check if the user has granted the specified `caller`
     ///     a sufficient permission level to use callee's plugin on the user's behalf. If the caller has insufficient 
     ///     permission, this function will cause the user to be prompted to consider the request.


### PR DESCRIPTION
The user should only be presented for requests to authorize apps with which they are familiar. They are implicitly familiar with the app they are using (the "active app"), so that app is allowed to call plugin functions that themselves call `permissions:authorize`, but besides that, the active app has to explicitly whitelist other apps that they allow to request permissions from the user while in the context of their app.

For example:

```mermaid
sequenceDiagram

actor A as Alice
participant 1 as App 1
participant 2 as App 2
participant p as Permissions plugin

A->>1: Use the app
1->>2: Calls a function
2->>p: Does Alice trust App 1?
note over p: This request is valid.<br>Alice knows App 1 and can<br>judge trust level
```

```mermaid
sequenceDiagram

actor A as Alice
participant 1 as App 1
participant 2 as App 2
participant 3 as App 3
participant p as Permissions plugin

A->>1: Use the app
1->>2: Calls a function
2->>3: Calls another function
3--xp: Does Alice trust App 2?
note over p: This request is invalid. <br>Alice doesn't know<br>what App 2 is.
```

The second scenario above with the invalid request can be made to work if the active app first explicitly authorizes App2 with `permisisons`.

```mermaid
sequenceDiagram

actor A as Alice
participant 1 as App 1
participant 2 as App 2
participant 3 as App 3
participant p as Permissions plugin

A->>1: Use the app
1->>p: set-allowed-callers("app2")
1->>2: Calls a function
2->>3: Calls another function
3->>p: Does Alice trust App 2?
note over p: This request is valid. <br>App1 attests that Alice knows<br>App 2 and can judge trust level.
```

