### PR TITLE
Convert database access to use subtree handles

### DIFF
--- a/libraries/psibase/CMakeLists.txt
+++ b/libraries/psibase/CMakeLists.txt
@@ -190,6 +190,7 @@ function(add suffix)
             common/include)
         target_sources(psibase${suffix} PRIVATE
             native/src/BlockContext.cpp
+            native/src/BucketSet.cpp
             native/src/ConfigFile.cpp
             native/src/ExecutionContext.cpp
             native/src/ForkDb.cpp

--- a/libraries/psibase/common/include/psibase/Service.hpp
+++ b/libraries/psibase/common/include/psibase/Service.hpp
@@ -76,12 +76,12 @@ namespace psibase
       /// }
       /// ```
       template <DbId db, std::uint16_t table, typename DerivedService>
-      auto open(this const DerivedService&)
+      auto open(this const DerivedService&, KvMode mode = defaultMode(DerivedService::service))
       {
          using AllTables = decltype(psibase_get_tables((DerivedService*)nullptr));
          constexpr auto index =
              boost::mp11::mp_find_if<AllTables, detail::IsDb<db>::template fn>::value;
-         return boost::mp11::mp_at_c<AllTables, index>(DerivedService::service)
+         return boost::mp11::mp_at_c<AllTables, index>(DerivedService::service, mode)
              .template open<table>();
       }
 
@@ -96,12 +96,13 @@ namespace psibase
       /// }
       /// ```
       template <DbId db, typename T, typename DerivedService>
-      auto open(this const DerivedService&)
+      auto open(this const DerivedService&, KvMode mode = defaultMode(DerivedService::service))
       {
          using AllTables = decltype(psibase_get_tables((DerivedService*)nullptr));
          constexpr auto index =
              boost::mp11::mp_find_if<AllTables, detail::CanOpenTableDb<db, T>::template fn>::value;
-         return boost::mp11::mp_at_c<AllTables, index>(DerivedService::service).template open<T>();
+         return boost::mp11::mp_at_c<AllTables, index>(DerivedService::service, mode)
+             .template open<T>();
       }
 
       /// Open a table by table or record type
@@ -115,12 +116,13 @@ namespace psibase
       /// }
       /// ```
       template <typename T, typename DerivedService>
-      auto open(this const DerivedService&)
+      auto open(this const DerivedService&, KvMode mode = defaultMode(DerivedService::service))
       {
          using AllTables = decltype(psibase_get_tables((DerivedService*)nullptr));
          constexpr auto index =
              boost::mp11::mp_find_if<AllTables, detail::CanOpenTable<T>::template fn>::value;
-         return boost::mp11::mp_at_c<AllTables, index>(DerivedService::service).template open<T>();
+         return boost::mp11::mp_at_c<AllTables, index>(DerivedService::service, mode)
+             .template open<T>();
       }
 
       /// Emit events

--- a/libraries/psibase/common/include/psibase/db.hpp
+++ b/libraries/psibase/common/include/psibase/db.hpp
@@ -164,6 +164,19 @@ namespace psibase
    inline constexpr uint32_t numIndependentDatabases =
        ((std::uint32_t)DbId::endIndependent) - ((std::uint32_t)DbId::beginIndependent);
 
+   enum class KvMode : std::uint8_t
+   {
+      none      = 0,
+      read      = 1,
+      write     = 2,
+      readWrite = 3,
+   };
+
+   enum KvHandle : std::uint32_t
+   {
+      invalid = 0xffffffffu,
+   };
+
    struct KvResourceKey
    {
       AccountNumber service = {};

--- a/libraries/psibase/native/include/psibase/BucketSet.hpp
+++ b/libraries/psibase/native/include/psibase/BucketSet.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <psibase/db.hpp>
+#include <vector>
+
+namespace psibase
+{
+   struct Bucket
+   {
+      DbId                              db;
+      std::vector<char>                 prefix;
+      KvMode                            mode = KvMode::none;
+      explicit                          operator bool() const { return mode != KvMode::none; }
+      std::vector<char>                 key(std::span<const char>) const;
+      std::optional<Database::KVResult> trimResult(std::optional<Database::KVResult> result) const;
+
+      bool isRead() const { return mode == KvMode::read || mode == KvMode::readWrite; }
+      bool isWrite() const { return mode == KvMode::write || mode == KvMode::readWrite; }
+
+      std::string to_string() const;
+   };
+
+   struct BucketSet
+   {
+      std::vector<Bucket> buckets;
+
+      KvHandle open(DbId db, std::vector<char> prefix, KvMode mode, std::uint32_t limit);
+      void     close(KvHandle handle);
+
+      const Bucket& operator[](KvHandle handle) const;
+   };
+}  // namespace psibase

--- a/libraries/psibase/native/include/psibase/NativeFunctions.hpp
+++ b/libraries/psibase/native/include/psibase/NativeFunctions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <psibase/BucketSet.hpp>
 #include <psibase/ExecutionContext.hpp>
 
 #include <eosio/vm/argument_proxy.hpp>
@@ -19,6 +20,8 @@ namespace psibase
 
       std::vector<char> result_key;
       std::vector<char> result_value;
+
+      BucketSet buckets;
 
       // TODO: delete range. Need some way for system services to enable/disable it
       //       since it's only compatible with some resource models
@@ -42,14 +45,21 @@ namespace psibase
       uint32_t getCurrentAction();
       uint32_t call(eosio::vm::span<const char> data);
       void     setRetval(eosio::vm::span<const char> data);
-      void kvPut(uint32_t db, eosio::vm::span<const char> key, eosio::vm::span<const char> value);
+      uint32_t kvOpen(uint32_t db, eosio::vm::span<const char> prefix, uint32_t mode);
+      uint32_t kvOpenAt(uint32_t handle, eosio::vm::span<const char> prefix, uint32_t mode);
+      void     kvClose(uint32_t handle);
+      void     kvPut(uint32_t                    handle,
+                     eosio::vm::span<const char> key,
+                     eosio::vm::span<const char> value);
       uint64_t putSequential(uint32_t db, eosio::vm::span<const char> value);
-      void     kvRemove(uint32_t db, eosio::vm::span<const char> key);
-      uint32_t kvGet(uint32_t db, eosio::vm::span<const char> key);
+      void     kvRemove(uint32_t handle, eosio::vm::span<const char> key);
+      uint32_t kvGet(uint32_t handle, eosio::vm::span<const char> key);
       uint32_t getSequential(uint32_t db, uint64_t indexNumber);
-      uint32_t kvGreaterEqual(uint32_t db, eosio::vm::span<const char> key, uint32_t matchKeySize);
-      uint32_t kvLessThan(uint32_t db, eosio::vm::span<const char> key, uint32_t matchKeySize);
-      uint32_t kvMax(uint32_t db, eosio::vm::span<const char> key);
+      uint32_t kvGreaterEqual(uint32_t                    handle,
+                              eosio::vm::span<const char> key,
+                              uint32_t                    matchKeySize);
+      uint32_t kvLessThan(uint32_t handle, eosio::vm::span<const char> key, uint32_t matchKeySize);
+      uint32_t kvMax(uint32_t handle, eosio::vm::span<const char> key);
       uint32_t kvGetTransactionUsage();
 
       void checkoutSubjective();

--- a/libraries/psibase/native/include/psibase/Socket.hpp
+++ b/libraries/psibase/native/include/psibase/Socket.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <psibase/SocketInfo.hpp>
 #include <psibase/check.hpp>
 #include <psibase/db.hpp>
 #include <set>

--- a/libraries/psibase/native/include/psibase/TransactionContext.hpp
+++ b/libraries/psibase/native/include/psibase/TransactionContext.hpp
@@ -62,6 +62,8 @@ namespace psibase
       // This may be called multiple times with different limits; the most-recent limit applies.
       void setWatchdog(CpuClock::duration watchdogLimit);
 
+      const WasmConfigRow& getWasmConfig() const;
+
       // Returns the alt stack for wasm execution.
       eosio::vm::stack_manager& getAltStack();
 

--- a/libraries/psibase/native/include/psibase/db.hpp
+++ b/libraries/psibase/native/include/psibase/db.hpp
@@ -3,7 +3,6 @@
 #include_next <psibase/db.hpp>
 
 #include <psibase/blob.hpp>
-#include <psibase/nativeTables.hpp>
 #include <psio/fracpack.hpp>
 #include <psio/from_bin.hpp>
 #include <psio/to_key.hpp>

--- a/libraries/psibase/native/src/BucketSet.cpp
+++ b/libraries/psibase/native/src/BucketSet.cpp
@@ -1,0 +1,62 @@
+#include <psibase/BucketSet.hpp>
+
+#include <psibase/check.hpp>
+#include <psio/to_hex.hpp>
+
+using namespace psibase;
+
+std::vector<char> Bucket::key(std::span<const char> subkey) const
+{
+   std::vector<char> result;
+   result.reserve(subkey.size() + prefix.size());
+   result.insert(result.end(), prefix.begin(), prefix.end());
+   result.insert(result.end(), subkey.begin(), subkey.end());
+   return result;
+}
+
+std::string Bucket::to_string() const
+{
+   return "db=" + std::to_string(static_cast<std::uint32_t>(db)) +
+          " prefix=" + psio::to_hex(prefix) +
+          " mode=" + std::to_string(static_cast<std::uint32_t>(mode));
+}
+
+std::optional<Database::KVResult> Bucket::trimResult(std::optional<Database::KVResult> result) const
+{
+   if (result)
+   {
+      result->key.skip(prefix.size());
+   }
+   return result;
+}
+
+KvHandle BucketSet::open(DbId db, std::vector<char> prefix, KvMode mode, std::uint32_t limit)
+{
+   check(mode != KvMode::none, "Invalid mode");
+   for (auto& bucket : buckets)
+   {
+      if (!bucket)
+      {
+         bucket = {db, std::move(prefix), mode};
+         return static_cast<KvHandle>(&bucket - &buckets[0]);
+      }
+   }
+   check(buckets.size() < limit, "Too many database handles");
+   buckets.push_back({db, std::move(prefix), mode});
+   return static_cast<KvHandle>(buckets.size() - 1);
+}
+
+void BucketSet::close(KvHandle handle)
+{
+   auto idx = static_cast<std::size_t>(handle);
+   check(idx < buckets.size() && buckets[idx].mode != KvMode::none, "Invalid bucket");
+   //buckets[idx] = {};
+   buckets[idx].mode = KvMode::none;
+}
+
+const Bucket& BucketSet::operator[](KvHandle handle) const
+{
+   auto idx = static_cast<std::size_t>(handle);
+   check(idx < buckets.size() && buckets[idx].mode != KvMode::none, "Invalid bucket");
+   return buckets[idx];
+}

--- a/libraries/psibase/native/src/ExecutionContext.cpp
+++ b/libraries/psibase/native/src/ExecutionContext.cpp
@@ -379,6 +379,9 @@ namespace psibase
       rhf_t::add<&ExecutionContextImpl::getCurrentAction>("env", "getCurrentAction");
       rhf_t::add<&ExecutionContextImpl::call>("env", "call");
       rhf_t::add<&ExecutionContextImpl::setRetval>("env", "setRetval");
+      rhf_t::add<&ExecutionContextImpl::kvOpen>("env", "kvOpen");
+      rhf_t::add<&ExecutionContextImpl::kvOpenAt>("env", "kvOpenAt");
+      rhf_t::add<&ExecutionContextImpl::kvClose>("env", "kvClose");
       rhf_t::add<&ExecutionContextImpl::kvPut>("env", "kvPut");
       rhf_t::add<&ExecutionContextImpl::putSequential>("env", "putSequential");
       rhf_t::add<&ExecutionContextImpl::kvRemove>("env", "kvRemove");

--- a/libraries/psibase/native/src/Socket.cpp
+++ b/libraries/psibase/native/src/Socket.cpp
@@ -1,5 +1,7 @@
 #include <psibase/Socket.hpp>
 
+#include <psibase/nativeTables.hpp>
+
 using namespace psibase;
 
 static constexpr auto wasi_errno_acces  = 2;

--- a/libraries/psibase/native/src/TransactionContext.cpp
+++ b/libraries/psibase/native/src/TransactionContext.cpp
@@ -337,6 +337,11 @@ namespace psibase
       impl->watchdog.setLimit(watchdogLimit);
    }  // TransactionContext::setWatchdog
 
+   const WasmConfigRow& TransactionContext::getWasmConfig() const
+   {
+      return impl->wasmConfig;
+   }
+
    eosio::vm::stack_manager& TransactionContext::getAltStack()
    {
       return impl->altStack;

--- a/libraries/psibase/native/src/useTriedent.cpp
+++ b/libraries/psibase/native/src/useTriedent.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <psibase/Socket.hpp>
+#include <psibase/nativeTables.hpp>
 #include <triedent/database.hpp>
 
 namespace psibase

--- a/packages/psibase_tests/src/NotifyService.cpp
+++ b/packages/psibase_tests/src/NotifyService.cpp
@@ -14,7 +14,7 @@ void NotifyService::onBlock()
 
    PSIBASE_SUBJECTIVE_TX
    {
-      if (Subjective{getReceiver()}.open<FailTable>().get({}))
+      if (Subjective{getReceiver(), KvMode::read}.open<FailTable>().get({}))
       {
          abortMessage("as you wish");
       }
@@ -31,7 +31,7 @@ void NotifyService::onTrx(const psibase::Checksum256& /*id*/,
 
    PSIBASE_SUBJECTIVE_TX
    {
-      if (Subjective{getReceiver()}.open<FailTable>().get({}))
+      if (Subjective{getReceiver(), KvMode::read}.open<FailTable>().get({}))
       {
          abortMessage("as you wish");
       }

--- a/packages/psibase_tests/src/RemoveCode.cpp
+++ b/packages/psibase_tests/src/RemoveCode.cpp
@@ -9,12 +9,14 @@ void RemoveCode::removeCode(psibase::Checksum256 codeHash,
                             std::uint8_t         vmType,
                             std::uint8_t         vmVersion)
 {
-   kvRemove(CodeByHashRow::db, codeByHashKey(codeHash, vmType, vmVersion));
+   Native::tables(KvMode::write)
+       .open<CodeByHashTable>()
+       .erase(std::tuple(codeHash, vmType, vmVersion));
 }
 
 void RemoveCode::setCodeRow(psibase::CodeRow row)
 {
-   kvPut(CodeRow::db, row.key(), row);
+   Native::tables(KvMode::write).open<CodeTable>().put(row);
 }
 
 PSIBASE_DISPATCH(RemoveCode)

--- a/packages/psibase_tests/src/SetWasmConfig.cpp
+++ b/packages/psibase_tests/src/SetWasmConfig.cpp
@@ -8,7 +8,13 @@ using namespace TestService;
 void SetWasmConfig::setWasmCfg(NativeTableNum table, WasmConfigRow row)
 {
    check(getSender() == getReceiver(), "Wrong sender");
-   psibase::kvPut(WasmConfigRow::db, row.key(table), row);
+   auto native = Native::tables(KvMode::write);
+   if (table == transactionWasmConfigTable)
+      native.open<transactionWasmConfigTable>().put(row);
+   else if (table == proofWasmConfigTable)
+      native.open<proofWasmConfigTable>().put(row);
+   else
+      abortMessage("Not a wasm config table");
 }
 
 PSIBASE_DISPATCH(SetWasmConfig)

--- a/packages/psibase_tests/src/TestServiceEntry.cpp
+++ b/packages/psibase_tests/src/TestServiceEntry.cpp
@@ -27,7 +27,7 @@ extern "C" void start(AccountNumber this_service)
    check(this_service == TestServiceEntry::service,
          std::format("{} != {}", this_service.str(), TestServiceEntry::service.str()));
    ++start_called;
-   auto counter = TestServiceEntry{}.open<CallCounterTable>();
+   auto counter = TestServiceEntry{}.open<CallCounterTable>(KvMode::readWrite);
    auto row     = counter.get(CallCounterRow::start)
                   .value_or(CallCounterRow{.id = CallCounterRow::start, .count = 0});
    ++row.count;
@@ -47,7 +47,7 @@ extern "C" void called(AccountNumber this_service, AccountNumber sender)
    check(act.method == MethodNumber{"call"}, "called: act.method = " + act.method.str());
    check(pl.memo == "Counting down", "memo: " + pl.memo);
    {
-      auto counter = TestServiceEntry{}.open<CallCounterTable>();
+      auto counter = TestServiceEntry{}.open<CallCounterTable>(KvMode::readWrite);
       auto row     = counter.get(CallCounterRow::called)
                      .value_or(CallCounterRow{.id = CallCounterRow::called, .count = 0});
       int depth = 3 - pl.number;

--- a/packages/system/Accounts/src/Accounts.cpp
+++ b/packages/system/Accounts/src/Accounts.cpp
@@ -21,13 +21,11 @@ namespace SystemService
       check(!statusIndex.get(std::tuple{}), "already started");
 
       uint32_t totalAccounts = 0;
-      auto     codeIndex     = psibase::TableIndex<psibase::CodeRow, std::tuple<>>{
-          psibase::CodeRow::db, psio::convert_to_key(codePrefix()), false};
+      auto     codeTable     = Native::tables(KvMode::read).open<CodeTable>();
       if constexpr (enable_print)
          writeConsole("initial accounts: ");
-      for (auto it = codeIndex.begin(); it != codeIndex.end(); ++it)
+      for (auto code : codeTable.getIndex<0>())
       {
-         auto code = *it;
          if constexpr (enable_print)
          {
             writeConsole(code.codeNum.str());
@@ -108,7 +106,7 @@ namespace SystemService
 
    std::optional<Account> Accounts::getAccount(AccountNumber name)
    {
-      Tables tables{getReceiver()};
+      Tables tables{getReceiver(), KvMode::read};
       auto   accountTable = tables.open<AccountTable>();
       auto   accountIndex = accountTable.getIndex<0>();
       return accountIndex.get(name);

--- a/packages/system/AuthDelegate/include/services/system/AuthDelegate.hpp
+++ b/packages/system/AuthDelegate/include/services/system/AuthDelegate.hpp
@@ -97,7 +97,6 @@ namespace SystemService
       psibase::AccountNumber getOwner(psibase::AccountNumber account);
 
      private:
-      Tables                        db{psibase::getReceiver()};
       psibase::Actor<AuthInterface> authServiceOf(psibase::AccountNumber account);
    };
    PSIO_REFLECT(AuthDelegate,  //

--- a/packages/system/AuthDelegate/src/AuthDelegate.cpp
+++ b/packages/system/AuthDelegate/src/AuthDelegate.cpp
@@ -78,7 +78,7 @@ namespace SystemService
 
    void AuthDelegate::setOwner(psibase::AccountNumber owner)
    {
-      auto table  = db.open<AuthDelegateTable>();
+      auto table  = open<AuthDelegateTable>();
       auto record = table.getIndex<0>().get(owner);
       auto sender = getSender();
       if (sender == owner || record && record->owner == sender)
@@ -91,7 +91,7 @@ namespace SystemService
 
    psibase::AccountNumber AuthDelegate::getOwner(psibase::AccountNumber account)
    {
-      auto row = db.open<AuthDelegateTable>().getIndex<0>().get(account);
+      auto row = open<AuthDelegateTable>(KvMode::read).getIndex<0>().get(account);
       check(row.has_value(), "account does not have an owning account");
       return row->owner;
    }
@@ -103,7 +103,7 @@ namespace SystemService
 
    void AuthDelegate::newAccount(psibase::AccountNumber name, psibase::AccountNumber owner)
    {
-      auto table  = db.open<AuthDelegateTable>();
+      auto table  = open<AuthDelegateTable>();
       auto record = table.getIndex<0>().get(name);
       if (record && record->owner == owner)
       {

--- a/packages/system/AuthSig/include/services/system/AuthSig.hpp
+++ b/packages/system/AuthSig/include/services/system/AuthSig.hpp
@@ -98,9 +98,6 @@ namespace SystemService
 
          /// Create a new account using this auth service configured with the specified public key.
          void newAccount(psibase::AccountNumber name, SubjectPublicKeyInfo key);
-
-        private:
-         Tables db{psibase::getReceiver()};
       };
       PSIO_REFLECT(AuthSig,  //
                    method(checkAuthSys, flags, requester, sender, action, allowedActions, claims),

--- a/packages/system/AuthSig/src/AuthSig.cpp
+++ b/packages/system/AuthSig/src/AuthSig.cpp
@@ -43,7 +43,7 @@ namespace SystemService
          else if (type != AuthInterface::topActionReq)
             abortMessage("unsupported auth type");
 
-         auto row = db.open<AuthTable>().getIndex<0>().get(sender);
+         auto row = open<AuthTable>(KvMode::read).getIndex<0>().get(sender);
 
          check(row.has_value(), "sender does not have a public key");
 
@@ -75,13 +75,13 @@ namespace SystemService
       void AuthSig::canAuthUserSys(psibase::AccountNumber user)
       {
          // Anyone with a public key in the AuthTable may use AuthSig
-         auto row = db.open<AuthTable>().getIndex<0>().get(user);
+         auto row = open<AuthTable>(KvMode::read).getIndex<0>().get(user);
          check(row.has_value(), "sender does not have a public key");
       }
 
       void AuthSig::setKey(SubjectPublicKeyInfo key)
       {
-         auto authTable = db.open<AuthTable>();
+         auto authTable = open<AuthTable>(KvMode::readWrite);
          authTable.put(AuthRecord{.account = getSender(), .pubkey = std::move(key)});
       }
 

--- a/packages/system/HttpServer/src/HttpServer.cpp
+++ b/packages/system/HttpServer/src/HttpServer.cpp
@@ -28,7 +28,9 @@ namespace SystemService
 
       std::optional<RegisteredServiceRow> getServer(const AccountNumber& server)
       {
-         return HttpServer::Tables(HttpServer::service).open<RegServTable>().get(server);
+         return HttpServer::Tables(HttpServer::service, KvMode::read)
+             .open<RegServTable>()
+             .get(server);
       }
 
       AccountNumber getTargetService(const HttpRequest& req)

--- a/packages/system/Producers/src/RProducers.cpp
+++ b/packages/system/Producers/src/RProducers.cpp
@@ -26,21 +26,21 @@ struct ProducerQuery
    }
    ConsensusData consensus() const
    {
-      auto status = psibase::kvGet<psibase::StatusRow>(StatusRow::db, StatusRow::key());
+      const auto& status = getOptionalStatus();
       if (!status)
          return {};
       return std::move(status->consensus.current.data);
    }
    std::optional<ConsensusData> nextConsensus() const
    {
-      auto status = psibase::kvGet<psibase::StatusRow>(StatusRow::db, StatusRow::key());
+      const auto& status = getOptionalStatus();
       if (!status || !status->consensus.next)
          return {};
       return std::move(status->consensus.next->consensus.data);
    }
    std::optional<BlockNum> jointStart() const
    {
-      auto status = psibase::kvGet<psibase::StatusRow>(StatusRow::db, StatusRow::key());
+      const auto& status = getOptionalStatus();
       if (!status || !status->consensus.next)
          return {};
       return status->consensus.next->blockNum;

--- a/packages/system/SetCode/src/RSetCode.cpp
+++ b/packages/system/SetCode/src/RSetCode.cpp
@@ -32,8 +32,9 @@ namespace SystemService
 
          std::string codeHex() const
          {
-            auto codeByHasRow =
-                kvGet<CodeByHashRow>(CodeByHashRow::db, codeByHashKey(codeHash, vmType, vmVersion));
+            auto codeByHasRow = Native::tables(KvMode::read)
+                                    .open<CodeByHashTable>()
+                                    .get({codeHash, vmType, vmVersion});
             check(!!codeByHasRow, "Raw code not found");
             return to_hex((*codeByHasRow).code);
          }
@@ -74,7 +75,7 @@ namespace SystemService
    {
       auto code(AccountNumber account) const -> std::optional<CodeRecord>
       {
-         auto codeRow = kvGet<CodeRow>(CodeRow::db, codeKey(account));
+         auto codeRow = Native::tables(KvMode::read).open<CodeRow>().get(account);
          if (!codeRow)
             return std::nullopt;
          return toCodeRecord(std::move(*codeRow));

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -668,7 +668,7 @@ void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> 
 void RTransact::onBlock()
 {
    check(getSender() == AccountNumber{}, "Wrong sender");
-   auto stat = psibase::kvGet<psibase::StatusRow>(psibase::StatusRow::db, psibase::statusKey());
+   const auto stat = getOptionalStatus();
    check(stat && stat->head, "Head block should be set before calling onBlock");
 
    checkReverify(stat->head->blockId);
@@ -758,9 +758,9 @@ void RTransact::onVerify(std::uint64_t                      id,
    auto unverifiedTransactions = open<UnverifiedTransactionTable>();
    auto reverify               = open<ReverifySignaturesTable>();
    auto clients                = open<TraceClientTable>();
-   auto runVerifyId            = open<VerifyIdTable>().get({}).value_or(VerifyIdRecord{}).verifyId;
-   auto errorTxId              = std::optional<Checksum256>{};
-   auto broadcastTxId          = std::optional<Checksum256>{};
+   auto runVerifyId = open<VerifyIdTable>(KvMode::read).get({}).value_or(VerifyIdRecord{}).verifyId;
+   auto errorTxId   = std::optional<Checksum256>{};
+   auto broadcastTxId = std::optional<Checksum256>{};
    PSIBASE_SUBJECTIVE_TX
    {
       to<XRun>().finish(id);

--- a/packages/user/Events/src/REvents.cpp
+++ b/packages/user/Events/src/REvents.cpp
@@ -143,6 +143,7 @@ struct EventCursor : sqlite3_vtab_cursor
    std::vector<char> end;
    std::vector<char> data;
    std::size_t       prefixLen;
+   EventIndexHandle  handle{KvMode::read};
    EventCursor(const EventVTab& vtab) : key(vtab.key()), prefixLen(key.size() + 1) {}
    EventVTab* vtab() { return static_cast<EventVTab*>(pVtab); }
    int        setEof()
@@ -154,7 +155,7 @@ struct EventCursor : sqlite3_vtab_cursor
    std::uint64_t eventId() const { return keyToEventId(key, prefixLen); }
    void          seek()
    {
-      auto sz = psibase::raw::kvGreaterEqual(DbId::writeOnly, key.data(), key.size(), prefixLen);
+      auto sz = psibase::raw::kvGreaterEqual(handle, key.data(), key.size(), prefixLen);
       if (sz == 0xffffffffu)
       {
          setEof();

--- a/packages/user/Events/src/eventKeys.cpp
+++ b/packages/user/Events/src/eventKeys.cpp
@@ -2,6 +2,7 @@
 
 #include <psibase/check.hpp>
 #include <ranges>
+#include <services/user/EventIndex.hpp>
 
 using namespace psibase;
 
@@ -21,4 +22,14 @@ namespace UserService
       return result;
    }
 
+   EventIndexHandle::EventIndexHandle(psibase::KvMode mode)
+       : value(psibase::kvOpen(DbId::writeOnly,
+                               psio::composite_key(EventIndex::service, eventIndexesNum),
+                               mode))
+   {
+   }
+   EventIndexHandle::~EventIndexHandle()
+   {
+      psibase::kvClose(value);
+   }
 }  // namespace UserService

--- a/packages/user/Events/src/eventKeys.hpp
+++ b/packages/user/Events/src/eventKeys.hpp
@@ -21,13 +21,20 @@ namespace UserService
 
    void to_key(const EventIndexTable& obj, auto& stream)
    {
-      psio::to_key(psibase::AccountNumber{"event-index"}, stream);
-      psio::to_key(eventIndexesNum, stream);
       psio::to_key(obj.db, stream);
       psio::to_key(obj.service, stream);
       psio::to_key(obj.event, stream);
    }
 
    std::uint64_t keyToEventId(const std::vector<char>& key, std::size_t prefixLen = 0);
+
+   struct EventIndexHandle
+   {
+      explicit EventIndexHandle(psibase::KvMode mode);
+      EventIndexHandle(const EventIndexHandle&) = delete;
+      ~EventIndexHandle();
+      operator psibase::KvHandle() const { return value; }
+      psibase::KvHandle value;
+   };
 
 }  // namespace UserService

--- a/packages/user/Events/test/EventsTest.cpp
+++ b/packages/user/Events/test/EventsTest.cpp
@@ -245,12 +245,14 @@ TEST_CASE("events")
 
 void clearDb(DbId db)
 {
-   auto key = std::vector<char>();
-   while (raw::kvGreaterEqual(db, key.data(), key.size(), 0) != -1)
+   auto key    = std::vector<char>();
+   auto handle = kvOpen(db, key, KvMode::readWrite);
+   while (raw::kvGreaterEqual(handle, key.data(), key.size(), 0) != -1)
    {
       key = getKey();
-      kvRemoveRaw(db, key);
+      kvRemoveRaw(handle, key);
    }
+   kvClose(handle);
 }
 
 TEST_CASE("events snapshot")

--- a/packages/user/Nft/src/Nft.cpp
+++ b/packages/user/Nft/src/Nft.cpp
@@ -30,7 +30,7 @@ Nft::Nft(psio::shared_view_ptr<psibase::Action> action)
    MethodNumber m{action->method()};
    if (m != MethodNumber{"init"})
    {
-      auto initRecord = Tables().open<InitTable>().get({});
+      auto initRecord = open<InitTable>(KvMode::read).get({});
       check(initRecord.has_value(), uninitialized);
    }
 }
@@ -180,7 +180,7 @@ void Nft::setUserConf(psibase::EnumElement flag, bool enable)
 
 NftRecord Nft::getNft(NID nftId)
 {
-   auto nftIdx    = Tables().open<NftTable>().getIndex<0>();
+   auto nftIdx    = open<NftTable>(KvMode::read).getIndex<0>();
    auto nftRecord = nftIdx.get(nftId);
    bool exists    = nftRecord.has_value();
 
@@ -205,7 +205,7 @@ NftRecord Nft::getNft(NID nftId)
 
 NftHolderRecord Nft::getNftHolder(AccountNumber account)
 {
-   auto nftHodler = Tables().open<NftHolderTable>().get(account);
+   auto nftHodler = open<NftHolderTable>(KvMode::read).get(account);
 
    if (nftHodler.has_value())
    {
@@ -222,7 +222,7 @@ NftHolderRecord Nft::getNftHolder(AccountNumber account)
 
 CreditRecord Nft::getCredRecord(NID nftId)
 {
-   auto creditRecord = Tables().open<CreditTable>().get(nftId);
+   auto creditRecord = open<CreditTable>(KvMode::read).get(nftId);
 
    if (creditRecord.has_value())
    {
@@ -242,12 +242,12 @@ CreditRecord Nft::getCredRecord(NID nftId)
 
 bool Nft::exists(NID nftId)
 {
-   return Tables().open<NftTable>().get(nftId).has_value();
+   return open<NftTable>(KvMode::read).get(nftId).has_value();
 }
 
 bool Nft::getUserConf(psibase::AccountNumber account, psibase::EnumElement flag)
 {
-   auto hodler = Tables().open<NftHolderTable>().get(account);
+   auto hodler = open<NftHolderTable>(KvMode::read).get(account);
    if (hodler.has_value() == false)
    {
       return false;
@@ -274,7 +274,7 @@ struct NftDetail
 };
 PSIO_REFLECT(NftDetail, id, owner, issuer);
 
-auto nftService = Nft::Tables{Nft::service};
+auto nftService = Nft::Tables{Nft::service, KvMode::read};
 struct NftQuery
 {
    auto allNfts() const

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -50,7 +50,7 @@ pub mod tables {
         }
 
         pub fn get(id: TID) -> Option<Self> {
-            TokenTable::new().get_index_pk().get(&id)
+            TokenTable::read().get_index_pk().get(&id)
         }
 
         pub fn get_assert(id: TID) -> Self {
@@ -58,7 +58,7 @@ pub mod tables {
         }
 
         pub fn get_by_symbol(symbol: AccountNumber) -> Option<Self> {
-            let mut tokens: Vec<Token> = TokenTable::new()
+            let mut tokens: Vec<Token> = TokenTable::read()
                 .get_index_by_symbol()
                 .range((Some(symbol), 0 as u32)..=(Some(symbol), u32::MAX))
                 .collect();
@@ -231,7 +231,9 @@ pub mod tables {
         }
 
         pub fn get(account: AccountNumber, token_id: TID) -> Option<Self> {
-            BalanceTable::new().get_index_pk().get(&(account, token_id))
+            BalanceTable::read()
+                .get_index_pk()
+                .get(&(account, token_id))
         }
 
         pub fn get_or_new(account: AccountNumber, token_id: TID) -> Self {
@@ -378,7 +380,7 @@ pub mod tables {
         }
 
         fn get(creditor: AccountNumber, debitor: AccountNumber, token_id: TID) -> Option<Self> {
-            SharedBalanceTable::new()
+            SharedBalanceTable::read()
                 .get_index_pk()
                 .get(&(creditor, debitor, token_id))
         }
@@ -522,7 +524,7 @@ pub mod tables {
         }
 
         fn get(account: AccountNumber, token_id: TID) -> Option<Self> {
-            BalanceConfigTable::new()
+            BalanceConfigTable::read()
                 .get_index_pk()
                 .get(&(account, token_id))
         }
@@ -582,7 +584,7 @@ pub mod tables {
         }
 
         fn get(account: AccountNumber) -> Option<Self> {
-            UserConfigTable::new().get_index_pk().get(&account)
+            UserConfigTable::read().get_index_pk().get(&account)
         }
 
         pub fn get_or_new(account: AccountNumber) -> Self {

--- a/rust/psibase/src/table.rs
+++ b/rust/psibase/src/table.rs
@@ -8,9 +8,9 @@ use custom_error::custom_error;
 use fracpack::{Pack, UnpackOwned};
 
 use crate::{
-    get_key_bytes, get_service, kv_get, kv_get_bytes, kv_greater_equal_bytes, kv_less_than_bytes,
-    kv_max_bytes, kv_put, kv_put_bytes, kv_remove, kv_remove_bytes, AccountNumber, DbId, KeyView,
-    RawKey, ToKey,
+    get_key_bytes, kv_get, kv_get_bytes, kv_greater_equal_bytes, kv_less_than_bytes, kv_max_bytes,
+    kv_put, kv_put_bytes, kv_remove, kv_remove_bytes, AccountNumber, DbId, KeyView, KvHandle,
+    KvMode, RawKey, ToKey,
 };
 
 custom_error! {
@@ -38,19 +38,31 @@ pub trait TableRecord: Pack + UnpackOwned {
 
 pub trait Table<Record: TableRecord>: Sized {
     const TABLE_INDEX: u16;
+    const SERVICE: AccountNumber;
 
-    fn with_prefix(db_id: DbId, prefix: Vec<u8>) -> Self;
+    fn with_prefix(db_id: DbId, prefix: Vec<u8>, mode: KvMode) -> Self;
     fn prefix(&self) -> &[u8];
-    fn db_id(&self) -> DbId;
+    fn handle(&self) -> &KvHandle;
 
     fn new() -> Self {
-        let prefix = (get_service(), Self::TABLE_INDEX).to_key();
-        Self::with_prefix(<Record as TableRecord>::DB, prefix)
+        Self::with_mode(KvMode::ReadWrite)
+    }
+
+    fn read() -> Self {
+        Self::with_mode(KvMode::Read)
+    }
+
+    fn with_mode(mode: KvMode) -> Self {
+        Self::with_service_mode(Self::SERVICE, mode)
     }
 
     fn with_service(service: AccountNumber) -> Self {
+        Self::with_service_mode(service, KvMode::Read)
+    }
+
+    fn with_service_mode(service: AccountNumber, mode: KvMode) -> Self {
         let prefix = (service, Self::TABLE_INDEX).to_key();
-        Self::with_prefix(<Record as TableRecord>::DB, prefix)
+        Self::with_prefix(<Record as TableRecord>::DB, prefix, mode)
     }
 
     /// Returns one of the table indexes: 0 = Primary Key Index, else secondary indexes
@@ -58,7 +70,7 @@ pub trait Table<Record: TableRecord>: Sized {
         let mut idx_prefix = self.prefix().to_owned();
         idx.append_key(&mut idx_prefix);
 
-        TableIndex::new(self.db_id(), idx_prefix, idx > 0)
+        TableIndex::new(self.handle(), idx_prefix, idx > 0)
     }
 
     /// Returns the Primary Key Index
@@ -70,14 +82,14 @@ pub trait Table<Record: TableRecord>: Sized {
     fn put(&self, value: &Record) -> Result<(), Error> {
         let pk = self.serialize_key(0, &value.get_primary_key());
         self.handle_secondary_keys_put(&pk.to_key(), value)?;
-        kv_put(self.db_id(), &pk, value);
+        kv_put(self.handle(), &pk, value);
         Ok(())
     }
 
     /// Removes a value from the table
     fn remove(&self, value: &Record) {
         let pk = self.serialize_key(0, &value.get_primary_key());
-        kv_remove(self.db_id(), &pk);
+        kv_remove(self.handle(), &pk);
         self.handle_secondary_keys_removal(value);
     }
 
@@ -92,7 +104,7 @@ pub trait Table<Record: TableRecord>: Sized {
             }
         } else {
             let pk = self.serialize_key(0, key);
-            kv_remove(self.db_id(), &pk);
+            kv_remove(self.handle(), &pk);
         }
     }
 
@@ -110,7 +122,7 @@ pub trait Table<Record: TableRecord>: Sized {
 
         let secondary_keys = value.get_secondary_keys();
 
-        let old_record: Option<Record> = kv_get(self.db_id(), &KeyView::new(pk)).unwrap();
+        let old_record: Option<Record> = kv_get(self.handle(), &KeyView::new(pk)).unwrap();
 
         if let Some(old_record) = old_record {
             self.replace_secondary_keys(pk, &secondary_keys, old_record)
@@ -182,7 +194,7 @@ pub trait Table<Record: TableRecord>: Sized {
     /// Check if any key already exists in the DB
     fn check_unique_keys<T: AsRef<[u8]>>(&self, keys: &[T]) -> Result<(), Error> {
         for key in keys {
-            if kv_get_bytes(self.db_id(), key.as_ref()).is_some() {
+            if kv_get_bytes(self.handle(), key.as_ref()).is_some() {
                 return Err(Error::DuplicatedKey);
             }
         }
@@ -191,19 +203,19 @@ pub trait Table<Record: TableRecord>: Sized {
 
     fn put_keys_bytes(&self, keys: &Vec<Vec<u8>>, pk: &[u8]) {
         for key in keys {
-            kv_put_bytes(self.db_id(), key, pk);
+            kv_put_bytes(self.handle(), key, pk);
         }
     }
 
     fn remove_keys_bytes(&self, keys: &Vec<Vec<u8>>) {
         for key in keys {
-            kv_remove_bytes(self.db_id(), key);
+            kv_remove_bytes(self.handle(), key);
         }
     }
 }
 
 pub trait ServiceTablesWrapper {
-    fn get_service() -> AccountNumber;
+    const SERVICE: AccountNumber;
 }
 
 pub struct SingletonKey {}
@@ -212,9 +224,8 @@ impl ToKey for SingletonKey {
     fn append_key(&self, _key: &mut Vec<u8>) {}
 }
 
-#[derive(Clone)]
 pub struct TableIndex<Key: ToKey, Record: TableRecord> {
-    pub db_id: DbId,
+    pub db: KvHandle,
     pub prefix: Vec<u8>,
     pub is_secondary: bool,
     pub key_type: PhantomData<Key>,
@@ -223,9 +234,9 @@ pub struct TableIndex<Key: ToKey, Record: TableRecord> {
 
 impl<Key: ToKey, Record: TableRecord> TableIndex<Key, Record> {
     /// Instantiate a new Table Index (Primary or Secondary)
-    pub fn new(db_id: DbId, prefix: Vec<u8>, is_secondary: bool) -> TableIndex<Key, Record> {
+    pub fn new(db: &KvHandle, prefix: Vec<u8>, is_secondary: bool) -> TableIndex<Key, Record> {
         TableIndex {
-            db_id,
+            db: db.subtree(&[], KvMode::Read),
             prefix,
             is_secondary,
             key_type: PhantomData,
@@ -238,7 +249,7 @@ impl<Key: ToKey, Record: TableRecord> TableIndex<Key, Record> {
         let mut key_bytes = self.prefix.clone();
         key.append_key(&mut key_bytes);
 
-        kv_get_bytes(self.db_id, &key_bytes).and_then(|v| self.get_value_from_bytes(v))
+        kv_get_bytes(&self.db, &key_bytes).and_then(|v| self.get_value_from_bytes(v))
     }
 
     /// Creates an iterator for visiting all the table key-values, in sorted order.
@@ -308,7 +319,7 @@ impl<Key: ToKey, Record: TableRecord> TableIndex<Key, Record> {
 
     fn get_value_from_bytes(&self, bytes: Vec<u8>) -> Option<Record> {
         if self.is_secondary {
-            kv_get(self.db_id, &RawKey::new(bytes)).unwrap()
+            kv_get(&self.db, &RawKey::new(bytes)).unwrap()
         } else {
             Some(Record::unpacked(&bytes[..]).unwrap())
         }
@@ -346,7 +357,7 @@ impl<'a, Key: ToKey, Record: TableRecord> Iterator for TableIter<'a, Key, Record
             .as_ref()
             .map_or(&self.table_index.prefix[..], |k| &k.data[..]);
         let value = kv_greater_equal_bytes(
-            self.table_index.db_id,
+            &self.table_index.db,
             key,
             self.table_index.prefix.len() as u32,
         );
@@ -394,12 +405,12 @@ impl<'a, Key: ToKey, Record: TableRecord> DoubleEndedIterator for TableIter<'a, 
 
         let value = if let Some(back_key) = &self.back_key {
             kv_less_than_bytes(
-                self.table_index.db_id,
+                &self.table_index.db,
                 &back_key.data[..],
                 self.table_index.prefix.len() as u32,
             )
         } else {
-            kv_max_bytes(self.table_index.db_id, &self.table_index.prefix)
+            kv_max_bytes(&self.table_index.db, &self.table_index.prefix)
         };
 
         if let Some(value) = value {

--- a/rust/psibase_macros/psibase-macros-lib/src/service_macro/mod.rs
+++ b/rust/psibase_macros/psibase-macros-lib/src/service_macro/mod.rs
@@ -720,9 +720,7 @@ fn process_mod(
         if let Some(tables) = tables {
             items.push(parse_quote! {
                 impl #psibase_mod::ServiceTablesWrapper for super::#tables::TablesWrapper {
-                    fn get_service() -> #psibase_mod::AccountNumber {
-                        #constant
-                    }
+                    const SERVICE: #psibase_mod::AccountNumber = #constant;
                 }
             });
         }

--- a/rust/test_contract_2/src/lib.rs
+++ b/rust/test_contract_2/src/lib.rs
@@ -104,7 +104,7 @@ mod service {
     impl Query {
         /// Get the answer to `account`'s most recent calculation
         async fn answer(&self, account: AccountNumber) -> Option<Answer> {
-            AnswerTable::new().get_index_pk().get(&account)
+            AnswerTable::read().get_index_pk().get(&account)
         }
 
         /// Look up an event


### PR DESCRIPTION
- add kvOpen, kvOpenAt, and kvClose
- Convert native tables to use Table instead of direct kvGet/Put
- Add mode arguments (read or write) as needed in many services

Permissions for open are the same as for get or put previously. They will updated in a follow-on PR that implements the host functions for transferring handles between services.