### PR TITLE
invoke scripts through direnv, so they get associated PATH config

### DIFF
--- a/.vscode/scripts/continue.sh
+++ b/.vscode/scripts/continue.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env -S direnv exec . bash
+set -euo pipefail
 
 # Continue/resume a chain
 # Same as launch but doesn't first delete the db.

--- a/.vscode/scripts/launch.sh
+++ b/.vscode/scripts/launch.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env -S direnv exec . bash
+set -euo pipefail
 
 # Launch a chain
 

--- a/.vscode/scripts/launch_secure.sh
+++ b/.vscode/scripts/launch_secure.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env -S direnv exec . bash
+set -euo pipefail
 
 # Launch a secure chain
 


### PR DESCRIPTION
After main is pulled that includes this, everyone relying on these scripts will need direnv installed (psibase-contributor version 0.15)