### PR TITLE
fix plugin tester

### DIFF
--- a/packages/user/CommonApi/common/packages/plugin-tester/ui/src/components/inputs/TypeBasedInput.tsx
+++ b/packages/user/CommonApi/common/packages/plugin-tester/ui/src/components/inputs/TypeBasedInput.tsx
@@ -86,7 +86,7 @@ export const TypeBasedInput = ({
             <NumberInput
                 {...commonProps}
                 value={actualValue as number}
-                type={resolvedType as string}
+                type={typeName}
             />
         );
     if (inputType === "boolean")


### PR DESCRIPTION
type aliases on numeric types (which were recently introduced to the tokens plugin) break the plugin tester dynamic GUI generator. This is a fix