### PR TITLE
Fix billing event

### DIFF
--- a/packages/system/Transact/include/services/system/Transact.hpp
+++ b/packages/system/Transact/include/services/system/Transact.hpp
@@ -180,6 +180,13 @@ namespace SystemService
                 //
    )
 
+   struct EventIndexerInterface
+   {
+      /// Indexes all new events. This is run automatically at the end of every transaction.
+      void sync();
+   };
+   PSIO_REFLECT(EventIndexerInterface, method(sync))
+
    struct VerifyInterface
    {
       void verifySys(psibase::Checksum256 transactionHash,
@@ -244,6 +251,14 @@ namespace SystemService
    using CallbacksTable = psibase::Table<Callbacks, &Callbacks::type>;
    PSIO_REFLECT_TYPENAME(CallbacksTable)
 
+   struct EventIndexer
+   {
+      psibase::AccountNumber service;
+   };
+   PSIO_REFLECT(EventIndexer, service)
+   using EventIndexerTable = psibase::Table<EventIndexer, psibase::SingletonKey{}>;
+   PSIO_REFLECT_TYPENAME(EventIndexerTable)
+
    struct SnapshotInfo
    {
       psibase::BlockTime lastSnapshot;
@@ -275,6 +290,7 @@ namespace SystemService
                                             BlockSummaryTable,
                                             IncludedTrxTable,
                                             CallbacksTable,
+                                            EventIndexerTable,
                                             SnapshotInfoTable>;
 
       /// This action enables the boot procedure to be split across multiple blocks
@@ -325,6 +341,9 @@ namespace SystemService
       void addCallback(CallbackType type, bool objective, psibase::Action act);
       /// Removes an existing callback
       void removeCallback(CallbackType type, bool objective, psibase::Action act);
+
+      /// Registers an event index service
+      void regEvIdx(psibase::AccountNumber service);
 
       /// Run `action` using `action.sender's` authority
       ///
@@ -387,6 +406,7 @@ namespace SystemService
                 method(setSnapTime, seconds),
                 method(addCallback, type, objective, action),
                 method(removeCallback, type, objective, action),
+                method(regEvIdx, service),
                 method(runAs, action, allowedActions),
                 method(checkFirstAuth, id, transaction),
                 method(resMonitoring, enable),

--- a/packages/user/Events/src/postinstall.json
+++ b/packages/user/Events/src/postinstall.json
@@ -1,1 +1,40 @@
-[{"sender":"transact","service":"transact","method":"addcallback","data":{"type":0,"objective":true,"action":{"sender":"transact","service":"events","method":"sync","rawData":"0000"}}},{"sender":"transact","service":"transact","method":"addcallback","data":{"type":1,"objective":false,"action":{"sender":"","service":"event-index","method":"onBlock","rawData":"0000"}}}]
+[
+  {
+    "sender": "transact",
+    "service": "transact",
+    "method": "addcallback",
+    "data": {
+      "type": 0,
+      "objective": true,
+      "action": {
+        "sender": "transact",
+        "service": "events",
+        "method": "sync",
+        "rawData": "0000"
+      }
+    }
+  },
+  {
+    "sender": "transact",
+    "service": "transact",
+    "method": "addcallback",
+    "data": {
+      "type": 1,
+      "objective": false,
+      "action": {
+        "sender": "",
+        "service": "event-index",
+        "method": "onBlock",
+        "rawData": "0000"
+      }
+    }
+  },
+  {
+    "sender": "transact",
+    "service": "transact",
+    "method": "regevidx",
+    "data": {
+      "service": "events"
+    }
+  }
+]

--- a/rust/psibase/src/services/transact.rs
+++ b/rust/psibase/src/services/transact.rs
@@ -294,6 +294,12 @@ mod service {
         unimplemented!()
     }
 
+    /// Registers an event index service
+    #[action]
+    fn regEvIdx(service: crate::AccountNumber) {
+        unimplemented!()
+    }
+
     /// Run `action` using `action.sender's` authority
     ///
     /// Also adds `allowedActions` to the list of actions that `action.service`


### PR DESCRIPTION
Events were indexed before `useCpuSys`, which is intentional because we want to bill CPU time for event indexing. 

However, this means the event emitted by `useCpuSys` that reports the used CPU doesn't get indexed, which means the billing history event index is never up-to-date.

Therefore, this PR causes one more event indexer sync after `useCpuSys`, which will only index the new event (and uses cached service schemas so isn't as expensive).