### PR TITLE
Save space during build by sharing output dir

### DIFF
--- a/libraries/psibase/sdk/pack_service.cmake
+++ b/libraries/psibase/sdk/pack_service.cmake
@@ -340,7 +340,7 @@ function(cargo_psibase_package)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_PATH}
         BUILD_BYPRODUCTS ${PACKAGE_OUTPUT}
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/cargo-home ${CMAKE_CURRENT_BINARY_DIR}/rust/release/cargo-psibase package
+        BUILD_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/rust/release/cargo-psibase package
             --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_PATH}/Cargo.toml
             --target-dir ${CMAKE_CURRENT_BINARY_DIR}/packages
         INSTALL_COMMAND ""

--- a/libraries/psibase/sdk/rs-components.cmake
+++ b/libraries/psibase/sdk/rs-components.cmake
@@ -70,7 +70,7 @@ function(add_rs_component_workspace TARGET_TUPLE)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${PATH}
         BUILD_BYPRODUCTS ${OUTPUT_FILEPATHS}
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/cargo-home cargo component build -r
+        BUILD_COMMAND cargo component build -r
             --target ${TARGET_ARCH}
             --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/${PATH}/Cargo.toml 
             --target-dir    ${TARGET_DIR}


### PR DESCRIPTION
Have all packages build to the same target dir.
Savings: ~3GB of space
Cost:
 - This process processes a lot of contention due to how cargo locks the target dir, BUT
 - the cost is only about 15% in time.

Note:
We have other options, like creating a workspace for packages/{local,system,user} separately, which would get back some of that lost time but trade more of the saved space, *and* the implementation would be a lot more work.
This solution is super simple and worth about 3GB.