### PR TITLE
Fix filtering of native endpoints

### DIFF
--- a/packages/local/XHttp/src/XHttp.cpp
+++ b/packages/local/XHttp/src/XHttp.cpp
@@ -135,7 +135,8 @@ extern "C" [[clang::export_name("serve")]] void serve()
          return;
       }
    }
-   else if (std::string_view{req.target()} == "/native/p2p")
+
+   if (std::string_view{req.target()} == "/native/p2p")
    {
       return;
    }

--- a/programs/psinode/tests/test_xadmin.py
+++ b/programs/psinode/tests/test_xadmin.py
@@ -34,5 +34,12 @@ class TestXAdmin(unittest.TestCase):
             transact.get_jwt_key('swordfish')
         key = transact.get_jwt_key(token)
 
+    @testutil.psinode_test
+    def test_native(self, cluster):
+        (a,) = cluster.complete(*testutil.generate_names(1))
+
+        with a.get('/native/admin/config', service='foo') as reply:
+            self.assertEqual(reply.status_code, 404)
+
 if __name__ == '__main__':
     testutil.main()


### PR DESCRIPTION
There are two nested ifs, and we want the else branch to apply if either test is false. Since the inner if returns, we can just leave off the `else` keyword.