### PR TITLE
Better support for worktree development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist
 vite.config.ts.timestamp-*.mjs
 .pnpm-store
 .env
+.envrc
 psinode_db
 psinode_db_secure
 /db

--- a/.vscode/.envrc
+++ b/.vscode/.envrc
@@ -1,0 +1,5 @@
+# .envrc
+PATH_rm "*/build/psidk/bin"
+PATH_rm "*/build/rust/release"
+PATH_add "$(pwd)/build/psidk/bin"
+PATH_add "$(pwd)/build/rust/release"

--- a/.vscode/scripts/env-setup.sh
+++ b/.vscode/scripts/env-setup.sh
@@ -9,11 +9,11 @@ for file in "$WORKSPACE_ROOT/.vscode"/*.sample; do
     echo "Copied $file to ${file%.sample}"
 done
 
+# Symlink files to workspace root
+[ ! -L "$WORKSPACE_ROOT/.clangd" ] && ln -s "$SCRIPT_DIR/../.clangd" "$WORKSPACE_ROOT/.clangd"
+[ ! -L "$WORKSPACE_ROOT/.envrc" ] && ln -s "$SCRIPT_DIR/../.envrc" "$WORKSPACE_ROOT/.envrc"
+
 # Install dependencies and configure VSCode SDKs
 cd "$WORKSPACE_ROOT/packages"
 yarn
 yarn dlx @yarnpkg/sdks vscode
-
-# Symlink files to workspace root
-[ ! -L "$WORKSPACE_ROOT/.clangd" ] && ln -s "$SCRIPT_DIR/.clangd" "$WORKSPACE_ROOT/.clangd"
-[ ! -L "$WORKSPACE_ROOT/.envrc" ] && ln -s "$SCRIPT_DIR/.envrc" "$WORKSPACE_ROOT/.envrc"

--- a/.vscode/scripts/env-setup.sh
+++ b/.vscode/scripts/env-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copy sample VSCode configuration files
+for file in /root/psibase/.vscode/*.sample; do
+    cp "$file" "${file%.sample}"
+    echo "Copied $file to ${file%.sample}"
+done
+
+# Install dependencies and configure VSCode SDKs
+cd packages
+yarn
+yarn dlx @yarnpkg/sdks vscode
+
+# Symlink files to workspace root
+[ ! -L /root/psibase/.clangd ] && ln -s /root/psibase/.vscode/.clangd /root/psibase/.clangd
+[ ! -L /root/psibase/.envrc ] && ln -s /root/psibase/.vscode/.envrc /root/psibase/.envrc

--- a/.vscode/scripts/env-setup.sh
+++ b/.vscode/scripts/env-setup.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+WORKSPACE_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
 # Copy sample VSCode configuration files
-for file in /root/psibase/.vscode/*.sample; do
+for file in "$WORKSPACE_ROOT/.vscode"/*.sample; do
     cp "$file" "${file%.sample}"
     echo "Copied $file to ${file%.sample}"
 done
 
 # Install dependencies and configure VSCode SDKs
-cd packages
+cd "$WORKSPACE_ROOT/packages"
 yarn
 yarn dlx @yarnpkg/sdks vscode
 
 # Symlink files to workspace root
-[ ! -L /root/psibase/.clangd ] && ln -s /root/psibase/.vscode/.clangd /root/psibase/.clangd
-[ ! -L /root/psibase/.envrc ] && ln -s /root/psibase/.vscode/.envrc /root/psibase/.envrc
+[ ! -L "$WORKSPACE_ROOT/.clangd" ] && ln -s "$SCRIPT_DIR/.clangd" "$WORKSPACE_ROOT/.clangd"
+[ ! -L "$WORKSPACE_ROOT/.envrc" ] && ln -s "$SCRIPT_DIR/.envrc" "$WORKSPACE_ROOT/.envrc"


### PR DESCRIPTION
I'm testing some support for git worktree development workflows.

Triggering this `env-setup` script would still be from the `psibase-contributor` tool, but the script source being in the psibase repo makes it more readily available for me to run in different worktrees.

I'm also testing using a tool called `direnv` for automatically setting up local PATH variables based on the shell working directory.