### PR TITLE
Add session databases

### DIFF
--- a/libraries/psibase/common/include/psibase/Table.hpp
+++ b/libraries/psibase/common/include/psibase/Table.hpp
@@ -1036,6 +1036,10 @@ namespace psibase
 
    /// Defines tables in the `temporary` database
    template <typename... Tables>
+   using SessionTables = DbTables<DbId::session, Tables...>;
+
+   /// Defines tables in the `temporary` database
+   template <typename... Tables>
    using TemporaryTables = DbTables<DbId::temporary, Tables...>;
 
    // An empty key that can be used for any singleton table

--- a/libraries/psibase/common/include/psibase/db.hpp
+++ b/libraries/psibase/common/include/psibase/db.hpp
@@ -145,11 +145,19 @@ namespace psibase
       /// blocks.
       nativeSubjective,
 
+      endPersistent,
+
+      /// Data that is not part of consensus and is not preserved when the server exits
+      session = endPersistent,
+
+      /// Native subjective tables that are not preserved when the server exits
+      nativeSession,
+
       endIndependent,
 
       /// Subjective tables that are local to the transaction/query/callback
       /// context.
-      temporary,
+      temporary = endIndependent,
    };
 
    inline constexpr uint32_t numChainDatabases = ((uint32_t)DbId::numChainDatabases);

--- a/libraries/psibase/common/include/psibase/nativeTables.hpp
+++ b/libraries/psibase/common/include/psibase/nativeTables.hpp
@@ -260,7 +260,7 @@ namespace psibase
       std::int32_t fd;
       SocketInfo   info;
 
-      static const auto db = psibase::DbId::nativeSubjective;
+      static const auto db = psibase::DbId::nativeSession;
       auto              key() const -> SocketKeyType;
       PSIO_REFLECT(SocketRow, fd, info)
    };
@@ -387,7 +387,7 @@ namespace psibase
    {
       std::string       name;
       std::string       value;
-      static const auto db = psibase::DbId::nativeSubjective;
+      static const auto db = psibase::DbId::nativeSession;
       auto              key() const -> EnvKeyType;
       PSIO_REFLECT(EnvRow, name, value);
    };

--- a/libraries/psibase/common/include/psibase/schema.hpp
+++ b/libraries/psibase/common/include/psibase/schema.hpp
@@ -81,8 +81,8 @@ namespace psibase
 
      private:
       template <typename M>
-      static auto makeParams(psio::SchemaBuilder&         builder,
-                             std::span<const char* const> ref) -> psio::schema_types::Object
+      static auto makeParams(psio::SchemaBuilder& builder, std::span<const char* const> ref)
+          -> psio::schema_types::Object
       {
          psio::schema_types::Object type;
          auto                       nameIter = ref.begin();
@@ -293,6 +293,8 @@ namespace psibase
             return "writeOnly";
          else if (db == DbId::subjective)
             return "subjective";
+         else if (db == DbId::session)
+            return "session";
          else
             abortMessage("db cannot be used in schema");
       }

--- a/libraries/psibase/native/include/psibase/db.hpp
+++ b/libraries/psibase/native/include/psibase/db.hpp
@@ -109,9 +109,14 @@ namespace psibase
       ConstRevisionPtr getRevision(Writer& writer, const Checksum256& blockId);
       void             removeRevisions(Writer& writer, const Checksum256& irreversible);
 
