### PR TITLE
Fix race when sending HTTP requests

### DIFF
--- a/doc/src/development/services/local.md
+++ b/doc/src/development/services/local.md
@@ -91,11 +91,15 @@ let socket = x_http::Wrapper::call().sendRequest(
         contentType: Default::default(),
         body: Default::default(),
     },
-    method!("succeeded"),
-    method!("failed"),
     None,
     None,
 );
+subjective_tx! {
+    x_http::Wrapper::call().setCallback(socket,
+        method!("succeeded"), method!("failed"));
+    // Add socket to a table so we know what to do
+    // with the response
+}
 
 ...
 #[action]
@@ -111,10 +115,15 @@ std::int32_t socket = to<XHttp>().sendRequest(
         .method = "GET",
         .target = "https://example.com/"
     },
-    MethodNumber{"succeeded"},
-    MethodNumber{"failed"},
     std::nullopt, std::nullopt
 );
+PSIBASE_SUBJECTIVE_TX
+{
+    to<XHttp>().setCallback(socket,
+        MethodNumber{"succeeded"}, MethodNumber{"failed"});
+    // Add socket to a table so we know what to do
+    // with the response
+}
 
 ...
 void succeeded(std::int32_t socket, HttpReply reply);
@@ -139,11 +148,15 @@ let socket = x_http::Wrapper::call().websocket(
         contentType: Default::default(),
         body: Default::default(),
     },
-    method!("connected"),
-    method!("failed"),
     None,
     None,
 );
+subjective_tx! {
+    x_http::Wrapper::call().setCallback(socket,
+        method!("connected"), method!("failed"));
+    // Add socket to a table so we know what to do with the
+    // messages we receive
+}
 
 ...
 #[action]
@@ -167,10 +180,15 @@ std::int32_t socket = to<XHttp>().websocket(
         .method = "GET",
         .target = "https://websocket.example.com/"
     },
-    MethodNumber{"connected"},
-    MethodNumber{"failed"},
     std::nullopt, std::nullopt
 );
+PSIBASE_SUBJECTIVE_TX
+{
+    to<XHttp>().setCallback(socket,
+        MethodNumber{"connected"}, MethodNumber{"failed"});
+    // Add socket to a table so we know what to do with the
+    // messages we receive
+}
 
 ...
 void connected(std::int32_t socket, HttpReply reply)

--- a/libraries/psibase/native/include/psibase/SystemContext.hpp
+++ b/libraries/psibase/native/include/psibase/SystemContext.hpp
@@ -40,6 +40,8 @@ namespace psibase
 
       bool needGenesis() const;
 
+      std::shared_ptr<Sockets> sockets();
+
       std::unique_ptr<SystemContext> getSystemContext();
       void                           addSystemContext(std::unique_ptr<SystemContext> context);
    };

--- a/libraries/psibase/native/src/SystemContext.cpp
+++ b/libraries/psibase/native/src/SystemContext.cpp
@@ -59,6 +59,11 @@ namespace psibase
       return result;
    }
 
+   std::shared_ptr<Sockets> SharedState::sockets()
+   {
+      return impl->sockets;
+   }
+
    bool SharedState::needGenesis() const
    {
       auto sharedDb = [&]

--- a/packages/local/XHttp/include/services/local/XHttp.hpp
+++ b/packages/local/XHttp/include/services/local/XHttp.hpp
@@ -52,16 +52,20 @@ namespace LocalService
       /// Sends a message to a socket. HTTP sockets should use sendReply, instead.
       void send(std::int32_t socket, psio::view<const std::vector<char>> data);
 
-      /// Sends an HTTP request and returns the new socket. When the response
+      /// Sends an HTTP request and returns the new socket.
+      ///
+      /// Must be followed by `setCallback(socket, callback, err)`, or the
+      /// socket will be closed when the current context exits. When the response
       /// is available, it will be passed to `sender::callback(socket, reply)`.
       /// If the the request fails without a response, calls `sender::err(socket)`
       std::int32_t sendRequest(psibase::HttpRequest                   request,
-                               psibase::MethodNumber                  callback,
-                               psibase::MethodNumber                  err,
                                std::optional<psibase::TLSInfo>        tls,
                                std::optional<psibase::SocketEndpoint> endpoint);
 
-      /// Opens a websocket connection and returns the new socket. The
+      /// Opens a websocket connection and returns the new socket.
+      ///
+      /// Must be followed by `setCallback(socket, callback, err)`, or the
+      /// socket will be closed when the current context exits. The
       /// request method must be GET. The required headers for the websocket
       /// handshake will be added to the request if they are not already
       /// provided. If the connection is successfully established, calls
@@ -70,8 +74,6 @@ namespace LocalService
       /// does not complete a websocket handshake, calls
       /// `sender::err(socket, optional(reply))`
       std::int32_t websocket(psibase::HttpRequest                   request,
-                             psibase::MethodNumber                  callback,
-                             psibase::MethodNumber                  err,
                              std::optional<psibase::TLSInfo>        tls,
                              std::optional<psibase::SocketEndpoint> endpoint);
 
@@ -91,8 +93,10 @@ namespace LocalService
                   psibase::MethodNumber     callback,
                   psibase::MethodNumber     err);
 
