### PR TITLE
use large runner - 4 vCPU, 16GB RAM, 150GB SSD

### DIFF
--- a/.github/workflows/ubuntu-builder.yml
+++ b/.github/workflows/ubuntu-builder.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Ubuntu ${{ matrix.ubuntu-version }} - Build
-    runs-on: ubuntu-xlarge
+    runs-on: ubuntu-large
     env:
       can-publish: ${{ !! secrets.publish-package-login }}
     strategy:


### PR DESCRIPTION
The xlarge runner is too expensive. Our github actions budget was consumed almost immediately.
This runner has the same vcpu/ram as the standard free github runners, so it won't be any faster, but it has larger storage so we shouldn't hit the storage limit.