-      void kvPutSubjective(Writer& writer, std::span<const char> key, std::span<const char> value);
-      void kvRemoveSubjective(Writer& writer, std::span<const char> key);
-      std::optional<std::vector<char>> kvGetSubjective(Writer& writer, std::span<const char> key);
+      void kvPutSubjective(Writer&               writer,
+                           DbId                  db,
+                           std::span<const char> key,
+                           std::span<const char> value);
+      void kvRemoveSubjective(Writer& writer, DbId db, std::span<const char> key);
+      std::optional<std::vector<char>> kvGetSubjective(Writer&               writer,
+                                                       DbId                  db,
+                                                       std::span<const char> key);
 
       IndependentRevision getSubjective();
       bool                commitSubjective(Writer&                writer,

--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -300,7 +300,7 @@ namespace psibase
    {
       auto notifyType = NotifyType::nextTransaction;
       auto notifyData = systemContext.sharedDatabase.kvGetSubjective(
-          *writer, psio::convert_to_key(notifyKey(notifyType)));
+          *writer, DbId::nativeSubjective, psio::convert_to_key(notifyKey(notifyType)));
       if (!notifyData)
          return {};
       if (!psio::fracpack_validate<NotifyRow>(*notifyData))
@@ -370,7 +370,7 @@ namespace psibase
       std::vector<Checksum256> tokens(trx.proofs.size());
       auto                     notifyType = NotifyType::preverifyTransaction;
       auto                     notifyData = systemContext.sharedDatabase.kvGetSubjective(
-          *writer, psio::convert_to_key(notifyKey(notifyType)));
+          *writer, DbId::nativeSubjective, psio::convert_to_key(notifyKey(notifyType)));
       if (!notifyData)
          return tokens;
       if (!psio::fracpack_validate<NotifyRow>(*notifyData))
@@ -708,8 +708,9 @@ namespace psibase
       {
          ConsensusChangeRow changeRow{status->consensus.next->blockNum, current.header.commitNum,
                                       current.header.blockNum};
-         systemContext.sharedDatabase.kvPutSubjective(
-             *writer, psio::convert_to_key(changeRow.key()), psio::to_frac(changeRow));
+         systemContext.sharedDatabase.kvPutSubjective(*writer, ConsensusChangeRow::db,
+                                                      psio::convert_to_key(changeRow.key()),
+                                                      psio::to_frac(changeRow));
       }
 
       if (status->consensus.next)

--- a/libraries/psibase/native/src/NativeFunctions.cpp
+++ b/libraries/psibase/native/src/NativeFunctions.cpp
@@ -44,7 +44,8 @@ namespace psibase
                   "database access disabled during proof verification");
             return (DbId)db;
          }
-         if (db == uint32_t(DbId::subjective) || db == uint32_t(DbId::temporary))
+         if (db == uint32_t(DbId::subjective) || db == uint32_t(DbId::session) ||
+             db == uint32_t(DbId::temporary))
          {
             uint64_t prefix = self.code.codeNum.value;
             std::reverse(reinterpret_cast<char*>(&prefix), reinterpret_cast<char*>(&prefix + 1));
@@ -60,7 +61,7 @@ namespace psibase
                   "subjective databases cannot be read in a deterministic context");
             return (DbId)db;
          }
-         if (db == uint32_t(DbId::nativeSubjective))
+         if (db == uint32_t(DbId::nativeSubjective) || db == uint32_t(DbId::nativeSession))
          {
             check(isSubjectiveContext(self),
                   "subjective databases cannot be read in a deterministic context");
@@ -86,7 +87,8 @@ namespace psibase
       bool keyHasServicePrefix(uint32_t db)
       {
          return db == uint32_t(DbId::service) || db == uint32_t(DbId::writeOnly) ||
-                db == uint32_t(DbId::subjective) || db == uint32_t(DbId::temporary);
+                db == uint32_t(DbId::subjective) || db == uint32_t(DbId::session) ||
+                db == uint32_t(DbId::temporary);
       }
 
       struct Writable
@@ -106,7 +108,8 @@ namespace psibase
                   "key prefix must match service during write");
          };
 
-         if (db == uint32_t(DbId::subjective) || db == uint32_t(DbId::temporary))
+         if (db == uint32_t(DbId::subjective) || db == uint32_t(DbId::session) ||
+             db == uint32_t(DbId::temporary))
          {
             check(isSubjectiveContext(self),
                   "subjective databases cannot be written in a deterministic context");
@@ -114,7 +117,7 @@ namespace psibase
             return {(DbId)db, false, false};
          }
 
