### PR TITLE
support divisor for the number of cpu cores to use for the build

### DIFF
--- a/.vscode/scripts/build.sh
+++ b/.vscode/scripts/build.sh
@@ -11,6 +11,8 @@ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
       -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       -DCMAKE_C_COMPILER_LAUNCHER=ccache \
       -DCMAKE_INSTALL_PREFIX="psidk" "$PROJECT_ROOT"
-
-JOBS=$(( $(nproc) / 3 ))
-make install -j "$JOBS"
+cores_divisor="${1:-3}"
+num_procs="$(nproc)"
+jobs=$(( num_procs / cores_divisor ))
+if [ "$jobs" -lt 1 ]; then jobs=1; fi
+make install -j "$jobs"


### PR DESCRIPTION
Add an optional arg after `build.sh` to determine the divisor to the number of cpu cores.
For example

`build.sh 3` means `make -j ($(nproc) / 3)`

Default is 3. Lowering the number increases cores, 1 is all cores, more cores means more probability of running out of memory during builds