### PR TITLE
Try to fix test_query

### DIFF
--- a/programs/psinode/tests/test_query.py
+++ b/programs/psinode/tests/test_query.py
@@ -93,6 +93,7 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(r1, {"i":9})
 
         XAdmin(a).install(os.path.join(testutil.test_packages(), "XSocketList.psi"))
+        time.sleep(0.5)
 
         # Check that all sockets were cleaned up
         sockets = a.graphql(service='x-sock-list', query='''


### PR DESCRIPTION
The test occasionally fails because the server doesn't finish closing the socket before the next request is sent. Add a short delay to let it finish.