-         if (db == uint32_t(DbId::nativeSubjective))
+         if (db == uint32_t(DbId::nativeSubjective) || db == uint32_t(DbId::nativeSession))
          {
             check(isSubjectiveContext(self),
                   "subjective databases cannot be written in a deterministic context");
@@ -330,6 +333,16 @@ namespace psibase
                "ScheduledSnapshotRow has incorrect key");
       }
 
+      void verifySocketRow(psio::input_stream key, psio::input_stream value)
+      {
+         abortMessage("Socket table is read only");
+      }
+
+      void verifyEnvRow(psio::input_stream key, psio::input_stream value)
+      {
+         // Native doesn't do anything with the env table.
+      }
+
       void verifyWriteConstrained(TransactionContext&               context,
                                   psio::input_stream                key,
                                   psio::input_stream                value,
@@ -371,6 +384,20 @@ namespace psibase
             verifyCodeByHashRow(key, value);
          else if (table == runTable)
             verifySubjectiveRunTableRow(db, key, value);
+         else
+            throw std::runtime_error("Unrecognized key in nativeSubjective");
+      }
+
+      void verifyWriteSession(Database& db, psio::input_stream key, psio::input_stream value)
+      {
+         NativeTableNum table;
+         check(key.remaining() >= sizeof(table), "Unrecognized key in nativeSubjective");
+         memcpy(&table, key.pos, sizeof(table));
+         std::reverse((char*)&table, (char*)(&table + 1));
+         if (table == socketTable)
+            verifySocketRow(key, value);
+         else if (table == envTable)
+            verifyEnvRow(key, value);
          else
             throw std::runtime_error("Unrecognized key in nativeSubjective");
       }
@@ -617,6 +644,11 @@ namespace psibase
              {
                 verifyWriteSubjective(database, {key.data(), key.size()},
                                       {value.data(), value.size()});
+             }
+             else if (db == uint32_t(DbId::nativeSession))
+             {
+                verifyWriteSession(database, {key.data(), key.size()},
+                                   {value.data(), value.size()});
              }
              database.kvPutRaw(w.db, {key.data(), key.size()}, {value.data(), value.size()});
           });

