### PR TITLE
Automatically adjust CFT timeout

### DIFF
--- a/libraries/net/include/psibase/auto_timeout.hpp
+++ b/libraries/net/include/psibase/auto_timeout.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <algorithm>
+
+namespace psibase::net
+{
+   // Automatically adjusts a timeout based on the observed network latency.
+   // The timeout increases by a factor of 1.5 every time it expires,
+   // but is periodically reduced if the maximum latency observed recently
+   // is significantly lower.
+   template <typename Clock>
+   class auto_timeout
+   {
+     public:
+      explicit auto_timeout(typename Clock::duration initial_value) : _current(initial_value) {}
+      void stop() {}
+      void start()
+      {
+         auto now    = Clock::now();
+         _last_reset = now;
+         _longest    = {};
+         _next_check = now + _window;
+      }
+      void reset()
+      {
+         auto now    = Clock::now();
+         _longest    = std::max(_longest, now - _last_reset);
+         _last_reset = now;
+         if (now >= _next_check)
+         {
+            _current    = std::min(_current, _longest * 2);
+            _longest    = {};
+            _next_check = now + _window;
+         }
+      }
+      void                     increase() { _current = std::min(_current * 3 / 2, _max); }
+      typename Clock::duration get() const { return _current; }
+
+     private:
+      typename Clock::duration   _current;
+      typename Clock::time_point _last_reset;
+      typename Clock::duration   _longest;
+      typename Clock::duration   _window = std::chrono::minutes(30);
+      typename Clock::duration   _max    = std::chrono::minutes(5);
+      typename Clock::time_point _next_check;
+   };
+}  // namespace psibase::net

--- a/libraries/net/include/psibase/auto_timeout.hpp
+++ b/libraries/net/include/psibase/auto_timeout.hpp
@@ -12,7 +12,10 @@ namespace psibase::net
    class auto_timeout
    {
      public:
-      explicit auto_timeout(typename Clock::duration initial_value) : _current(initial_value) {}
+      explicit auto_timeout(typename Clock::duration initial_value) : _current(initial_value)
+      {
+         start();
+      }
       void stop() {}
       void start()
       {

--- a/libraries/net/include/psibase/direct_routing.hpp
+++ b/libraries/net/include/psibase/direct_routing.hpp
@@ -85,6 +85,7 @@ namespace psibase::net
          }
          async_multicast(std::move(peers_for_producer), msg);
       }
+      bool is_reachable(producer_id prod) const { return producers.find(prod) != producers.end(); }
       struct connection;
       void connect(peer_id id)
       {

--- a/libraries/net/include/psibase/mock_routing.hpp
+++ b/libraries/net/include/psibase/mock_routing.hpp
@@ -143,6 +143,17 @@ namespace psibase::net
             }
          }
       }
+      bool is_reachable(producer_id producer) const
+      {
+         for (const auto& [id, peer] : _peers)
+         {
+            if (static_cast<Derived*>(peer.ptr)->producer_name() == producer)
+            {
+               return true;
+            }
+         }
+         return false;
+      }
       void add_peer(mock_routing* other, test::mock_clock::duration latency = {})
       {
          auto* p1 = add_peer_impl(other, latency);

--- a/libraries/net/include/psibase/shortest_path_routing.hpp
+++ b/libraries/net/include/psibase/shortest_path_routing.hpp
@@ -536,6 +536,11 @@ namespace psibase::net
          }
       }
 
+      bool is_reachable(producer_id prod) const
+      {
+         return selectedRoutes.find(prod) != selectedRoutes.end();
+      }
+
       using message_type = std::
           variant<RouteUpdateMessage, RouteSeqnoRequest, RequestRoutesMessage, RoutingEnvelope>;
 

--- a/libraries/net/test/CMakeLists.txt
+++ b/libraries/net/test/CMakeLists.txt
@@ -42,6 +42,11 @@ add_test(
     COMMAND test_consensus "[bft]"
 )
 
+set_tests_properties(
+    test_consensus test_consensus-cft test_consensus-bft
+    PROPERTIES TIMEOUT 900
+)
+
 add_executable(bft_fuzz bft_fuzz.cpp test_util.cpp fuzz.cpp)
 target_include_directories(bft_fuzz PUBLIC ../include)
 target_link_libraries(bft_fuzz PUBLIC Catch2::Catch2WithMain psibase services_system)


### PR DESCRIPTION
The network can be very unstable if the timeout is too low, but it's slow to recover when it's too high. Try to figure out a good value dynamically.