### PR TITLE
Add a timeout to ctest

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -58,7 +58,7 @@ ${DOCKER} bash -c "cd build && make -j $(nproc) && ( echo '===== sccache =====';
 echo =====
 ${DOCKER} bash -c "cd rust && cargo build --target-dir ../build/rust --release"
 echo =====
-${DOCKER} bash -c "cd build && ctest --output-on-failure -j $(nproc)"
+${DOCKER} bash -c "cd build && ctest --output-on-failure -j $(nproc) --timeout 600"
 echo =====
 ls -la ${WORKSPACE_ROOT}
 ls -la ${WORKSPACE_ROOT}/build/doc


### PR DESCRIPTION
When github times out at 6 hours, it's not necessarily easy to figure which test hung. The longest test currently takes ~200 seconds, so 10 minutes should be plenty.