### PR TITLE
Prefer 404 over 405 in XSites

### DIFF
--- a/packages/local/XSites/src/XSites.cpp
+++ b/packages/local/XSites/src/XSites.cpp
@@ -43,7 +43,17 @@ std::optional<HttpReply> XSites::serveSys(HttpRequest req, std::optional<std::in
       }
       return HttpReply{.headers = allowCors(req, XAdmin::service)};
    }
-   else if (req.method == "GET")
+   else if (req.method == "DELETE")
+   {
+      if (auto reply = to<XAdmin>().checkAuth(req, socket))
+         return reply;
+      PSIBASE_SUBJECTIVE_TX
+      {
+         table.erase(target);
+      }
+      return HttpReply{.headers = allowCors(req, XAdmin::service)};
+   }
+   else
    {
       std::optional<ContentRow> row;
       PSIBASE_SUBJECTIVE_TX
@@ -56,6 +66,10 @@ std::optional<HttpReply> XSites::serveSys(HttpRequest req, std::optional<std::in
       }
       if (row)
       {
+         if (req.method != "GET")
+         {
+            return HttpReply::methodNotAllowed(req);
+         }
          auto reply = HttpReply{
              .contentType = std::move(row->contentType),
              .body        = std::move(row->content),
@@ -71,20 +85,6 @@ std::optional<HttpReply> XSites::serveSys(HttpRequest req, std::optional<std::in
          }
          return reply;
       }
-   }
-   else if (req.method == "DELETE")
-   {
-      if (auto reply = to<XAdmin>().checkAuth(req, socket))
-         return reply;
-      PSIBASE_SUBJECTIVE_TX
-      {
-         table.erase(target);
-      }
-      return HttpReply{.headers = allowCors(req, XAdmin::service)};
-   }
-   else
-   {
-      return HttpReply::methodNotAllowed(req);
    }
    return {};
 }


### PR DESCRIPTION
This is mainly for POST. Methods that are not supported by native will still return 405.