--- a/libraries/psibase/native/src/Socket.cpp
+++ b/libraries/psibase/native/src/Socket.cpp
@@ -33,7 +33,7 @@ void SocketAutoCloseSet::close(Writer&                           writer,
    {
       socket->autoClose(message);
       auto key = socketKey(socket->id);
-      parent.sharedDb.kvRemoveSubjective(writer, psio::convert_to_key(key));
+      parent.sharedDb.kvRemoveSubjective(writer, SocketRow::db, psio::convert_to_key(key));
    }
    {
       std::lock_guard l{parent.mutex};
@@ -159,7 +159,7 @@ std::int32_t Sockets::send(Writer& writer, std::int32_t fd, std::span<const char
    if (p->closed)
    {
       auto key = socketKey(p->id);
-      sharedDb.kvRemoveSubjective(writer, psio::convert_to_key(key));
+      sharedDb.kvRemoveSubjective(writer, SocketRow::db, psio::convert_to_key(key));
    }
 
    p->send(buf);
@@ -199,7 +199,8 @@ void Sockets::add(Writer& writer, const std::shared_ptr<Socket>& socket, SocketA
 
    {
       SocketRow row{socket->id, socket->info()};
-      sharedDb.kvPutSubjective(writer, psio::convert_to_key(row.key()), psio::to_frac(row));
+      sharedDb.kvPutSubjective(writer, SocketRow::db, psio::convert_to_key(row.key()),
+                               psio::to_frac(row));
    }
 }
 void Sockets::set(Writer& writer, std::int32_t fd, const std::shared_ptr<Socket>& socket)
@@ -235,7 +236,8 @@ void Sockets::set(Writer& writer, std::int32_t fd, const std::shared_ptr<Socket>
    if (!existing)
    {
       SocketRow row{socket->id, socket->info()};
-      sharedDb.kvPutSubjective(writer, psio::convert_to_key(row.key()), psio::to_frac(row));
+      sharedDb.kvPutSubjective(writer, SocketRow::db, psio::convert_to_key(row.key()),
+                               psio::to_frac(row));
    }
 }
 void Sockets::remove(Writer& writer, const std::shared_ptr<Socket>& socket)
@@ -252,7 +254,7 @@ void Sockets::remove(Writer& writer, const std::shared_ptr<Socket>& socket)
    if (matched)
    {
       auto key = socketKey(socket->id);
-      sharedDb.kvRemoveSubjective(writer, psio::convert_to_key(key));
+      sharedDb.kvRemoveSubjective(writer, SocketRow::db, psio::convert_to_key(key));
    }
 }
 std::int32_t Sockets::autoClose(std::int32_t               fd,

--- a/libraries/psibase/native/src/useTriedent.cpp
+++ b/libraries/psibase/native/src/useTriedent.cpp
@@ -260,6 +260,7 @@ namespace psibase
       {
          return std::span{subjective}.subspan(0, numPersistentDatabases);
       }
+      std::span<DbPtr> session() { return std::span{subjective}.subspan(numPersistentDatabases); }
    };  // SharedDatabaseImpl
 
    SharedDatabase::SharedDatabase(const std::filesystem::path&     dir,
@@ -273,6 +274,10 @@ namespace psibase
    {
       SharedDatabase result{*this};
       result.impl = std::make_shared<SharedDatabaseImpl>(*impl);
+      for (auto& sessionRoot : result.impl->session())
+      {
+         sessionRoot.reset();
+      }
       return result;
    }
 

--- a/libraries/psibase/native/src/useTriedent.cpp
+++ b/libraries/psibase/native/src/useTriedent.cpp
@@ -182,6 +182,10 @@ namespace psibase
       std::mutex          subjectiveMutex;
       IndependentRevision subjective;
 
+      static constexpr auto numPersistentDatabases =
+          static_cast<std::uint32_t>(DbId::endPersistent) -
+          static_cast<std::uint32_t>(DbId::beginIndependent);
+
       SharedDatabaseImpl(const std::filesystem::path&     dir,
                          const triedent::database_config& config,
                          triedent::open_mode              mode)
@@ -202,8 +206,8 @@ namespace psibase
          std::vector<std::shared_ptr<triedent::root>> roots;
          if (s->get(topRoot, subjectiveKey, nullptr, &roots))
          {
-            check(roots.size() == numIndependentDatabases, "Wrong number of subjective databases");
-            for (std::size_t i = 0; i < numIndependentDatabases; ++i)
+            check(roots.size() == numPersistentDatabases, "Wrong number of subjective databases");
+            for (std::size_t i = 0; i < numPersistentDatabases; ++i)
                subjective[i] = roots[i];
          }
       }
@@ -219,10 +223,10 @@ namespace psibase
          return topRoot;
       }
 
-      auto getNativeSubjective()
+      auto getNativeSubjective(DbId db = DbId::nativeSubjective)
       {
          std::lock_guard l{subjectiveMutex};
-         return subjective[independentIndex(DbId::nativeSubjective)];
+         return subjective[independentIndex(db)];
       }
 
       auto getHead()
@@ -250,6 +254,11 @@ namespace psibase
          std::lock_guard lock{topMutex};
          session.upsert(topRoot, revisionById(blockId), r.roots);
          session.set_top_root(topRoot);
+      }
+
+      std::span<DbPtr> persistent()
+      {
+         return std::span{subjective}.subspan(0, numPersistentDatabases);
       }
    };  // SharedDatabaseImpl
 
