### PR TITLE
remove user namespacing from the transactional db

### DIFF
--- a/packages/user/Host/plugin/common/src/bucket.rs
+++ b/packages/user/Host/plugin/common/src/bucket.rs
@@ -1,4 +1,3 @@
-use crate::accounts::plugin::api as Accounts;
 use crate::exports::host::common::{
     store::{Database, DbMode, GuestBucket, StorageDuration},
 };
@@ -157,17 +156,7 @@ impl GuestBucket for Bucket {
         };
         let chain_id = get_chain_id();
 
-        let bucket_id = if db.mode == DbMode::Transactional {
-            // Transactional databases are additionally namespaced by the current user
-            let current_user = Accounts::get_current_user()
-                .expect("User must be logged in to use the transactional database");
-            format!(
-                "{}:{}:{}:{}:{}",
-                chain_id, mode, current_user, service_account, identifier
-            )
-        } else {
-            format!("{}:{}:{}:{}", chain_id, mode, service_account, identifier)
-        };
+        let bucket_id = format!("{}:{}:{}:{}", chain_id, mode, service_account, identifier);
         Self { bucket_id, db }
     }
 


### PR DESCRIPTION
Originally, the reason I added the user namespace was in preparation for synchronizing user data using the chain. 

I still think this is a good idea, but I think we need to introduce a different DbMode, like `DbMode::Synchronized`. This is because I am now convinced that there are valid scenarios where updates to the client-side db should persist only if the call context is successful, but where there is no logged-in user.