### PR TITLE
Add the ability to disconnect accounts from apps

### DIFF
--- a/packages/system/Accounts/plugin/accounts/src/interfaces/active_app.rs
+++ b/packages/system/Accounts/plugin/accounts/src/interfaces/active_app.rs
@@ -50,6 +50,25 @@ impl ActiveApp for AccountsPlugin {
         Ok(())
     }
 
+    fn disconnect(account: String) -> Result<(), Error> {
+        let app = get_assert_top_level_app("disconnect", &vec![client::get_receiver().as_str()])?;
+        let apps_table = AppsTable::new(&app);
+
+        if !apps_table.get_connected_accounts().contains(&account) {
+            return Ok(());
+        }
+
+        if let Some(user) = apps_table.get_logged_in_user() {
+            if user == account {
+                HostAuth::log_out_user(&user, &app);
+                apps_table.logout();
+            }
+        }
+
+        apps_table.disconnect(&account);
+        Ok(())
+    }
+
     fn get_connected_accounts() -> Result<Vec<String>, Error> {
         let app = get_assert_top_level_app("get_connected_accounts", &vec!["supervisor"])?;
         Ok(AppsTable::new(&app).get_connected_accounts())

--- a/packages/system/Accounts/plugin/accounts/wit/world.wit
+++ b/packages/system/Accounts/plugin/accounts/wit/world.wit
@@ -20,6 +20,9 @@ interface active-app {
     /// Logs out the currently logged-in user.
     logout: func() -> result<_, error>;
 
+    /// Disconnects a previously connected account from the active app
+    disconnect: func(account: string) -> result<_, error>;
+
     /// Retrieves a list of accounts that the user has connected to this app.
     /// The user may only log in to accounts that have been connected.
     get-connected-accounts: func() -> result<list<string>, error>;


### PR DESCRIPTION
Tested calling `disconnect` directly from the active app, which works.
Didn't test it from the login prompt page, but it should also work there.