@@ -354,29 +363,31 @@ namespace psibase
    }  // removeRevisions
 
    void SharedDatabase::kvPutSubjective(Writer&               writer,
+                                        DbId                  db,
                                         std::span<const char> key,
                                         std::span<const char> value)
    {
       std::lock_guard l{impl->subjectiveMutex};
-      writer.upsert(impl->subjective[independentIndex(DbId::nativeSubjective)], key, value);
+      writer.upsert(impl->subjective[independentIndex(db)], key, value);
       std::lock_guard lock{impl->topMutex};
-      writer.upsert(impl->topRoot, subjectiveKey, impl->subjective);
+      writer.upsert(impl->topRoot, subjectiveKey, impl->persistent());
       writer.set_top_root(impl->topRoot);
    }
 
-   void SharedDatabase::kvRemoveSubjective(Writer& writer, std::span<const char> key)
+   void SharedDatabase::kvRemoveSubjective(Writer& writer, DbId db, std::span<const char> key)
    {
       std::lock_guard l{impl->subjectiveMutex};
-      writer.remove(impl->subjective[independentIndex(DbId::nativeSubjective)], key);
+      writer.remove(impl->subjective[independentIndex(db)], key);
       std::lock_guard lock{impl->topMutex};
-      writer.upsert(impl->topRoot, subjectiveKey, impl->subjective);
+      writer.upsert(impl->topRoot, subjectiveKey, impl->persistent());
       writer.set_top_root(impl->topRoot);
    }
 
    std::optional<std::vector<char>> SharedDatabase::kvGetSubjective(Writer&               reader,
+                                                                    DbId                  db,
                                                                     std::span<const char> key)
    {
-      auto root = impl->getNativeSubjective();
+      auto root = impl->getNativeSubjective(db);
       return reader.get(root, key);
    }
 
@@ -430,7 +441,7 @@ namespace psibase
             }
          }
          std::lock_guard lock{impl->topMutex};
-         writer.upsert(impl->topRoot, subjectiveKey, impl->subjective);
+         writer.upsert(impl->topRoot, subjectiveKey, impl->persistent());
          writer.set_top_root(impl->topRoot);
       }
       return true;

--- a/packages/local/XHttp/include/services/local/XHttp.hpp
+++ b/packages/local/XHttp/include/services/local/XHttp.hpp
@@ -13,7 +13,7 @@ namespace LocalService
    {
       static constexpr auto service = psibase::AccountNumber{"x-http"};
 
-      using Subjective = psibase::SubjectiveTables<PendingRequestTable>;
+      using Session = psibase::SessionTables<PendingRequestTable>;
 
       /// Sends a message to a socket. HTTP sockets should use sendReply, instead.
       void send(std::int32_t socket, psio::view<const std::vector<char>> data);
@@ -32,5 +32,5 @@ namespace LocalService
                 method(autoClose, socket, value),
                 method(sendReply, socket, response))
 
-   PSIBASE_REFLECT_TABLES(XHttp, XHttp::Subjective)
+   PSIBASE_REFLECT_TABLES(XHttp, XHttp::Session)
 }  // namespace LocalService

--- a/packages/local/XHttp/src/XHttp.cpp
+++ b/packages/local/XHttp/src/XHttp.cpp
@@ -41,7 +41,7 @@ void XHttp::autoClose(std::int32_t socket, bool value)
    auto sender = getSender();
    PSIBASE_SUBJECTIVE_TX
    {
-      auto requests = Subjective{}.open<PendingRequestTable>();
+      auto requests = Session{}.open<PendingRequestTable>();
       auto owned    = Temporary{}.open<PendingRequestTable>();
 
       auto from = value ? &requests : &owned;

--- a/packages/system/HttpServer/include/services/system/HttpServer.hpp
+++ b/packages/system/HttpServer/include/services/system/HttpServer.hpp
@@ -50,7 +50,7 @@ namespace SystemService
       static constexpr auto homepageService  = psibase::AccountNumber("homepage");
       using Tables                           = psibase::ServiceTables<RegServTable>;
 
-      using Subjective = psibase::SubjectiveTables<PendingRequestTable>;
+      using Session = psibase::SessionTables<PendingRequestTable>;
 
       void sendProds(const psibase::Action& action);
 
@@ -89,5 +89,5 @@ namespace SystemService
                 method(recv, socket, data),
                 method(serve, socket, req))
 
