### PR TITLE
Allow separate versions for 2204 and 2404 images.

### DIFF
--- a/.github/workflows/ubuntu-builder.yml
+++ b/.github/workflows/ubuntu-builder.yml
@@ -48,7 +48,8 @@ jobs:
           BUILDER_IMAGE_2204: f8d833ccdd03cbaaa2e6319c9c01a93168b82f37
           BUILDER_IMAGE_2404: 69a0c8fa35ac92723a85000d2775aca292e71e54
         run: |
-          BUILDER_IMAGE="ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-${{ matrix.ubuntu-version }}:$BUILDER_IMAGE${{ matrix.ubuntu-version }}"
+          BUILDER_IMAGE="ghcr.io/${{ github.repository_owner }}/psibase-builder-ubuntu-${{ matrix.ubuntu-version }}:$BUILDER_IMAGE_${{ matrix.ubuntu-version }}"
+          echo $BUILDER_IMAGE
           bash ${GITHUB_WORKSPACE}/.github/scripts/build.sh ${GITHUB_WORKSPACE} "$BUILDER_IMAGE" ${{ matrix.ubuntu-version }}
       - name: Publish packages
         if: fromJSON(env.can-publish) && matrix.ubuntu-version == '2404'


### PR DESCRIPTION
image-builders only rebuilds the images that were changed, so there isn't necessarily a single version that is usable for both.