### PR TITLE
fix account import permissions error

### DIFF
--- a/packages/system/AuthSig/plugin/src/lib.rs
+++ b/packages/system/AuthSig/plugin/src/lib.rs
@@ -156,7 +156,10 @@ impl KeyVault for AuthSig {
     }
 
     fn import_key(private_key: Pem) -> Result<Pem, CommonTypes::Error> {
-        assert_authorized_with_whitelist(FunctionName::import_key, vec!["x-admin".into()])?;
+        assert_authorized_with_whitelist(
+            FunctionName::import_key,
+            vec!["accounts".into(), "x-admin".into()],
+        )?;
 
         let public_key = AuthSig::pub_from_priv(private_key.clone())?;
         ManagedKeys::add(&public_key, &AuthSig::to_der(private_key)?);


### PR DESCRIPTION
`accounts` should be in the `auth-sig` whitelist for `import`. Otherwise, `auth-sig` will ask the user for permission on account import, and on a new device where the user isn't logged in, there is no user to authorize the `permissions` prompt and account import is therefore impossible.