### PR TITLE
Fix cft crash test

### DIFF
--- a/libraries/net/test/test_cft_consensus.cpp
+++ b/libraries/net/test/test_cft_consensus.cpp
@@ -41,7 +41,7 @@ TEST_CASE("cft crash", "[cft]")
    PSIBASE_LOG(logger, info) << "Final sync";
    // Make all nodes active
    nodes.connect_all();
-   runFor(ctx, 10s);
+   runFor(ctx, 20s);
 
    auto final_state = nodes[0].chain().get_head_state();
    // Verify that all three chains are consistent


### PR DESCRIPTION
Now that the CFT timeout increases automatically, 10 seconds is not necessarily long enough to start producing blocks again.