### PR TITLE
Fix database corruption when a change to the verify services flushes the transaction queue

### DIFF
--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -1291,9 +1291,9 @@ void RTransact::requeue()
                auto data = txdata.get(item.id);
                check(!!data, "Missing transaction data");
 
-               scheduleVerify(item.id, data->trx, true, item.speculative);
-
                pending.remove(item);
+
+               scheduleVerify(item.id, data->trx, true, item.speculative);
             }
             nextSequence = item.sequence + 1;
          }
@@ -1424,7 +1424,7 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest&  reques
       {
          auto clients = open<TraceClientTable>();
          auto row     = clients.get(id).value_or(
-                 TraceClientRow{.id = id, .expiration = trx.transaction->tapos().expiration()});
+             TraceClientRow{.id = id, .expiration = trx.transaction->tapos().expiration()});
          row.clients.push_back({*socket, json, query.flag()});
          clients.put(row);
          to<HttpServer>().deferReply(*socket);


### PR DESCRIPTION
If a transaction has no signatures, it still gets processed, but gets added back to the queue immediately. This overwrites the same primary key, which makes the subsequent remove wrong.