-      /// Changes the callback for a socket. The sender must be the owner
+      /// Changes the callbacks for a socket. The sender must be the owner
       /// of the socket.
+      ///
+      /// Can be called inside `PSIBASE_SUBJECTIVE_TX`
       void setCallback(std::int32_t          socket,
                        psibase::MethodNumber callback,
                        psibase::MethodNumber err);
@@ -109,8 +113,8 @@ namespace LocalService
    };
    PSIO_REFLECT(XHttp,
                 method(send, socket, data),
-                method(sendRequest, request, callback, err, tls, endpoint),
-                method(websocket, request, callback, err, tls, endpoint),
+                method(sendRequest, request, tls, endpoint),
+                method(websocket, request, tls, endpoint),
                 method(autoClose, socket, value),
                 method(sendReply, socket, response),
                 method(accept, socket, reply, callback, err),

--- a/packages/local/XHttp/src/XHttp.cpp
+++ b/packages/local/XHttp/src/XHttp.cpp
@@ -10,10 +10,20 @@ using namespace psibase;
 using namespace LocalService;
 using namespace SystemService;
 
-using Temporary = TemporaryTables<PendingRequestTable>;
-
 namespace
 {
+   // This is used to store outgoing HTTP requests before their callbacks are set.
+   struct TempResponseHandlerRow
+   {
+      std::int32_t           socket;
+      SocketType             type;
+      psibase::AccountNumber service;
+   };
+   PSIO_REFLECT(TempResponseHandlerRow, socket, type, service)
+   using TempResponseHandlerTable = Table<TempResponseHandlerRow, &TempResponseHandlerRow::socket>;
+
+   using Temporary = TemporaryTables<PendingRequestTable, TempResponseHandlerTable>;
+
    bool matches(psio::view<const HttpHeader> header, std::string_view h)
    {
       return std::ranges::equal(std::string_view{header.name()}, h, {}, ::tolower, ::tolower);
@@ -152,7 +162,7 @@ extern "C" [[clang::export_name("recv")]] void recv()
          if (row->type == SocketType::http)
          {
             requests.remove(*row);
-            socketAutoClose(socket, true);
+            check(socketAutoClose(socket, true) == 0, "Failed to set auto-close");
          }
          else if (row->type == SocketType::handshake)
          {
@@ -169,7 +179,7 @@ extern "C" [[clang::export_name("recv")]] void recv()
             else
             {
                requests.remove(*row);
-               socketAutoClose(socket, true);
+               check(socketAutoClose(socket, true) == 0, "Failed to set auto-close");
             }
          }
       }
@@ -225,7 +235,7 @@ extern "C" [[clang::export_name("close")]] void closeSocket()
       {
          requests.remove(*row);
       }
-      socketAutoClose(socket, true);
+      check(socketAutoClose(socket, true) == 0, "Failed to set auto-close");
    }
 
    if (row)
@@ -266,8 +276,6 @@ void XHttp::send(std::int32_t socket, psio::view<const std::vector<char>> data)
 }
 
 std::int32_t XHttp::sendRequest(HttpRequest                   request,
-                                MethodNumber                  callback,
-                                MethodNumber                  err,
                                 std::optional<TLSInfo>        tls,
                                 std::optional<SocketEndpoint> endpoint)
 {
@@ -278,20 +286,17 @@ std::int32_t XHttp::sendRequest(HttpRequest                   request,
       if (!codeTable.get(sender))
          abortMessage("Only local services can use sendRequest");
    }
-   auto requests = Session{}.open<ResponseHandlerTable>();
+   auto requests = Temporary{}.open<TempResponseHandlerTable>();
    auto sock     = socketOpen(request, tls, endpoint);
    check(sock >= 0, "Failed to open socket");
    PSIBASE_SUBJECTIVE_TX
    {
-      requests.put({sock, SocketType::http, sender, callback, err});
-      socketAutoClose(sock, false);
+      requests.put({sock, SocketType::http, sender});
    }
    return sock;
 }
 
 std::int32_t XHttp::websocket(HttpRequest                   request,
-                              MethodNumber                  callback,
-                              MethodNumber                  err,
                               std::optional<TLSInfo>        tls,
                               std::optional<SocketEndpoint> endpoint)
 {
@@ -302,13 +307,12 @@ std::int32_t XHttp::websocket(HttpRequest                   request,
       if (!codeTable.get(sender))
          abortMessage("Only local services can use sendRequest");
    }
-   auto requests = Session{}.open<ResponseHandlerTable>();
+   auto requests = Temporary{}.open<TempResponseHandlerTable>();
    auto sock     = socketOpen(request, tls, endpoint);
    check(sock >= 0, "Failed to open socket");
    PSIBASE_SUBJECTIVE_TX
    {
-      requests.put({sock, SocketType::handshake, sender, callback, err});
-      socketAutoClose(sock, false);
+      requests.put({sock, SocketType::handshake, sender});
    }
    return sock;
 }
