### PR TITLE
Simplify token stream tests

### DIFF
--- a/packages/user/TokenStream/service/src/tests.rs
+++ b/packages/user/TokenStream/service/src/tests.rs
@@ -68,40 +68,6 @@ mod tests {
         token_id
     }
 
-    // λ = ln(2) / half_life_seconds
-    fn rate(half_life_seconds: u32) -> f64 {
-        std::f64::consts::LN_2 / half_life_seconds as f64
-    }
-
-    // Δt > (1/λ) * ln(P(0))
-    pub fn full_vesting_time(half_life_seconds: u32, balance: u64) -> i64 {
-        if balance == 0 {
-            return 0;
-        }
-
-        let factor = 1.0 / rate(half_life_seconds);
-        let t = factor * ((balance as f64).ln());
-
-        t.ceil() as i64
-    }
-
-    fn reset_clock(chain: &psibase::Chain) {
-        let time: i64 = 1000;
-        chain.start_block_at(TimePointSec { seconds: time }.microseconds());
-    }
-
-    fn create_stream(
-        chain: &psibase::Chain,
-        author: AccountNumber,
-        half_life_seconds: u32,
-        token_id: u32,
-    ) -> u32 {
-        TokenStream::push_from(&chain, author)
-            .create(half_life_seconds, token_id)
-            .get()
-            .unwrap()
-    }
-
     struct TestHelper {
         chain: psibase::Chain,
         token_id: u32,
@@ -168,6 +134,40 @@ mod tests {
         fn pass_time(&self, seconds: i64) {
             self.chain.start_block_after(Seconds::new(seconds).into());
         }
+    }
+
+    // λ = ln(2) / half_life_seconds
+    fn rate(half_life_seconds: u32) -> f64 {
+        std::f64::consts::LN_2 / half_life_seconds as f64
+    }
+
+    // Δt > (1/λ) * ln(P(0))
+    pub fn full_vesting_time(half_life_seconds: u32, balance: u64) -> i64 {
+        if balance == 0 {
+            return 0;
+        }
+
+        let factor = 1.0 / rate(half_life_seconds);
+        let t = factor * ((balance as f64).ln());
+
+        t.ceil() as i64
+    }
+
+    fn reset_clock(chain: &psibase::Chain) {
+        let time: i64 = 1000;
+        chain.start_block_at(TimePointSec { seconds: time }.microseconds());
+    }
+
+    fn create_stream(
+        chain: &psibase::Chain,
+        author: AccountNumber,
+        half_life_seconds: u32,
+        token_id: u32,
+    ) -> u32 {
+        TokenStream::push_from(&chain, author)
+            .create(half_life_seconds, token_id)
+            .get()
+            .unwrap()
     }
 
     #[psibase::test_case(packages("TokenStream"))]

--- a/packages/user/TokenStream/service/src/tests.rs
+++ b/packages/user/TokenStream/service/src/tests.rs
@@ -13,32 +13,9 @@ mod tests {
     static CHARLIE: AccountNumber = account!("charlie");
     static TOKEN_STREAM: AccountNumber = account!("token-stream");
 
-    fn check_balance(
-        chain: &psibase::Chain,
-        token_id: u32,
-        account: AccountNumber,
-        value: Option<u64>,
-    ) -> Quantity {
-        let res = Tokens::push(&chain)
-            .getBalance(token_id, account)
-            .get()
-            .unwrap();
-
-        if value.is_some() {
-            assert_eq!(res.value, value.unwrap())
-        }
-
-        res
-    }
-
-    fn get_shared_balance(
-        chain: &psibase::Chain,
-        token_id: u32,
-        creditor: AccountNumber,
-        debitor: AccountNumber,
-    ) -> Quantity {
+    fn get_balance(chain: &psibase::Chain, token_id: u32, account: AccountNumber) -> Quantity {
         Tokens::push(&chain)
-            .getSharedBal(token_id, creditor, debitor)
+            .getBalance(token_id, account)
             .get()
             .unwrap()
     }
@@ -69,12 +46,13 @@ mod tests {
             .unwrap();
     }
 
-    fn setup_env(chain: &psibase::Chain) -> Result<u32, psibase::Error> {
-        chain.new_account(ALICE)?;
-        chain.new_account(BOB)?;
-        chain.new_account(CHARLIE)?;
+    /// Creates alice, bob, charlie, and alice mints a new token with supply 1000_0000.
+    fn setup_env(chain: &psibase::Chain) -> u32 {
+        chain.new_account(ALICE).unwrap();
+        chain.new_account(BOB).unwrap();
+        chain.new_account(CHARLIE).unwrap();
 
-        let supply = Quantity::from(10000000);
+        let supply = Quantity::from(1000_0000);
 
         let token_id = Tokens::push_from(&chain, ALICE)
             .create(4.try_into().unwrap(), supply)
@@ -87,15 +65,24 @@ mod tests {
             supply,
             "memo".to_string().try_into().unwrap(),
         );
-        Ok(token_id)
+        token_id
     }
 
+    // λ = ln(2) / half_life_seconds
+    fn rate(half_life_seconds: u32) -> f64 {
+        std::f64::consts::LN_2 / half_life_seconds as f64
+    }
+
+    // Δt > (1/λ) * ln(P(0))
     pub fn full_vesting_time(half_life_seconds: u32, balance: u64) -> i64 {
         if balance == 0 {
             return 0;
         }
-        let t = half_life_seconds as f64 * ((2.0 * balance as f64).ln() / std::f64::consts::LN_2);
-        t.ceil() as i64 + 1
+
+        let factor = 1.0 / rate(half_life_seconds);
+        let t = factor * ((balance as f64).ln());
+
+        t.ceil() as i64
     }
 
     fn reset_clock(chain: &psibase::Chain) {
@@ -115,333 +102,228 @@ mod tests {
             .unwrap()
     }
 
-    #[psibase::test_case(packages("TokenStream"))]
-    fn test_basics(mut chain: psibase::Chain) -> Result<(), psibase::Error> {
-        chain.set_auto_block_start(false);
-        chain.start_block();
-
-        reset_clock(&chain);
-
-        let token_id = setup_env(&chain)?;
-
-        tokens_credit(&chain, token_id, ALICE, TOKEN_STREAM, 500);
-
-        let stream_nft_id = create_stream(&chain, ALICE, 10000, token_id);
-
-        check_balance(&chain, token_id, TOKEN_STREAM, Some(0));
-
-        assert_eq!(
-            get_shared_balance(&chain, token_id, ALICE, TOKEN_STREAM),
-            500.into()
-        );
-
-        TokenStream::push_from(&chain, ALICE)
-            .deposit(stream_nft_id)
-            .get()
-            .unwrap();
-
-        assert_eq!(
-            get_stream(&chain, stream_nft_id).total_deposited,
-            500.into()
-        );
-
-        Nfts::push_from(&chain, ALICE).credit(stream_nft_id, BOB, "memo".to_string());
-        Nfts::push_from(&chain, BOB).debit(stream_nft_id, "memo".to_string());
-
-        // Claim fails because no vesting has yet occured.
-        assert_eq!(
-            TokenStream::push_from(&chain, BOB)
-                .claim(stream_nft_id)
-                .get()
-                .unwrap_err()
-                .to_string(),
-            "service 'tokens' aborted with message: credit quantity must be greater than 0"
-                .to_string()
-        );
-
-        check_balance(&chain, token_id, BOB, Some(0));
-
-        let expected_full_vesting_wait_time = full_vesting_time(10000, 500);
-
-        chain.start_block_after(Seconds::new(expected_full_vesting_wait_time).into());
-
-        TokenStream::push_from(&chain, BOB)
-            .claim(stream_nft_id)
-            .get()
-            .unwrap();
-        check_balance(&chain, token_id, BOB, Some(500));
-
-        Ok(())
+    struct TestHelper {
+        chain: psibase::Chain,
+        token_id: u32,
     }
 
-    #[psibase::test_case(packages("TokenStream"))]
-    fn claiming_sparsely_is_same_as_regularly(chain: psibase::Chain) -> Result<(), psibase::Error> {
-        reset_clock(&chain);
+    impl TestHelper {
+        const HALF_LIFE: u32 = 10000;
 
-        let token_id = setup_env(&chain)?;
-        tokens_credit(&chain, token_id, ALICE, TOKEN_STREAM, 100000);
-        let first_stream = create_stream(&chain, ALICE, 10000, token_id);
-        TokenStream::push_from(&chain, ALICE)
-            .deposit(first_stream)
-            .get()
-            .unwrap();
+        fn new(mut chain: psibase::Chain) -> Self {
+            chain.set_auto_block_start(false);
+            reset_clock(&chain);
+            let token_id = setup_env(&chain);
+            Self { chain, token_id }
+        }
 
-        tokens_credit(&chain, token_id, ALICE, TOKEN_STREAM, 100000);
-        let second_stream = create_stream(&chain, ALICE, 10000, token_id);
-        TokenStream::push_from(&chain, ALICE)
-            .deposit(second_stream)
-            .get()
-            .unwrap();
+        fn credit(&self, creditor: AccountNumber, debitor: AccountNumber, amount: u64) {
+            tokens_credit(&self.chain, self.token_id, creditor, debitor, amount);
+        }
 
-        Nfts::push_from(&chain, ALICE).credit(first_stream, BOB, "memo".to_string());
-        Nfts::push_from(&chain, ALICE).credit(second_stream, CHARLIE, "memo".to_string());
+        fn get_balance(&self, account: AccountNumber) -> Quantity {
+            get_balance(&self.chain, self.token_id, account)
+        }
 
-        let mut bob_total_claimed = 0;
-        for _ in 0..8 {
-            chain.start_block_after(Seconds::new(50).into());
+        fn create_stream(&self, owner: AccountNumber, deposit_amount: u64) -> u32 {
+            let id = create_stream(&self.chain, owner, Self::HALF_LIFE, self.token_id);
+            self.deposit(owner, id, deposit_amount);
+            id
+        }
 
-            TokenStream::push_from(&chain, BOB)
-                .claim(first_stream)
+        fn deposit(&self, sender: AccountNumber, stream_nft_id: u32, amount: u64) {
+            self.credit(sender, TOKEN_STREAM, amount);
+            TokenStream::push_from(&self.chain, sender)
+                .deposit(stream_nft_id)
                 .get()
                 .unwrap();
-            let bob_balance = check_balance(&chain, token_id, BOB, None);
-            bob_total_claimed += bob_balance.value - bob_total_claimed;
         }
-        let bob_balance = check_balance(&chain, token_id, BOB, None);
-        assert_eq!(bob_balance.value, bob_total_claimed);
 
-        TokenStream::push_from(&chain, CHARLIE)
-            .claim(second_stream)
-            .get()
-            .unwrap();
-        let charlie_balance = check_balance(&chain, token_id, CHARLIE, None);
+        fn transfer_stream_ownership(
+            &self,
+            sender: AccountNumber,
+            recipient: AccountNumber,
+            stream_nft_id: u32,
+        ) {
+            Nfts::push_from(&self.chain, sender).credit(
+                stream_nft_id,
+                recipient,
+                "Giving tokenstream NFT".to_string(),
+            );
+            Nfts::push_from(&self.chain, recipient)
+                .debit(stream_nft_id, "claiming tokenstream NFT".to_string());
+        }
 
-        assert_eq!(
-            bob_balance, charlie_balance,
-            "Balances should match after claims"
-        );
+        fn stream(&self, stream_nft_id: u32) -> Stream {
+            get_stream(&self.chain, stream_nft_id)
+        }
 
-        Ok(())
+        fn claim(&self, recipient: AccountNumber, stream_nft_id: u32) {
+            TokenStream::push_from(&self.chain, recipient)
+                .claim(stream_nft_id)
+                .get()
+                .unwrap();
+        }
+
+        fn pass_time(&self, seconds: i64) {
+            self.chain.start_block_after(Seconds::new(seconds).into());
+        }
     }
 
     #[psibase::test_case(packages("TokenStream"))]
-    fn dust_eventually_rounds_to_zero(chain: psibase::Chain) -> Result<(), psibase::Error> {
+    fn test_basics(mut chain: psibase::Chain) {
+        chain.set_auto_block_start(false);
         reset_clock(&chain);
-        let token_id = setup_env(&chain)?;
+        let token_id = setup_env(&chain);
 
-        tokens_credit(&chain, token_id, ALICE, BOB, 100);
-        tokens_credit(&chain, token_id, BOB, TOKEN_STREAM, 100);
+        let id = create_stream(&chain, ALICE, TestHelper::HALF_LIFE, token_id);
 
-        let first_stream = TokenStream::push_from(&chain, BOB)
-            .create(100, token_id)
-            .get()
-            .unwrap();
-
-        TokenStream::push_from(&chain, BOB)
-            .deposit(first_stream)
-            .get()
-            .unwrap();
-
-        chain.start_block_after(Seconds::new(9999999999).into());
-
-        TokenStream::push_from(&chain, BOB)
-            .claim(first_stream)
-            .get()
-            .unwrap();
-
-        check_balance(&chain, token_id, BOB, Some(100));
-        Ok(())
-    }
-
-    #[psibase::test_case(packages("TokenStream"))]
-    fn multiple_deposits_same_stream(chain: psibase::Chain) -> Result<(), psibase::Error> {
-        reset_clock(&chain);
-
-        let token_id = setup_env(&chain)?;
-        tokens_credit(&chain, token_id, ALICE, TOKEN_STREAM, 300);
-
-        let stream_nft_id = TokenStream::push_from(&chain, ALICE)
-            .create(10000, token_id)
-            .get()
-            .unwrap();
-
-        // First deposit
-        TokenStream::push_from(&chain, ALICE)
-            .deposit(stream_nft_id)
-            .get()
-            .unwrap();
-
-        chain.start_block_after(Seconds::new(50).into());
-
-        // Second deposit after some time
-        tokens_credit(&chain, token_id, ALICE, TOKEN_STREAM, 200);
-        TokenStream::push_from(&chain, ALICE)
-            .deposit(stream_nft_id)
-            .get()
-            .unwrap();
-
-        // Transfer NFT to Bob
-        Nfts::push_from(&chain, ALICE).credit(stream_nft_id, BOB, "memo".to_string());
-
-        // Claim after another time increment
-        chain.start_block_after(Seconds::new(50).into());
-
-        TokenStream::push_from(&chain, BOB)
-            .claim(stream_nft_id)
-            .get()
-            .unwrap();
-
-        let bob_balance = check_balance(&chain, token_id, BOB, None);
-        let stream = get_stream(&chain, stream_nft_id);
-        assert_eq!(
-            stream.total_deposited,
-            500.into(),
-            "Total deposited should be 500"
-        );
-        assert!(bob_balance.value > 0, "Bob should have claimed some tokens");
-
-        Ok(())
-    }
-
-    #[psibase::test_case(packages("TokenStream"))]
-    fn zero_deposit_fails(chain: psibase::Chain) -> Result<(), psibase::Error> {
-        reset_clock(&chain);
-
-        let token_id = setup_env(&chain)?;
-
-        let stream_nft_id = TokenStream::push_from(&chain, ALICE)
-            .create(10000, token_id)
-            .get()
-            .unwrap();
-
-        // Attempt to deposit zero
-        let result = TokenStream::push_from(&chain, ALICE)
-            .deposit(stream_nft_id)
-            .get();
-
+        // Test zero deposit fails
+        let result = TokenStream::push_from(&chain, ALICE).deposit(id).get();
         assert!(result.is_err(), "Depositing zero should fail");
         assert_eq!(
-            get_stream(&chain, stream_nft_id).total_deposited,
+            get_stream(&chain, id).total_deposited,
             0.into(),
             "No tokens should be deposited"
         );
 
-        Ok(())
-    }
-
-    #[psibase::test_case(packages("TokenStream"))]
-    fn claim_without_deposit(chain: psibase::Chain) -> Result<(), psibase::Error> {
-        reset_clock(&chain);
-
-        let token_id = setup_env(&chain)?;
-        let stream_nft_id = TokenStream::push_from(&chain, ALICE)
-            .create(10000, token_id)
-            .get()
-            .unwrap();
-
-        Nfts::push_from(&chain, ALICE).credit(stream_nft_id, BOB, "memo".to_string());
-
-        chain.start_block_after(Seconds::new(100).into());
-
-        let err = TokenStream::push_from(&chain, BOB)
-            .claim(stream_nft_id)
+        // Test claim fails since there's been no deposit
+        let err = TokenStream::push_from(&chain, ALICE)
+            .claim(id)
             .get()
             .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("credit quantity must be greater than 0"));
 
-        assert_eq!(
-            err.to_string(),
-            "service 'tokens' aborted with message: credit quantity must be greater than 0"
-                .to_string()
-        );
+        // Make deposit
+        tokens_credit(&chain, token_id, ALICE, TOKEN_STREAM, 500);
+        TokenStream::push_from(&chain, ALICE)
+            .deposit(id)
+            .get()
+            .unwrap();
 
-        let bob_balance = check_balance(&chain, token_id, BOB, None);
-        assert_eq!(
-            bob_balance,
-            0.into(),
-            "No tokens should be claimable without deposit"
-        );
+        // Check claim fails when no vesting has yet occured
+        Nfts::push_from(&chain, ALICE).credit(id, BOB, "memo".to_string());
+        Nfts::push_from(&chain, BOB).debit(id, "memo".to_string());
+        assert!(TokenStream::push_from(&chain, BOB)
+            .claim(id)
+            .get()
+            .unwrap_err()
+            .to_string()
+            .contains("credit quantity must be greater than 0"));
 
-        Ok(())
+        // Check total deposited is correct
+        chain.start_block();
+        assert_eq!(get_stream(&chain, id).total_deposited, 500.into());
     }
 
     #[psibase::test_case(packages("TokenStream"))]
-    fn stream_transfer_preserves_vesting(chain: psibase::Chain) -> Result<(), psibase::Error> {
-        reset_clock(&chain);
+    fn test_full_vesting_time(chain: psibase::Chain) {
+        let test = TestHelper::new(chain);
+        let stream = test.create_stream(ALICE, 500);
 
-        let token_id = setup_env(&chain)?;
-        tokens_credit(&chain, token_id, ALICE, TOKEN_STREAM, 500);
+        let alice_balance_before = test.get_balance(ALICE);
 
-        let stream_nft_id = TokenStream::push_from(&chain, ALICE)
-            .create(10000, token_id)
-            .get()
-            .unwrap();
-
-        TokenStream::push_from(&chain, ALICE)
-            .deposit(stream_nft_id)
-            .get()
-            .unwrap();
-
-        chain.start_block_after(Seconds::new(50).into());
-
-        Nfts::push_from(&chain, ALICE).credit(stream_nft_id, BOB, "memo".to_string());
-        Nfts::push_from(&chain, BOB).credit(stream_nft_id, CHARLIE, "memo".to_string());
-
-        chain.start_block_after(Seconds::new(50).into());
-
-        TokenStream::push_from(&chain, CHARLIE)
-            .claim(stream_nft_id)
-            .get()
-            .unwrap();
-
-        let charlie_balance = check_balance(&chain, token_id, CHARLIE, None);
+        // Wait for 1 less than the full vesting time
+        let expected_full_vesting_wait_time = full_vesting_time(TestHelper::HALF_LIFE, 500);
+        test.pass_time(expected_full_vesting_wait_time - 1);
+        test.claim(ALICE, stream);
+        let total_claimed = test.get_balance(ALICE) - alice_balance_before;
         assert!(
-            charlie_balance.value > 0,
+            total_claimed == 499.into(),
+            "Alice should not have claimed the full balance. She claimed {} of 500",
+            total_claimed.value
+        );
+
+        // Finish waiting full vesting time
+        test.pass_time(1);
+        test.claim(ALICE, stream);
+        let total_claimed = test.get_balance(ALICE) - alice_balance_before;
+        assert_eq!(total_claimed, 500.into());
+    }
+
+    #[psibase::test_case(packages("TokenStream"))]
+    fn claiming_sparsely_is_same_as_regularly(chain: psibase::Chain) {
+        let test = TestHelper::new(chain);
+
+        test.credit(ALICE, BOB, 100_000);
+        let stream1 = test.create_stream(BOB, 100_000);
+
+        test.credit(ALICE, CHARLIE, 100_000);
+        let stream2 = test.create_stream(CHARLIE, 100_000);
+
+        for _ in 0..8 {
+            test.pass_time(50);
+            test.claim(BOB, stream1);
+        }
+
+        test.claim(CHARLIE, stream2);
+
+        assert_eq!(
+            test.get_balance(BOB).value,
+            test.get_balance(CHARLIE).value,
+            "Balances should match after claims"
+        );
+    }
+
+    #[psibase::test_case(packages("TokenStream"))]
+    fn multiple_deposits_same_stream(chain: psibase::Chain) {
+        let test = TestHelper::new(chain);
+        let stream = test.create_stream(ALICE, 300);
+
+        // Check second deposit works
+        test.pass_time(50);
+        test.deposit(ALICE, stream, 200);
+        assert_eq!(test.stream(stream).total_deposited, 500.into());
+
+        // Check claim still works
+        test.pass_time(50);
+        test.claim(ALICE, stream);
+        assert!(
+            test.get_balance(ALICE).value > 0,
+            "Alice should have claimed some tokens"
+        );
+    }
+
+    #[psibase::test_case(packages("TokenStream"))]
+    fn stream_transfer_preserves_vesting(chain: psibase::Chain) {
+        let test = TestHelper::new(chain);
+        let stream = test.create_stream(ALICE, 500);
+
+        test.pass_time(50);
+
+        test.transfer_stream_ownership(ALICE, BOB, stream);
+        test.transfer_stream_ownership(BOB, CHARLIE, stream);
+
+        test.pass_time(50);
+
+        test.claim(CHARLIE, stream);
+        assert!(
+            test.get_balance(CHARLIE).value > 0,
             "Charlie should claim vested tokens"
         );
         assert_eq!(
-            get_stream(&chain, stream_nft_id).total_deposited,
+            test.stream(stream).total_deposited,
             500.into(),
             "Total deposited should remain unchanged"
         );
-
-        Ok(())
     }
 
     #[psibase::test_case(packages("TokenStream"))]
-    fn precision_check(chain: psibase::Chain) -> Result<(), psibase::Error> {
-        reset_clock(&chain);
+    fn precision_check(chain: psibase::Chain) {
+        let test = TestHelper::new(chain);
+        let stream_nft_id = test.create_stream(ALICE, 80_000);
 
-        let token_id = setup_env(&chain)?;
-        let alice_balance_before = check_balance(&chain, token_id, ALICE, None);
+        let alice_balance_before = test.get_balance(ALICE);
+        test.pass_time(TestHelper::HALF_LIFE as i64 * 3);
+        test.claim(ALICE, stream_nft_id);
+        let total_claimed = test.get_balance(ALICE) - alice_balance_before;
 
-        tokens_credit(&chain, token_id, ALICE, TOKEN_STREAM, 80000);
-
-        let half_life_seconds = 10000 as u32;
-        let stream_nft_id = TokenStream::push_from(&chain, ALICE)
-            .create(half_life_seconds, token_id)
-            .get()
-            .unwrap();
-
-        TokenStream::push_from(&chain, ALICE)
-            .deposit(stream_nft_id)
-            .get()
-            .unwrap();
-
-        chain.start_block_after(Seconds::new((half_life_seconds * 3) as i64).into());
-
-        TokenStream::push_from(&chain, ALICE)
-            .claim(stream_nft_id)
-            .get()
-            .unwrap();
-
-        let alice_balance_after = check_balance(&chain, token_id, ALICE, None);
-
-        let dust = 1;
-        assert_eq!(
-            (alice_balance_before - alice_balance_after).value,
-            10000 - dust
+        assert!(
+            (69_999..=70_001).contains(&total_claimed.value),
+            "Claimed amount {} not in expected range 69_999..=70_001",
+            total_claimed.value
         );
-
-        Ok(())
     }
 }


### PR DESCRIPTION
- Refactoring with a test helper utility
- `dust_eventually_rounds_to_zero` deleted in favor of `test_full_vesting_time`
- Testing that depositing 0 doesn't work was moved to `test_basics`
- Testing claim on 0 deposit also moved to `test_basics`
- Removed the checks related to underlying token transfer mechanisms
