### PR TITLE
add debit_up_to

### DIFF
--- a/packages/user/Tokens/service/src/lib.rs
+++ b/packages/user/Tokens/service/src/lib.rs
@@ -348,7 +348,7 @@ pub mod service {
 
     /// Debit
     ///
-    /// Debits tokens from a shared balance between the creditor and the debitor (sender)
+    /// Debits exact amount of tokens from a shared balance between the creditor and the debitor (sender)
     ///
     /// By default, the debitor will automatically debit the amount towards the debitors balance.
     /// `manual_debit` can be enabled using `setBalConf` or `setUserConf`
@@ -361,6 +361,27 @@ pub mod service {
     #[action]
     fn debit(token_id: TID, creditor: AccountNumber, amount: Quantity, memo: Memo) {
         SharedBalance::get_assert(creditor, get_sender(), token_id).debit(amount, memo);
+    }
+
+    /// Debit up to
+    ///
+    /// Debits up to X amount of tokens from a shared balance between the creditor and the debitor (sender)
+    ///
+    /// Action will return the amount of tokens actually debited. Set amount to 0 for entire shared balance.
+    ///
+    /// # Arguments
+    /// * `token_id` - Unique token identifier.
+    /// * `creditor` - User which previously sent balance towards debitor (sender).
+    /// * `amount`   - Max amount to debit from shared balance, set to 0 for entire shared balance.
+    /// * `memo`     - Memo
+    #[action]
+    fn debit_up_to(
+        token_id: TID,
+        creditor: AccountNumber,
+        amount: Quantity,
+        memo: Memo,
+    ) -> Quantity {
+        SharedBalance::get_assert(creditor, get_sender(), token_id).debit_up_to(amount, memo)
     }
 
     /// Reject

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -428,6 +428,19 @@ pub mod tables {
             Balance::get_or_new(self.creditor, self.token_id).add_balance(quantity);
         }
 
+        pub fn debit_up_to(&mut self, quantity: Quantity, memo: Memo) -> Quantity {
+            let current_balance = self.balance.value;
+            let debit_amount: Quantity = if quantity.value == 0 {
+                current_balance.into()
+            } else {
+                current_balance.min(quantity.value).into()
+            };
+            if debit_amount.value > 0 {
+                self.debit(debit_amount, memo);
+            }
+            debit_amount
+        }
+
         pub fn debit(&mut self, quantity: Quantity, memo: Memo) {
             check(quantity.value > 0, "debit quantity must be greater than 0");
 

--- a/rust/psibase/src/services/tokens/mod.rs
+++ b/rust/psibase/src/services/tokens/mod.rs
@@ -131,6 +131,27 @@ mod service {
         unimplemented!()
     }
 
+    /// Debit up to
+    ///
+    /// Debits up to X amount of tokens from a shared balance between the creditor and the debitor (sender)
+    ///
+    /// Action will return the amount of tokens actually debited. Set amount to 0 for entire shared balance.
+    ///
+    /// # Arguments
+    /// * `token_id` - Unique token identifier.
+    /// * `creditor` - User which previously sent balance towards debitor (sender).
+    /// * `amount`   - Max amount to debit from shared balance, set to 0 for entire shared balance.
+    /// * `memo`     - Memo
+    #[action]
+    fn debit_up_to(
+        token_id: TID,
+        creditor: AccountNumber,
+        amount: Quantity,
+        memo: Memo,
+    ) -> Quantity {
+        unimplemented!()
+    }
+
     /// Create a new token.
     ///
     /// # Arguments


### PR DESCRIPTION
Adds `debit_up_to` action to `tokens` service.  
Useful for cases where a service wants to debit the entire balance or potential amount of from another, action returns actual amount being debited. 