### PR TITLE
Augmenting Rust tester

### DIFF
--- a/packages/.cargo/config.toml
+++ b/packages/.cargo/config.toml
@@ -1,2 +1,3 @@
 [build]
+# This setting cascades through the *directory tree*; it doesn't just apply to workspace members.
 target = "wasm32-wasip1"

--- a/packages/system/.cargo/config.toml
+++ b/packages/system/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-wasip1"

--- a/packages/user/.cargo/config.toml
+++ b/packages/user/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-wasip1"

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -60,7 +60,7 @@ pub mod tables {
         pub fn get_by_symbol(symbol: AccountNumber) -> Option<Self> {
             let mut tokens: Vec<Token> = TokenTable::read()
                 .get_index_by_symbol()
-                .range((Some(symbol), 0 as u32)..=(Some(symbol), u32::MAX))
+                .range((Some(symbol), 0_u32)..=(Some(symbol), u32::MAX))
                 .collect();
 
             tokens.pop()


### PR DESCRIPTION
Making WASM functions visible to rust linter (avoiding linter errors for functions that *do* exist but only in the WASM build context)
add filter to allow running individual tests