### PR TITLE
Fix rust declaration of x-admin

### DIFF
--- a/rust/psibase/src/services/x_admin.rs
+++ b/rust/psibase/src/services/x_admin.rs
@@ -1,10 +1,45 @@
 #[crate::service(name = "x-admin", dispatch = false, psibase_mod = "crate")]
 #[allow(non_snake_case, unused_variables)]
 mod service {
-    use crate::AccountNumber;
-    /// Returns true if the account is a node admin
+    use crate::{AccountNumber, HttpReply, HttpRequest};
+    use fracpack::{Pack, ToSchema, Unpack};
+    use serde::{Deserialize, Serialize};
+
+    /// Returns true if the account or the remote end of socket is a node admin
     #[action]
-    fn isAdmin(account: AccountNumber) -> bool {
+    fn isAdmin(account: Option<AccountNumber>, socket: Option<i32>) -> bool {
         unimplemented!()
     }
+
+    #[action]
+    fn checkAuth(req: HttpRequest, socket: Option<i32>) -> Option<HttpReply> {
+        unimplemented!()
+    }
+
+    #[action]
+    fn serveSys(req: HttpRequest, socket: Option<i32>) -> Option<HttpReply> {
+        unimplemented!()
+    }
+
+    #[action]
+    fn startSession() {
+        unimplemented!()
+    }
+
+    #[action]
+    fn options() -> AdminOptionsRow {
+        unimplemented!()
+    }
+
+    #[derive(Debug, Pack, Unpack, ToSchema, Serialize, Deserialize)]
+    #[fracpack(fracpack_mod = "fracpack")]
+    struct AdminOptionsRow {
+        p2p: bool,
+        hosts: Vec<String>,
+    }
+}
+
+#[test]
+fn verify_schema() {
+    crate::assert_schema_matches_package::<Wrapper>();
 }


### PR DESCRIPTION
XAdmin wasn't a package when the schema verification was added. Now it is.