### PR TITLE
Fix deadlock when receiving messages on a websocket

### DIFF
--- a/libraries/psibase_http/websocket.hpp
+++ b/libraries/psibase_http/websocket.hpp
@@ -130,7 +130,7 @@ namespace psibase::http
       void close(std::shared_ptr<WebSocket>&& self) override
       {
          PSIBASE_LOG(self->logger, debug) << "closing websocket";
-         boost::asio::dispatch(
+         boost::asio::post(
              stream.get_executor(),
              [self = std::move(self)]() mutable
              {


### PR DESCRIPTION
`onLock` should not directly run another wasm instance, because there is already one running, and we don't want to overflow the stack or block the current instance. It also deadlocks because `onLock` is called from `commitSubjective` while holding the database mutex.