### PR TITLE
Rename setMaxTransactionTime

### DIFF
--- a/libraries/psibase/common/include/psibase/api.hpp
+++ b/libraries/psibase/common/include/psibase/api.hpp
@@ -251,9 +251,11 @@ namespace psibase
       /// This function is non-deterministic and is only available in subjective services.
       PSIBASE_NATIVE(getRandom) void getRandom(void* buf, std::uint32_t len);
 
-      /// Sets the transaction timer to expire a given number of nanoseconds
-      /// after the beginning of the current transaction.
-      PSIBASE_NATIVE(setMaxTransactionTime) void setMaxTransactionTime(uint64_t ns);
+      /// Sets the CPU timer to expire after the current transaction/query/callback
+      /// context has run for a given number of nanoseconds. When the timer
+      /// expires, the current context will be terminated. Setting the timeout
+      /// replaces any previous timeout.
+      PSIBASE_NATIVE(setMaxCpuTime) void setMaxCpuTime(uint64_t ns);
 
       /// Loads the subjective database
       ///

--- a/libraries/psibase/common/include/psibase/nativeTables.hpp
+++ b/libraries/psibase/common/include/psibase/nativeTables.hpp
@@ -382,7 +382,7 @@ namespace psibase
       RunMode mode;
       // The initial time limit for the action. If the
       // action has sufficient permissions, it can change
-      // the limit using setMaxTransactionTime. The limit
+      // the limit using setMaxCpuTime. The limit
       // only applies to the action. The continuation is
       // not limited and therefore should be a system service.
       MicroSeconds maxTime;

--- a/libraries/psibase/native/include/psibase/NativeFunctions.hpp
+++ b/libraries/psibase/native/include/psibase/NativeFunctions.hpp
@@ -41,7 +41,7 @@ namespace psibase
       void     abortMessage(eosio::vm::span<const char> str);
       int32_t  clockTimeGet(uint32_t id, eosio::vm::argument_proxy<uint64_t*> time);
       void     getRandom(eosio::vm::span<char> dest);
-      void     setMaxTransactionTime(uint64_t nanoseconds);
+      void     setMaxCpuTime(uint64_t nanoseconds);
       uint32_t getCurrentAction();
       uint32_t call(eosio::vm::span<const char> data, std::uint64_t flags);
       void     setRetval(eosio::vm::span<const char> data);

--- a/libraries/psibase/native/src/ExecutionContext.cpp
+++ b/libraries/psibase/native/src/ExecutionContext.cpp
@@ -355,7 +355,7 @@ namespace psibase
       rhf_t::add<&ExecutionContextImpl::abortMessage>("env", "abortMessage");
       rhf_t::add<&ExecutionContextImpl::clockTimeGet>("env", "clockTimeGet");
       rhf_t::add<&ExecutionContextImpl::getRandom>("env", "getRandom");
-      rhf_t::add<&ExecutionContextImpl::setMaxTransactionTime>("env", "setMaxTransactionTime");
+      rhf_t::add<&ExecutionContextImpl::setMaxCpuTime>("env", "setMaxCpuTime");
       rhf_t::add<&ExecutionContextImpl::getCurrentAction>("env", "getCurrentAction");
       rhf_t::add<&ExecutionContextImpl::call>("env", "call");
       rhf_t::add<&ExecutionContextImpl::setRetval>("env", "setRetval");

--- a/libraries/psibase/native/src/NativeFunctions.cpp
+++ b/libraries/psibase/native/src/NativeFunctions.cpp
@@ -498,9 +498,9 @@ namespace psibase
       std::ranges::generate(dest, [&] { return rng(); });
    }
 
