### PR TITLE
Fix install of Credentials after boot

### DIFF
--- a/packages/system/Credentials/service/Cargo.toml
+++ b/packages/system/Credentials/service/Cargo.toml
@@ -8,8 +8,8 @@ publish.workspace = true
 [package.metadata.psibase]
 plugin = "credentials-plugin"
 postinstall = [
-    { sender = "credentials", service = "credentials", method = "init", data = {} },
     { sender = "accounts", service = "accounts", method = "newAccount", data = { name = "cred-sys", authService = "credentials", requireNew = false } },
+    { sender = "credentials", service = "credentials", method = "init", data = {} },
 ]
 
 [dependencies]


### PR DESCRIPTION
`init` uses `cred-sys`, so it should only be called after `cred-sys` is created. It works at boot, because auth checks are skipped.