@@ -335,7 +339,7 @@ void XHttp::autoClose(std::int32_t socket, bool value)
             abortMessage(sender.str() + " cannot send a response on socket " +
                          std::to_string(socket));
       }
-      socketAutoClose(socket, value);
+      check(socketAutoClose(socket, value) == 0, "Failed to change auto-close");
    }
 }
 
@@ -349,7 +353,7 @@ void XHttp::close(std::int32_t socket)
       if (!row || row->service != sender)
          abortMessage(sender.str() + " cannot close socket " + std::to_string(socket));
       requests.remove(*row);
-      socketAutoClose(socket, true);
+      check(socketAutoClose(socket, true) == 0, "Failed to set auto-close");
    }
 }
 
@@ -414,6 +418,16 @@ void XHttp::setCallback(std::int32_t          socket,
    PSIBASE_SUBJECTIVE_TX
    {
       auto row = requests.get(socket);
+      if (!row)
+      {
+         auto temp = Temporary{}.open<TempResponseHandlerTable>();
+         if (auto tempRow = temp.get(socket))
+         {
+            row = {tempRow->socket, tempRow->type, tempRow->service, callback, err};
+            temp.remove(*tempRow);
+            check(socketAutoClose(socket, false) == 0, "Failed to disable auto-close");
+         }
+      }
       if (!row || row->service != sender)
          abortMessage(sender.str() + " does not own socket " + std::to_string(socket));
       row->method = callback;

--- a/programs/psinode/tests/test_fetch.py
+++ b/programs/psinode/tests/test_fetch.py
@@ -59,7 +59,7 @@ class TestFetch(unittest.TestCase):
 
         XAdmin(a).install(os.path.join(testutil.test_packages(), "XProxy.psi"))
 
-        with a.post('/set_origin_server', service='x-proxy', json={"host":"x-admin.%s" % a.hostname, "endpoint": a.socketpath}) as reply:
+        with a.post('/set_origin_server', service='x-proxy', json={"host":"x-admin.%s" % a.hostname, "endpoint": a.socketpath, "spin": 100000}) as reply:
             reply.raise_for_status()
 
         with a.get('/config', service='x-proxy') as reply:

--- a/rust/psibase/src/services/x_http.rs
+++ b/rust/psibase/src/services/x_http.rs
@@ -9,33 +9,35 @@ mod service {
         unimplemented!()
     }
 
-    /// Sends an HTTP request and returns the new socket. When the response
+    /// Sends an HTTP request and returns the new socket.
+    ///
+    /// Must be followed by `setCallback(socket, callback, err)`, or the
+    /// socket will be closed when the current context exits. When the response
     /// is available, it will be passed to `sender::callback(socket, reply)`.
     /// If the the request fails without a response, calls `sender::err(socket)`
     #[action]
     fn sendRequest(
         request: HttpRequest,
-        callback: MethodNumber,
-        err: MethodNumber,
         tls: Option<TLSInfo>,
         endpoint: Option<SocketEndpoint>,
     ) -> i32 {
         unimplemented!()
     }
 
-    /// Opens a websocket connection and returns the new socket. The
+    /// Opens a websocket connection and returns the new socket.
+    ///
+    /// Must be followed by `setCallback(socket, callback, err)`, or the
+    /// socket will be closed when the current context exits. The
     /// request method must be GET. The required headers for the websocket
     /// handshake will be added to the request if they are not already
     /// provided. If the connection is successfully established, calls
     /// `sender::callback(socket, reply)`. If the request fails without
-    /// a response, calls `sender::err(socket, None)`. If the response
+    /// a response, calls `sender::err(socket, nullopt)`. If the response
     /// does not complete a websocket handshake, calls
-    /// `sender::err(socket, Some(reply))`
+    /// `sender::err(socket, optional(reply))`
     #[action]
     fn websocket(
         request: HttpRequest,
-        callback: MethodNumber,
-        err: MethodNumber,
         tls: Option<TLSInfo>,
         endpoint: Option<SocketEndpoint>,
     ) -> i32 {


### PR DESCRIPTION
The socket isn't known until after the call to sendRequest returns, so the service has to insert it in a table afterwards. However, the response might come back at any time after sendRequest, and it could be before the table entry was added, causing the response to get lost.

The solution is to add some extra rules:
- The socket for an outgoing request starts with autoClose enabled.
- recv cannot be run while autoClose is enabled. If a response is received, it will be delayed until autoClose is disabled.
- setting autoClose will fail, if recv is running in a different context.

The interface in XHttp is refactored to require a separate call to setCallback instead of passing the callbacks to setRequest.

Provided the service inserts the socket in a table and calls setCallback in a single subjective tx, this ensures that:
- If the service aborts before inserting the socket into a table, everything related to the socket will be cleaned up correctly.
- When recv is called, it will see the table entry