-   void NativeFunctions::setMaxTransactionTime(uint64_t nanoseconds)
+   void NativeFunctions::setMaxCpuTime(uint64_t nanoseconds)
    {
-      check(code.flags & CodeRow::isPrivileged, "setMaxTransactionTime requires privileges");
+      check(code.flags & CodeRow::isPrivileged, "setMaxCpuTime requires privileges");
       clearResult(*this);
       // Ensure no overflow by capping the value. The exact value is not visible to
       // wasm and does not affect consensus and there's no way a transaction can

--- a/libraries/psibase/tester/src/chain_polyfill.cpp
+++ b/libraries/psibase/tester/src/chain_polyfill.cpp
@@ -153,7 +153,7 @@ std::int32_t psibase::raw::socketSend(std::int32_t fd, const void* data, std::si
    psibase::abortMessage("Tester does not support socketSend");
 }
 
-// PSIBASE_NATIVE(setMaxTransactionTime) void setMaxTransactionTime(uint64_t ns);
+// PSIBASE_NATIVE(setMaxCpuTime) void setMaxCpuTime(uint64_t ns);
 
 void psibase::raw::checkoutSubjective()
 {

--- a/packages/system/CpuLimit/src/CpuLimit.cpp
+++ b/packages/system/CpuLimit/src/CpuLimit.cpp
@@ -37,7 +37,7 @@ namespace SystemService
          {
             limit = std::chrono::nanoseconds::max();
          }
-         psibase::raw::setMaxTransactionTime(limit.count());
+         psibase::raw::setMaxCpuTime(limit.count());
       }
    }
 }  // namespace SystemService

--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -7,7 +7,7 @@
 //!
 //! These functions wrap the [Raw Native Functions](crate::native_raw).
 
-use crate::{native_raw, AccountNumber, DbId, ToKey};
+use crate::{native_raw, AccountNumber, DbId, MicroSeconds, ToKey};
 use anyhow::anyhow;
 use fracpack::{Pack, Unpack, UnpackOwned};
 
@@ -337,6 +337,16 @@ pub fn kv_max<K: ToKey, V: UnpackOwned>(db: &KvHandle, key: &K) -> Option<V> {
 pub fn get_sequential_bytes(db_id: DbId, id: u64) -> Option<Vec<u8>> {
     let size = unsafe { native_raw::getSequential(db_id, id) };
     get_optional_result_bytes(size)
+}
+
+/// Sets the CPU timer to expire after the current transaction/query/callback
+/// context has run for a given time. When the timer
+/// expires, the current context will be terminated. Setting the timeout
+/// replaces any previous timeout.
+pub fn set_max_cpu_time<T: Into<MicroSeconds>>(time: T) {
+    let time: MicroSeconds = time.into();
+    let time = (time.value * 1000) as u64;
+    unsafe { native_raw::setMaxCpuTime(time) }
 }
 
 pub use scopeguard;

--- a/rust/psibase/src/native_raw.rs
+++ b/rust/psibase/src/native_raw.rs
@@ -160,6 +160,12 @@ extern "C" {
     /// and [getKey] to get found key.
     pub fn kvMax(db: KvHandle, key: *const u8, key_len: u32) -> u32;
 
+    /// Sets the CPU timer to expire after the current transaction/query/callback
+    /// context has run for a given number of nanoseconds. When the timer
+    /// expires, the current context will be terminated. Setting the timeout
+    /// replaces any previous timeout.
+    pub fn setMaxCpuTime(ns: u64);
+
     pub fn checkoutSubjective();
     pub fn commitSubjective() -> bool;
     pub fn abortSubjective();

--- a/rust/psibase/src/time.rs
+++ b/rust/psibase/src/time.rs
@@ -281,7 +281,7 @@ impl Sub<Seconds> for TimePointUSec {
 #[fracpack(definition_will_not_change, fracpack_mod = "fracpack")]
 #[to_key(psibase_mod = "crate")]
 pub struct MicroSeconds {
-    value: i64,
+    pub value: i64,
 }
 
 impl MicroSeconds {


### PR DESCRIPTION
The name is inaccurate, because it doesn't just apply to transactions