### PR TITLE
Add callback on database writes

### DIFF
--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -40,6 +40,8 @@ namespace psibase
          return false;
       if (action.service == "events"_a && action.method == "sync"_m)
          return false;
+      if (action.sender == AccountNumber{})
+         return false;
       return true;
    }
 

--- a/packages/system/Transact/include/services/system/Transact.hpp
+++ b/packages/system/Transact/include/services/system/Transact.hpp
@@ -318,6 +318,13 @@ namespace SystemService
       void execTrx(psio::view<const psio::shared_view_ptr<psibase::Transaction>> trx,
                    bool                                                          speculative);
 
+      /// Called by native code on objective writes to the database
+      void kvNotify(psibase::AccountNumber service,
+                    psibase::DbId          db,
+                    std::uint32_t          keyLen,
+                    std::uint32_t          oldValueLen,
+                    std::uint32_t          newValueLen);
+
       /// Sets the time between snapshots
       ///
       /// A value of 0 will disable snapshots. This is a chain-wide
@@ -458,6 +465,7 @@ namespace SystemService
                 method(finishBoot),
                 method(startBlock),
                 method(execTrx, transaction, speculative),
+                method(kvNotify, service, db, keyLen, oldValueLen, newValueLen),
                 method(setSnapTime, seconds),
                 method(addCallback, type, objective, action),
                 method(removeCallback, type, objective, action),

--- a/programs/psinode/tests/test_subjective.py
+++ b/programs/psinode/tests/test_subjective.py
@@ -18,6 +18,8 @@ def is_user_action(action):
         return False
     if action['service'] == 'events' and action['method'] == 'sync':
         return False
+    if action['sender'] == '':
+        return False
     return True
 
 def get_raw_retval(trace):

--- a/rust/psibase/src/services/transact.rs
+++ b/rust/psibase/src/services/transact.rs
@@ -261,6 +261,18 @@ mod service {
         unimplemented!()
     }
 
+    /// Called by native code on objective writes to the database
+    #[action]
+    fn kvNotify(
+        service: crate::AccountNumber,
+        db: crate::DbId,
+        keyLen: u32,
+        oldValueLen: u32,
+        newValueLen: u32,
+    ) {
+        unimplemented!()
+    }
+
     /// Sets the time between snapshots
     ///
     /// A value of 0 will disable snapshots. This is a chain-wide

--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -701,7 +701,8 @@ impl<T: fracpack::UnpackOwned> ChainResult<T> {
         !(act.service == db::SERVICE && act.method == method!("open")
             || act.service == cpu_limit::SERVICE
             || act.sender == transact::SERVICE && act.service == virtual_server::SERVICE
-            || act.service == events::SERVICE && act.method == method!("sync"))
+            || act.service == events::SERVICE && act.method == method!("sync")
+            || act.sender == AccountNumber::default())
     }
 
     pub fn get_with_debug(&self, debug: bool) -> Result<T, anyhow::Error> {


### PR DESCRIPTION
The signature is

```
transact::kvNotify(service, db, keyLen, oldLen, newLen)
```

- oldLen = -1 when adding a new row
- newLen = -1 when removing a row
- Removing a row that doesn't exist will skip the callback