### PR TITLE
for now, ignore agents md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ bindings.rs
 target/
 **/install-state.gz
 .clangd
+AGENTS.md


### PR DESCRIPTION
While agents.md is under development and we play around to find optimal descriptions/instructions, let's ignore this. When we have one that works well we can commit to source control.