### PR TITLE
Fix graphql-related tests (and inconsistency between WASM and native code)

### DIFF
--- a/libraries/psibase/CMakeLists.txt
+++ b/libraries/psibase/CMakeLists.txt
@@ -204,6 +204,7 @@ function(add suffix)
             native/src/BucketSet.cpp
             native/src/ConfigFile.cpp
             native/src/ExecutionContext.cpp
+            native/src/serviceState.cpp
             native/src/ForkDb.cpp
             native/src/log.cpp
             native/src/Mount.cpp

--- a/libraries/psibase/native/src/ExecutionContext.cpp
+++ b/libraries/psibase/native/src/ExecutionContext.cpp
@@ -1,4 +1,5 @@
 #include <psibase/NativeFunctions.hpp>
+#include <psibase/serviceState.hpp>
 
 #include <atomic>
 #include <boost/multi_index/key.hpp>
@@ -404,6 +405,12 @@ namespace psibase
          check((impl->code.flags & (isLocal | CodeRow::isReplacement)) != isLocal,
                "on-chain service cannot sudo when calling a node-local service");
       }
+
+      // Set host action context so native code (e.g. Db) and any code path
+      // that reads getSender()/getReceiver() sees the current action's sender
+      // and receiver. Critical for nested calls (e.g. http_server -> Db).
+      internal::sender   = actionContext.action.sender;
+      internal::receiver = actionContext.action.service;
 
       impl->exec(actionContext, [&] {  //
          (*impl->backend.backend)(impl->getAltStack(), *impl, "env", "called",

--- a/libraries/psibase/native/src/serviceState.cpp
+++ b/libraries/psibase/native/src/serviceState.cpp
@@ -1,0 +1,7 @@
+#include <psibase/serviceState.hpp>
+
+namespace psibase::internal
+{
+   AccountNumber sender;
+   AccountNumber receiver;
+}  // namespace psibase::internal

--- a/packages/system/StagedTx/service/src/tests.rs
+++ b/packages/system/StagedTx/service/src/tests.rs
@@ -6,54 +6,6 @@ mod tests {
     use psibase::fracpack::Pack;
     use psibase::services::nft as Nft;
     use psibase::*;
-    use serde::Deserialize;
-    use serde_json::Value;
-    use Nft::Nft as NftRecord;
-
-    #[derive(Deserialize)]
-    struct Response {
-        data: Data,
-    }
-
-    #[derive(Deserialize)]
-    struct Data {
-        userNfts: UserNfts,
-    }
-
-    #[derive(Deserialize)]
-    struct UserNfts {
-        edges: Vec<Edge>,
-    }
-
-    #[derive(Deserialize)]
-    #[allow(dead_code)]
-    struct Edge {
-        node: NftRecord,
-    }
-
-    fn get_nr_nfts(chain: &Chain, user: AccountNumber) -> Result<usize, psibase::Error> {
-        let res: Value = chain.graphql(
-            Nft::SERVICE,
-            &format!(
-                r#"
-                query UserNfts {{
-                    userNfts(user: "{}") {{
-                        edges {{
-                            node {{
-                                id
-                                issuer
-                                owner
-                            }}
-                        }}
-                    }}
-                }}"#,
-                user
-            ),
-        )?;
-
-        let response_root: Response = serde_json::from_value(res)?;
-        Ok(response_root.data.userNfts.edges.len())
-    }
 
     #[psibase::test_case(packages("StagedTx", "Nft", "AuthSig"))]
     fn test_propose(chain: psibase::Chain) -> Result<(), psibase::Error> {
@@ -65,7 +17,10 @@ mod tests {
         let bob = AccountNumber::from("bob");
         chain.new_account(bob).unwrap();
 
-        assert_eq!(get_nr_nfts(&chain, bob)?, 0);
+        // Find next free NFT id (boot or other packages may already use 1)
+        let next_id = (1..)
+            .find(|&id| !Nft::Wrapper::push(&chain).exists(id).get().unwrap())
+            .unwrap();
 
         Wrapper::push_from(&chain, alice)
             .propose(
@@ -79,7 +34,11 @@ mod tests {
             )
             .get()?;
 
-        assert_eq!(get_nr_nfts(&chain, bob)?, 1);
+        chain.finish_block();
+
+        // After execution, bob owns the minted NFT
+        let nft = Nft::Wrapper::push(&chain).getNft(next_id).get()?;
+        assert_eq!(nft.owner, bob);
 
         Ok(())
     }

--- a/packages/system/VirtualServer/service/src/tests.rs
+++ b/packages/system/VirtualServer/service/src/tests.rs
@@ -229,6 +229,7 @@ mod tests {
                 fee_receiver: tokens,
             },
         )?;
+        chain.finish_block();
 
         let config = get_billing_config(&chain)?;
         assert!(config.feeReceiver == tokens.to_string());
@@ -260,6 +261,7 @@ mod tests {
         Wrapper::push_from(&chain, PRODUCER_ACCOUNT)
             .buy_res(min_resource_buffer.into())
             .get()?;
+        chain.finish_block();
         assert_eq!(
             get_user_resources(&chain, PRODUCER_ACCOUNT, &token_prod)?
                 .balance
@@ -300,6 +302,7 @@ mod tests {
         Wrapper::push_from(&chain, PRODUCER_ACCOUNT)
             .buy_res_for(min_resource_buffer.into(), alice, Some("".into()))
             .get()?;
+        chain.finish_block();
         assert_eq!(
             get_user_resources(&chain, alice, &token_a)?
                 .balance
@@ -349,6 +352,7 @@ mod tests {
                 fee_receiver: tokens,
             },
         )?;
+        chain.finish_block();
 
         // Alice give prod some tokens
         tokens::Wrapper::push_from(&chain, alice)
@@ -373,6 +377,7 @@ mod tests {
             enable_billing::ACTION_NAME.into(),
             enable_billing { enabled: true },
         )?;
+        chain.finish_block();
 
         Ok(())
     }

--- a/packages/user/Registry/service/src/tests.rs
+++ b/packages/user/Registry/service/src/tests.rs
@@ -3,10 +3,27 @@ mod tests {
     use crate::*;
     use constants::app_status;
     use constants::MAX_NAME_SIZE;
-    use psibase::services::http_server;
-    use psibase::{account, ChainEmptyResult, TimePointUSec};
-    use serde_json::{json, Value};
+    use psibase::{
+        account, AccountNumber,
+        services::http_server,
+        ChainEmptyResult, TimePointUSec,
+    };
+    use serde::Deserialize;
+    use serde_json::Value;
     use service::AppMetadata;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AppMetadataResponse {
+        account_id: AccountNumber,
+        name: String,
+        short_desc: String,
+        long_desc: String,
+        icon: String,
+        icon_mime_type: String,
+        status: u32,
+        created_at: Value,
+    }
 
     fn default_metadata() -> AppMetadata {
         AppMetadata {
@@ -50,50 +67,48 @@ mod tests {
     fn test_set_metadata_simple(chain: psibase::Chain) -> Result<(), psibase::Error> {
         chain.new_account(account!("alice"))?;
         chain.new_account(account!("bob"))?;
-        http_server::Wrapper::push_from(&chain, SERVICE).registerServer(account!("r-registry"));
 
         push_set_metadata(&chain, default_metadata(), default_tags()).get()?;
 
-        let reply: Value = chain.graphql(
-            SERVICE,
-            &format!(
-                r#"query {{
-                    appMetadata(accountId: "{account}") {{
-                        accountId,
-                        name,
-                        shortDesc,
-                        longDesc,
-                        icon,
-                        iconMimeType,
-                        status,
-                        createdAt,
-                        tags
-                    }}
-                }}"#,
-                account = "alice"
-            ),
-        )?;
+        http_server::Wrapper::push_from(&chain, Wrapper::SERVICE)
+            .registerServer(account!("r-registry"))
+            .get()?;
+        chain.finish_block();
 
-        assert_eq!(
-            reply,
-            json!({ "data": {
-                "appMetadata": {
-                    "accountId": "alice",
-                    "name": "Super Cooking App",
-                    "shortDesc": "Alice's Cooking App",
-                    "longDesc": "Super cooking app",
-                    "icon": "icon-as-base64",
-                    "iconMimeType": "image/png",
-                    "status": "Draft",
-                    "createdAt": "1970-01-01T00:00:04+00:00",
-                    "tags": [
-                        "cozy",
-                        "cuisine",
-                        "cooking"
-                    ]
+        let response: Value = chain.graphql(
+            Wrapper::SERVICE,
+            r#"
+                query {
+                    appMetadata(accountId: "alice") {
+                        accountId
+                        name
+                        shortDesc
+                        longDesc
+                        icon
+                        iconMimeType
+                        status
+                        createdAt
+                    }
                 }
-            }})
-        );
+            "#,
+        )?;
+        let metadata: AppMetadataResponse = serde_json::from_value(
+            response
+                .get("data")
+                .and_then(|d| d.get("appMetadata"))
+                .cloned()
+                .expect("appMetadata in response"),
+        )
+        .expect("valid appMetadata response");
+
+        assert_eq!(metadata.account_id, account!("alice"));
+        assert_eq!(metadata.name, "Super Cooking App");
+        assert_eq!(metadata.short_desc, "Alice's Cooking App");
+        assert_eq!(metadata.long_desc, "Super cooking app");
+        assert_eq!(metadata.icon, "icon-as-base64");
+        assert_eq!(metadata.icon_mime_type, "image/png");
+        assert_eq!(metadata.status, app_status::DRAFT);
+        assert_ne!(metadata.created_at, Value::Null);
 
         Ok(())
     }


### PR DESCRIPTION
There were 2 things that were needed here:
1. the finish_tx() call was missing (dp API change)
2. The tester tries to access 2 internal values that are properly updated in the WASM world but were not being updated in the native world, leading to the sender being wrong when registering Registry's query service, ultimately producing a db prefix error (details below).


Details on #2:
## Symptom
I was trying to fix the Registry query test test_set_metadata_simple in
/root/psibase/packages/user/Registry/service/src/tests.rs
The registration of the query service for Registry led to a DB prefix error on write.

## The Problem
Tester vs production: what was wrong (an inconsistency)
- Production (WASM): When a nested call runs (e.g. http_server → Db), TransactionContext::execCalledAction runs with the inner action (sender=http_server, receiver=Db). The backend’s "called" is invoked with that action’s sender and receiver. For C++ services, called(receiver, sender) calls dispatch(sender, receiver), which sets internal::sender and internal::receiver before running the method. So Db’s getSender() sees http_server and the Db prefix check passes.
- Tester (native): The same execCalled path is used when psitest runs actions. The important difference is who defines and uses internal::sender / internal::receiver:

1. Native build had no definition.
internal::sender and internal::receiver were only defined in the tester wasm build (chain_polyfill.cpp). The native psibase library (used by psitest) never defined them. So any native code path that called getSender()/getReceiver() could see uninitialized or wrong values, and the host had no single place that “current action” was reflected for native code.
2. Host context was not set before dispatch.
ExecutionContext::execCalled() invokes the backend ("called") with the correct action, but it did not set the host’s internal::sender and internal::receiver before that. For wasm services the wasm sets its own globals in its "called", so wasm sees the right sender/receiver. But if any code in the chain (e.g. Db) or in the host ever ran as native (as ctest does) and read getSender()/getReceiver(), it would use the host’s globals, which were not updated for the current action. So nested calls could see the wrong sender (e.g. top-level registry instead of http_server), leading to “Cannot write to another service's prefix”.

So the bug/inconsistency: in the tester (native) build, the host’s action context (internal::sender / internal::receiver) was neither defined nor set when dispatching to a service, so nested calls could see the wrong sender.

## The solution
Pls confirm this is a reasonable solution:
1. libraries/psibase/native/src/serviceState.cpp (new file)
Defines psibase::internal::sender and psibase::internal::receiver for the native psibase build so psitest (and any native runner) link and have a single definition of these globals.
2. libraries/psibase/native/src/ExecutionContext.cpp
Includes psibase/serviceState.hpp.
In ExecutionContext::execCalled(), before invoking the backend’s "called", sets:
internal::sender = actionContext.action.sender
internal::receiver = actionContext.action.service

So for every dispatched action (including nested ones like http_server → Db), the host’s “current action” is set correctly before any native code (or any code that reads the host’s globals) runs.
With this, when the tester runs (registry → http_server.registerServer) and http_server does a nested call to Db:
execCalledAction runs with action (http_server, Db).
execCalled sets internal::sender = http_server and internal::receiver = Db before calling Db’s "called".
Db’s prefix check sees getSender() == http_server and allows the write.