### PR TITLE
add crude nix fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -251,6 +251,10 @@
               export PATH="$PSIBASE_ROOT/build/rust/release:$PATH"
             fi
 
+            if [ -d "$PSIBASE_ROOT/build" ]; then
+                      export PATH="$PSIBASE_ROOT/build:$PATH"
+            fi
+
             export CCACHE_DIR="''${CCACHE_DIR:-$HOME/.cache/ccache}"
             export SCCACHE_DIR="''${SCCACHE_DIR:-$HOME/.cache/sccache}"
             export CARGO_COMPONENT_CACHE_DIR="''${CARGO_COMPONENT_CACHE_DIR:-$HOME/.cache/cargo-component}"
@@ -262,25 +266,8 @@
             }
             export PS1="\[\033[01;32m\]psibase-nix\[\033[00m\]:\[\033[01;34m\]\w\[\033[32m\]\$(parse_git_branch)\[\033[00m\]\$ "
 
-            if [ -n "$BASH_VERSION" ]; then
-              set -o vi
-              if [[ -r ${pkgs.bash-completion}/share/bash-completion/bash_completion ]]; then
-                source ${pkgs.bash-completion}/share/bash-completion/bash_completion
-              fi
-              # Init file for inner bash (e.g. Cursor terminal) so vi mode and completions
-              # are applied even when bash is started with custom args.
-              _nix_bash_init="$PSIBASE_ROOT/nix/.nix-develop-bashrc"
-              if [[ -d "$PSIBASE_ROOT/nix" ]] && [[ -w "$PSIBASE_ROOT/nix" ]]; then
-                cat > "$_nix_bash_init" << 'NIX_BASH_INIT_EOF'
-            set -o vi
-            [[ -r __BASH_COMPLETION__ ]] && source __BASH_COMPLETION__
-            [[ -f "$HOME/.bashrc" ]] && . "$HOME/.bashrc"
-            NIX_BASH_INIT_EOF
-                sed -i "s|__BASH_COMPLETION__|${pkgs.bash-completion}/share/bash-completion/bash_completion|g" "$_nix_bash_init"
-              fi
-              if command -v direnv &> /dev/null; then
-                eval "$(direnv hook bash)"
-              fi
+            if [ -n "$BASH_VERSION" ] && command -v direnv &> /dev/null; then
+                          eval "$(direnv hook bash)"
             fi
 
             export CARGO_INSTALL_ROOT="$HOME/.cache/psibase-nix-cargo"


### PR DESCRIPTION
From my understanding commit 3c57ab24692922cf4584e0e63df9ece2ea6bcf31 introduced a bug where 
```
   if [ -n "$BASH_VERSION" ]; then
              set -o vi
```
made the assumption that a full shell would be available when its only minimal (according to Grok, I'm not fully aware here) 
which caused my issues of 

```
environment: line 3642: set: vi: invalid option name
/nix/store/a2rb03nxfzl4warj18infnhn4wvlf4gm-bash-completion-2.13.0/share/bash-completion/bash_completion: line 45: shopt: progcomp: invalid shell option name
/nix/store/a2rb03nxfzl4warj18infnhn4wvlf4gm-bash-completion-2.13.0/share/bash-completion/bash_completion:104: complete: command not found
```

While the changes like 
```
            if [ -d "$PSIBASE_ROOT/build/psidk/bin" ]; then
              export PATH="$PSIBASE_ROOT/build/psidk/bin:$PATH"
            fi
``` 
have been helpful the removal of 

```
           if [ -d "$PSIBASE_ROOT/build" ]; then
                      export PATH="$PSIBASE_ROOT/build:$PATH"
            fi
```
seemed to stop `psinode` from working. 

I'm not sure how to approach the bash completion bit but I've made this PR to illustrate the problem. 