-   PSIBASE_REFLECT_TABLES(HttpServer, HttpServer::Tables, HttpServer::Subjective)
+   PSIBASE_REFLECT_TABLES(HttpServer, HttpServer::Tables, HttpServer::Session)
 }  // namespace SystemService

--- a/packages/system/HttpServer/src/HttpServer.cpp
+++ b/packages/system/HttpServer/src/HttpServer.cpp
@@ -127,7 +127,7 @@ namespace SystemService
       {
          PSIBASE_SUBJECTIVE_TX
          {
-            auto requests = HttpServer::Subjective{}.open<PendingRequestTable>();
+            auto requests = HttpServer::Session{}.open<PendingRequestTable>();
             requests.put(*row);
             owned.remove(*row);
             to<XHttp>().autoClose(socket, false);
@@ -144,7 +144,7 @@ namespace SystemService
       auto sender = getSender();
       PSIBASE_SUBJECTIVE_TX
       {
-         auto requests = Subjective{}.open<PendingRequestTable>();
+         auto requests = Session{}.open<PendingRequestTable>();
          auto owned    = Temporary{}.open<PendingRequestTable>();
          auto row      = requests.get(socket);
          if (row && row->owner == sender)
@@ -178,7 +178,7 @@ namespace SystemService
       {
          PSIBASE_SUBJECTIVE_TX
          {
-            auto requests = Subjective{}.open<PendingRequestTable>();
+            auto requests = Session{}.open<PendingRequestTable>();
             auto row      = requests.get(socket);
             if (row && row->owner == sender)
             {

--- a/packages/system/Transact/include/services/system/RTransact.hpp
+++ b/packages/system/Transact/include/services/system/RTransact.hpp
@@ -237,13 +237,13 @@ namespace SystemService
       using Subjective              = psibase::SubjectiveTables<PendingTransactionTable,
                                                                 TransactionDataTable,
                                                                 AvailableSequenceTable,
-                                                                TraceClientTable,
                                                                 JWTKeyTable,
                                                                 TxFailedTable,
                                                                 UnverifiedTransactionTable,
                                                                 PendingVerifyTable,
                                                                 ReverifySignaturesTable,
                                                                 SpeculativeTransactionTable>;
+      using Session                 = psibase::DbTables<psibase::DbId::session, TraceClientTable>;
       using WriteOnly               = psibase::WriteOnlyTables<UnappliedTransactionTable,
                                                                ReversibleBlocksTable,
                                                                TxSuccessTable,
@@ -288,5 +288,8 @@ namespace SystemService
                 method(serveSys, request, socket, user),
                 method(login, rootHost),
                 method(getUser, request))
-   PSIBASE_REFLECT_TABLES(RTransact, RTransact::Subjective, RTransact::WriteOnly)
+   PSIBASE_REFLECT_TABLES(RTransact,
+                          RTransact::Subjective,
+                          RTransact::Session,
+                          RTransact::WriteOnly)
 }  // namespace SystemService

--- a/packages/system/Transact/include/services/system/RTransact.hpp
+++ b/packages/system/Transact/include/services/system/RTransact.hpp
@@ -243,7 +243,7 @@ namespace SystemService
                                                                 PendingVerifyTable,
                                                                 ReverifySignaturesTable,
                                                                 SpeculativeTransactionTable>;
-      using Session                 = psibase::DbTables<psibase::DbId::session, TraceClientTable>;
+      using Session                 = psibase::SessionTables<TraceClientTable>;
       using WriteOnly               = psibase::WriteOnlyTables<UnappliedTransactionTable,
                                                                ReversibleBlocksTable,
                                                                TxSuccessTable,

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -320,7 +320,7 @@ namespace
        -> ClaimedSockets
    {
       {
-         auto                      clients = RTransact::Subjective{}.open<TraceClientTable>();
+         auto                      clients = RTransact{}.open<TraceClientTable>();
          std::vector<std::int32_t> json_clients, bin_clients;
 
          auto socketClaimed = [&](const auto& client)
@@ -616,7 +616,7 @@ void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> 
    check(getSender() == AccountNumber{}, "Wrong sender");
    printf("trace size: %zu\n", find_view_span(trace).size());
 
-   auto clients = Subjective{}.open<TraceClientTable>();
+   auto clients = open<TraceClientTable>();
 
    bool waitForApplied = false;
    bool waitForFinal   = false;
@@ -695,7 +695,7 @@ void RTransact::onBlock()
    auto failedTxTable     = Subjective{}.open<TxFailedTable>();
    auto pendingTxTable    = Subjective{}.open<PendingTransactionTable>();
    auto dataTable         = Subjective{}.open<TransactionDataTable>();
-   auto clientTable       = Subjective{}.open<TraceClientTable>();
+   auto clientTable       = open<TraceClientTable>();
 
    // Get all successful and irreversible transactions
    auto successTxIdx = successfulTxTable.getIndex<1>();
@@ -862,7 +862,7 @@ void RTransact::onSpecTrx(std::uint64_t id, psio::view<const TransactionTrace> t
    auto                       speculative = open<SpeculativeTransactionTable>();
    auto                       unverified  = open<UnverifiedTransactionTable>();
    auto                       pending     = open<PendingTransactionTable>();
-   auto                       clients     = Subjective{}.open<TraceClientTable>();
+   auto                       clients     = open<TraceClientTable>();
    std::optional<Checksum256> errorTxId;
    std::optional<Checksum256> broadcastTxId;
    PSIBASE_SUBJECTIVE_TX
@@ -1394,7 +1394,7 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest&  reques
       bool json        = acceptJson(request.headers);
       PSIBASE_SUBJECTIVE_TX
       {
-         auto clients = Subjective{}.open<TraceClientTable>();
+         auto clients = open<TraceClientTable>();
          auto row     = clients.get(id).value_or(
              TraceClientRow{.id = id, .expiration = trx.transaction->tapos().expiration()});
          row.clients.push_back({*socket, json, query.flag()});

--- a/programs/psitest/main.cpp
+++ b/programs/psitest/main.cpp
@@ -293,8 +293,6 @@ struct test_chain
                                  std::make_shared<psibase::Sockets>(this->db)});
       state.shared_memory_cache.init(*sys);
       head = this->db.getHead();
-
-      sys->sockets->set(*writer, 0, std::make_shared<NullSocket>());
    }
 
    test_chain(::state&                         state,
@@ -303,6 +301,8 @@ struct test_chain
               triedent::open_mode              mode)
        : test_chain{state, {path, config, mode}}
    {
+      if (mode != triedent::open_mode::read_only)
+         sys->sockets->set(*writer, 0, std::make_shared<NullSocket>());
    }
 
    explicit test_chain(const test_chain& other) : test_chain{other.state, other.db.clone()} {}

--- a/programs/psitest/main.cpp
+++ b/programs/psitest/main.cpp
@@ -305,7 +305,10 @@ struct test_chain
          sys->sockets->set(*writer, 0, std::make_shared<NullSocket>());
    }
 
-   explicit test_chain(const test_chain& other) : test_chain{other.state, other.db.clone()} {}
+   explicit test_chain(const test_chain& other) : test_chain{other.state, other.db.clone()}
+   {
+      sys->sockets->set(*writer, 0, std::make_shared<NullSocket>());
+   }
 
    bool setFork(const psibase::Checksum256& id)
    {


### PR DESCRIPTION
These are used to store data that is linked to the psinode process.
- Sockets are a per-process resource, and are always closed when psinode exits. Keeping them open in wasm but transforming the response into a no-op is a bit convoluted.
- The environment can change when psinode starts. It should not be preserved.
