### PR TITLE
No op token debit

### DIFF
--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -431,7 +431,9 @@ pub mod tables {
         }
 
         pub fn debit(&mut self, quantity: Quantity, memo: Memo) {
-            check(quantity.value > 0, "debit quantity must be greater than 0");
+            if quantity.value == 0 {
+                return;
+            }
 
             crate::Wrapper::emit().history().balChanged(
                 self.token_id,


### PR DESCRIPTION
Is throwing really warranted if one tries to debit nothing? 
I imagine this is going to be a common mistake in 3rd party development. 