### PR TITLE
Fix uninitialized variable.

### DIFF
--- a/libraries/psibase/native/include/psibase/Mount.hpp
+++ b/libraries/psibase/native/include/psibase/Mount.hpp
@@ -44,8 +44,8 @@ namespace psibase
       {
          std::string                name;
          std::string                hostPath;
-         Dir*                       parent;
-         bool                       isMountpoint;
+         Dir*                       parent       = nullptr;
+         bool                       isMountpoint = false;
          std::map<std::string, Dir> children;
       };
       Dir               root;


### PR DESCRIPTION
Note that every node except root is value initialized, and `Mount()` sets `root.parent`, so only `isMountpoint` actually needs to be initialized here.