### PR TITLE
Allow cargo-psibase to build multiple packages

### DIFF
--- a/rust/cargo-psibase/src/main.rs
+++ b/rust/cargo-psibase/src/main.rs
@@ -657,7 +657,7 @@ async fn test(args: &Args, opts: &TestCommand, metadata: &MetadataIndex<'_>) -> 
             if let Some(found) = built.get(p) {
                 index.push(found.clone());
             } else {
-                let info = build_package(args, metadata, Some(id)).await?;
+                let info = build_package(args, metadata, Some(p.repr.as_str())).await?;
                 built.insert(p, info.clone());
                 index.push(info);
             }


### PR DESCRIPTION
This does not improve parallelism, because I couldn't figure out a way to build the services with a single cargo command. (`cargo rustc` only builds one crate; `cargo build` can't take the options that we need to pass). It does make it behave more like cargo.