### PR TITLE
Transact snapshot improvements

### DIFF
--- a/packages/system/Transact/include/services/system/Transact.hpp
+++ b/packages/system/Transact/include/services/system/Transact.hpp
@@ -295,7 +295,7 @@ namespace SystemService
       ///
       /// A value of 0 will disable snapshots. This is a chain-wide
       /// setting because snapshots are signed by the block producers.
-      void setSnapTime(psibase::Seconds seconds);
+      void setSnapTime(uint32_t seconds);
 
       /// Adds a callback that will be run whenever the trigger happens.
       /// - onTransaction is run at the end of every transaction

--- a/packages/system/Transact/plugin/src/lib.rs
+++ b/packages/system/Transact/plugin/src/lib.rs
@@ -144,10 +144,7 @@ impl Intf for TransactPlugin {
 
 impl Network for TransactPlugin {
     fn set_snapshot_time(seconds: u32) -> Result<(), HostTypes::Error> {
-        let packed_args = setSnapTime {
-            seconds: Seconds::new(seconds as i64),
-        }
-        .packed();
+        let packed_args = setSnapTime { seconds }.packed();
 
         schedule_action(
             psibase::services::transact::SERVICE.to_string(),

--- a/packages/system/Transact/plugin/src/lib.rs
+++ b/packages/system/Transact/plugin/src/lib.rs
@@ -106,34 +106,39 @@ impl Hooks for TransactPlugin {
     }
 }
 
+fn schedule_action(
+    service: String,
+    method_name: String,
+    packed_args: Vec<u8>,
+) -> Result<(), HostTypes::Error> {
+    validate_action_name(&method_name)?;
+    let sender = get_action_sender(service.as_str(), method_name.as_str())?;
+
+    let action = Action {
+        sender,
+        service,
+        method: method_name,
+        raw_data: packed_args,
+    };
+
+    if let Some(plugin) = ActionAuthPlugins::get() {
+        ActionAuthPlugins::clear();
+        let plugin_ref = HostTypes::PluginRef::new(&plugin, "plugin", "transact-hook-action-auth");
+        let claims = on_action_auth_claims(plugin_ref, &action)?;
+        ActionClaims::push(plugin, claims);
+    }
+
+    CurrentActions::push(action, TxTransformLabel::get_current_label());
+
+    Ok(())
+}
+
 impl Intf for TransactPlugin {
     fn add_action_to_transaction(
         method_name: String,
         packed_args: Vec<u8>,
     ) -> Result<(), HostTypes::Error> {
-        validate_action_name(&method_name)?;
-
-        let service = Host::client::get_sender();
-        let sender = get_action_sender(service.as_str(), method_name.as_str())?;
-
-        let action = Action {
-            sender,
-            service,
-            method: method_name,
-            raw_data: packed_args,
-        };
-
-        if let Some(plugin) = ActionAuthPlugins::get() {
-            ActionAuthPlugins::clear();
-            let plugin_ref =
-                HostTypes::PluginRef::new(&plugin, "plugin", "transact-hook-action-auth");
-            let claims = on_action_auth_claims(plugin_ref, &action)?;
-            ActionClaims::push(plugin, claims);
-        }
-
-        CurrentActions::push(action, TxTransformLabel::get_current_label());
-
-        Ok(())
+        schedule_action(Host::client::get_sender(), method_name, packed_args)
     }
 }
 
@@ -144,7 +149,11 @@ impl Network for TransactPlugin {
         }
         .packed();
 
-        TransactPlugin::add_action_to_transaction(setSnapTime::ACTION_NAME.to_string(), packed_args)
+        schedule_action(
+            psibase::services::transact::SERVICE.to_string(),
+            setSnapTime::ACTION_NAME.to_string(),
+            packed_args,
+        )
     }
 }
 

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -112,7 +112,7 @@ namespace SystemService
       }
    }
 
-   void Transact::setSnapTime(psibase::Seconds seconds)
+   void Transact::setSnapTime(uint32_t seconds)
    {
       check(getSender() == getReceiver(), "Wrong sender");
       Tables tables(Transact::service);
@@ -123,9 +123,9 @@ namespace SystemService
       auto row   = table.get({});
       if (!row)
          row = {.lastSnapshot     = stat.head ? stat.head->header.time : stat.current.time,
-                .snapshotInterval = seconds};
+                .snapshotInterval = psibase::Seconds{seconds}};
       else
-         row->snapshotInterval = seconds;
+         row->snapshotInterval = psibase::Seconds{seconds};
       table.put(*row);
    }
 
@@ -337,7 +337,7 @@ namespace SystemService
                               ServiceMethod{action.service, action.method}, allowedActions,
                               std::vector<Claim>{});
          }  // if (requester != account->authService)
-      }  // if(enforceAuth)
+      }     // if(enforceAuth)
 
       for (auto& a : allowedActions)
          ++runAsMap[{action.sender, action.service, a.service, a.method}];

--- a/rust/psibase/src/services/transact.rs
+++ b/rust/psibase/src/services/transact.rs
@@ -213,7 +213,7 @@ pub mod auth_interface {
 #[allow(non_snake_case, unused_variables)]
 mod service {
     use super::CallbackType;
-    use crate::{Action, Checksum256, Hex, Seconds, Transaction};
+    use crate::{Action, Checksum256, Hex, Transaction};
     use fracpack::Nested;
 
     /// Only called once, immediately after the boot transaction.
@@ -254,7 +254,7 @@ mod service {
     /// A value of 0 will disable snapshots. This is a chain-wide
     /// setting because snapshots are signed by the block producers.
     #[action]
-    fn setSnapTime(seconds: Seconds) {
+    fn setSnapTime(seconds: u32) {
         unimplemented!()
     }
 


### PR DESCRIPTION
* Uses u32 for `setSnapTime` which ensures that it can be returned from queries as a json number instead of getting stringified.
* Adds a query for snapshot info
* Fixes transact plugin, which wasn't easily able to call tx on itself previously