### PR TITLE
Fixing graphql query error when billing not enabled

### DIFF
--- a/packages/system/VirtualServer/service/src/rpc.rs
+++ b/packages/system/VirtualServer/service/src/rpc.rs
@@ -253,7 +253,9 @@ impl Query {
     async fn user_resources(&self, user: AccountNumber) -> async_graphql::Result<UserResources> {
         self.check_user_auth(user)?;
 
-        let config = BillingConfig::get_assert();
+        let config = BillingConfig::get()
+            .filter(|c| c.enabled)
+            .ok_or_else(|| async_graphql::Error::new("billing not enabled"))?;
         let p = Tokens::call().getToken(config.sys).precision;
 
         let settings = UserSettings::get(user);

--- a/packages/system/VirtualServer/service/src/rpc.rs
+++ b/packages/system/VirtualServer/service/src/rpc.rs
@@ -253,10 +253,12 @@ impl Query {
     async fn user_resources(&self, user: AccountNumber) -> async_graphql::Result<UserResources> {
         self.check_user_auth(user)?;
 
-        let config = BillingConfig::get()
-            .filter(|c| c.enabled)
-            .ok_or_else(|| async_graphql::Error::new("billing not enabled"))?;
-        let p = Tokens::call().getToken(config.sys).precision;
+        let config = BillingConfig::get();
+        if config.is_none() {
+            return Err(async_graphql::Error::new("billing not initialized"));
+        }
+
+        let p = Tokens::call().getToken(config.unwrap().sys).precision;
 
         let settings = UserSettings::get(user);
 


### PR DESCRIPTION
Querying virtual-server for resources/gas tank info was causing an error when billing wasn't enabled. This handles that event properly.

The result of the query now looks like this
{
  "data": null,
  "errors": [
    {
      "message": "billing not enabled",
      "locations": [
        {
          "line": 33,
          "column": 3
        }
      ],
      "path": [
        "userResources"
      ]
    }
  ]
}