### PR TITLE
Fix XSites sharing files across subdomains

### DIFF
--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -298,6 +298,7 @@ namespace psibase
       Self&& account(this Self&& self, AccountNumber account)
       {
          self._account = account;
+         return std::forward<Self>(self);
       }
 
       struct Default

--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -158,6 +158,12 @@ namespace psibase
       { t.body() } -> std::convertible_to<std::vector<char>>;
    };
 
+   template <typename T>
+   concept HttpReplyBody = requires(std::vector<char>&& t) {
+      { T::contentType() } -> std::convertible_to<std::string>;
+      { T::unpack(std::move(t)) };
+   };
+
    struct GraphQLBody
    {
       std::string       contentType() const { return "application/graphql"; }
@@ -176,15 +182,27 @@ namespace psibase
    template <typename T>
    struct JsonBody
    {
-      std::string       contentType() const { return "application/json"; }
-      std::vector<char> body() const
+      static std::string contentType() { return "application/json"; }
+      std::vector<char>  body() const
       {
          std::vector<char>   result;
          psio::vector_stream stream{result};
          to_json(value, stream);
          return result;
       }
+      static JsonBody unpack(std::vector<char> data)
+      {
+         data.push_back('\0');
+         psio::json_token_stream stream(data.data());
+         return {psio::from_json<T>(stream)};
+      }
       T value;
+   };
+
+   struct EmptyBody
+   {
+      std::string       contentType() const { return {}; }
+      std::vector<char> body() const { return {}; }
    };
 
    template <typename R>
@@ -209,11 +227,19 @@ namespace psibase
                             std::to_string(static_cast<std::uint16_t>(response.status)));
             }
          }
-         if (response.contentType != "application/json")
-            abortMessage("Wrong Content-Type " + response.contentType);
-         response.body.push_back('\0');
-         psio::json_token_stream stream(response.body.data());
-         return psio::from_json<R>(stream);
+         if constexpr (HttpReplyBody<R>)
+         {
+            if (response.contentType != R::contentType())
+               abortMessage("Wrong Content-Type " + response.contentType);
+            return R::unpack(std::move(response.body));
+         }
+         else
+         {
+            if (response.contentType == "application/json")
+               return JsonBody<R>::unpack(std::move(response.body)).value;
+            else
+               abortMessage("Wrong Content-Type " + response.contentType);
+         }
       }
    }
 
@@ -242,6 +268,169 @@ namespace psibase
          return unpackReply<R>(std::move(*reply));
       }
    };
+
+   class HttpRequestBuilder
+   {
+     public:
+      HttpRequestBuilder(AccountNumber account = {}, std::vector<HttpHeader> headers = {})
+          : _account(account), _headers(headers)
+      {
+      }
+      template <typename Self>
+      Self&& header(this Self&& self, HttpHeader header)
+      {
+         self._headers.push_back(std::move(header));
+         return std::forward<Self>(self);
+      }
+      template <typename Self>
+      Self&& header(this Self&& self, std::string_view name, std::string_view value)
+      {
+         self._headers.push_back({std::string{name}, std::string{value}});
+         return std::forward<Self>(self);
+      }
+      template <typename Self>
+      Self&& token(this Self&& self, std::string_view token)
+      {
+         self._headers.push_back({"Authorization", std::format("Bearer {}", token)});
+         return std::forward<Self>(self);
+      }
+      template <typename Self>
+      Self&& account(this Self&& self, AccountNumber account)
+      {
+         self._account = account;
+      }
+
+      struct Default
+      {
+      };
+
+      template <typename R = Default, typename Self>
+      decltype(auto) get(this Self&& self, std::string target, std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(AccountNumber{}, "GET", target,
+                                                             EmptyBody{}, std::move(headers));
+      }
+      template <typename R = Default, typename Self>
+      decltype(auto) get(this Self&&             self,
+                         AccountNumber           account,
+                         std::string             target,
+                         std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(account, "GET", target, EmptyBody{},
+                                                             std::move(headers));
+      }
+      template <typename R = Default, typename Self, HttpRequestBody T>
+      decltype(auto) post(this Self&&             self,
+                          AccountNumber           account,
+                          std::string             target,
+                          const T&                body,
+                          std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(account, "POST", target, body,
+                                                             std::move(headers));
+      }
+      template <typename R = Default, typename Self, HttpRequestBody T>
+      decltype(auto) post(this Self&&             self,
+                          std::string             target,
+                          const T&                body,
+                          std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(AccountNumber{}, "POST", target, body,
+                                                             std::move(headers));
+      }
+      template <typename R = Default, typename Self, HttpRequestBody T>
+      decltype(auto) put(this Self&&             self,
+                         AccountNumber           account,
+                         std::string             target,
+                         const T&                body,
+                         std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(account, "PUT", target, body,
+                                                             std::move(headers));
+      }
+      template <typename R = Default, typename Self, HttpRequestBody T>
+      decltype(auto) put(this Self&&             self,
+                         std::string             target,
+                         const T&                body,
+                         std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(AccountNumber{}, "PUT", target, body,
+                                                             std::move(headers));
+      }
+
+      template <typename R = Default, typename Self>
+      decltype(auto) request(this Self&&             self,
+                             std::string_view        method,
+                             std::string_view        target,
+                             std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(AccountNumber{}, method, target,
+                                                             EmptyBody{}, std::move(headers));
+      }
+
+      template <typename R = Default, typename Self>
+      decltype(auto) request(this Self&&             self,
+                             AccountNumber           account,
+                             std::string_view        method,
+                             std::string_view        target,
+                             std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(account, method, target, EmptyBody{},
+                                                             std::move(headers));
+      }
+
+      template <typename R = Default, typename Self, HttpRequestBody T>
+      decltype(auto) request(this Self&&             self,
+                             std::string_view        method,
+                             std::string_view        target,
+                             const T&                body,
+                             std::vector<HttpHeader> headers = {})
+      {
+         return std::forward<Self>(self).template request<R>(AccountNumber{}, method, target, body,
+                                                             std::move(headers));
+      }
+
+      template <typename R = Default, HttpRequestBody T>
+      auto request(AccountNumber           account,
+                   std::string_view        method,
+                   std::string_view        target,
+                   const T&                body,
+                   std::vector<HttpHeader> headers = {})
+      {
+         return HttpRequest{.host = buildHost(account),
+                            .method{method},
+                            .target{target},
+                            .contentType = body.contentType(),
+                            .headers     = buildHeaders(std::move(headers)),
+                            .body        = body.body()};
+      }
+
+     private:
+      std::string buildHost(AccountNumber account)
+      {
+         if (account == AccountNumber{})
+            account = _account;
+         if (account == AccountNumber{})
+            return "psibase.io";
+         else
+            return account.str() + ".psibase.io";
+      }
+      std::vector<HttpHeader> buildHeaders(std::vector<HttpHeader>&& extra)
+      {
+         if (_headers.empty())
+            return std::move(extra);
+         else
+         {
+            auto result = _headers;
+            result.insert(result.begin(), std::move_iterator{extra.begin()},
+                          std::move_iterator{extra.end()});
+            return result;
+         }
+      }
+      AccountNumber           _account;
+      std::vector<HttpHeader> _headers;
+   };
+   class HttpClient;
 
    /**
     * Manages a chain.
@@ -461,6 +650,9 @@ namespace psibase
          return req;
       }
 
+      HttpClient http(AccountNumber account = {}, std::vector<HttpHeader> headers = {});
+      HttpClient http(std::vector<HttpHeader> headers);
+
       /**
        * Runs a query and returns the response
        */
@@ -625,6 +817,34 @@ namespace psibase
       }
    };  // TestChain
 
+   class HttpClient : public HttpRequestBuilder
+   {
+     public:
+      HttpClient(TestChain& chain, AccountNumber account = {}, std::vector<HttpHeader> headers = {})
+          : HttpRequestBuilder{account, std::move(headers)}, _chain(&chain)
+      {
+      }
+      template <typename R = HttpReply, HttpRequestBody T>
+      auto request(AccountNumber           account,
+                   std::string_view        method,
+                   std::string_view        target,
+                   const T&                body,
+                   std::vector<HttpHeader> headers = {})
+      {
+         auto req = HttpRequestBuilder::request(account, method, target, body, std::move(headers));
+         if constexpr (std::is_same_v<R, Default>)
+         {
+            return _chain->http(req);
+         }
+         else
+         {
+            return _chain->http<R>(req);
+         }
+      }
+
+     private:
+      TestChain* _chain;
+   };
 }  // namespace psibase
 
 template <>

--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -328,7 +328,7 @@ namespace psibase
          return std::forward<Self>(self).template request<R>(account, "GET", target, EmptyBody{},
                                                              std::move(headers));
       }
-      template <typename R = Default, typename Self, HttpRequestBody T>
+      template <typename R = Default, typename Self, typename T>
       decltype(auto) post(this Self&&             self,
                           AccountNumber           account,
                           std::string_view        target,
@@ -338,7 +338,7 @@ namespace psibase
          return std::forward<Self>(self).template request<R>(account, "POST", target, body,
                                                              std::move(headers));
       }
-      template <typename R = Default, typename Self, HttpRequestBody T>
+      template <typename R = Default, typename Self, typename T>
       decltype(auto) post(this Self&&             self,
                           std::string_view        target,
                           const T&                body,
@@ -347,7 +347,7 @@ namespace psibase
          return std::forward<Self>(self).template request<R>(AccountNumber{}, "POST", target, body,
                                                              std::move(headers));
       }
-      template <typename R = Default, typename Self, HttpRequestBody T>
+      template <typename R = Default, typename Self, typename T>
       decltype(auto) put(this Self&&             self,
                          AccountNumber           account,
                          std::string_view        target,
@@ -357,7 +357,7 @@ namespace psibase
          return std::forward<Self>(self).template request<R>(account, "PUT", target, body,
                                                              std::move(headers));
       }
-      template <typename R = Default, typename Self, HttpRequestBody T>
+      template <typename R = Default, typename Self, typename T>
       decltype(auto) put(this Self&&             self,
                          std::string_view        target,
                          const T&                body,
@@ -388,7 +388,7 @@ namespace psibase
                                                              std::move(headers));
       }
 
-      template <typename R = Default, typename Self, HttpRequestBody T>
+      template <typename R = Default, typename Self, typename T>
       decltype(auto) request(this Self&&             self,
                              std::string_view        method,
                              std::string_view        target,
@@ -399,22 +399,33 @@ namespace psibase
                                                              std::move(headers));
       }
 
-      template <typename R = Default, HttpRequestBody T>
+      template <typename R = Default, typename T>
       auto request(AccountNumber           account,
                    std::string_view        method,
                    std::string_view        target,
                    const T&                body,
                    std::vector<HttpHeader> headers = {})
       {
+         decltype(auto) wrapped = wrapBody(body);
          return HttpRequest{.host = buildHost(account),
                             .method{method},
                             .target{target},
-                            .contentType = body.contentType(),
+                            .contentType = wrapped.contentType(),
                             .headers     = buildHeaders(std::move(headers)),
-                            .body        = body.body()};
+                            .body        = wrapped.body()};
       }
 
      private:
+      template <typename T>
+      decltype(auto) wrapBody(const T& body)
+      {
+         return JsonBody<const T&>(body);
+      }
+      template <HttpRequestBody T>
+      decltype(auto) wrapBody(const T& body)
+      {
+         return body;
+      }
       std::string buildHost(AccountNumber account)
       {
          if (account == AccountNumber{})
@@ -598,21 +609,9 @@ namespace psibase
       void runAll();
 
       /**
-       * Creates a POST request with a JSON body
-       */
-      template <typename T>
-      HttpRequest makePost(AccountNumber                   account,
-                           std::string_view                target,
-                           const T&                        data,
-                           std::optional<std::string_view> token = std::nullopt) const
-      {
-         return HttpRequestBuilder{}.auth_bearer(token).post(account, target, JsonBody{data});
-      }
-
-      /**
        * Creates a POST request
        */
-      template <HttpRequestBody T>
+      template <typename T>
       HttpRequest makePost(AccountNumber                   account,
                            std::string_view                target,
                            const T&                        data,
@@ -662,6 +661,12 @@ namespace psibase
             std::optional<std::string_view> token = std::nullopt)
       {
          return http<R>(makeGet(account, target, token));
+      }
+
+      template <typename R = HttpReply, typename T>
+      R put(AccountNumber account, std::string_view target, const T& data)
+      {
+         return http<R>(HttpRequestBuilder{}.put(account, target, data));
       }
 
       /**
@@ -805,7 +810,7 @@ namespace psibase
           : HttpRequestBuilder{account, std::move(headers)}, _chain(&chain)
       {
       }
-      template <typename R = HttpReply, HttpRequestBody T>
+      template <typename R = HttpReply, typename T>
       auto request(AccountNumber           account,
                    std::string_view        method,
                    std::string_view        target,

--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -295,13 +295,6 @@ namespace psibase
          return std::forward<Self>(self);
       }
       template <typename Self>
-      Self&& auth_bearer(this Self&& self, std::optional<std::string_view> token)
-      {
-         if (token)
-            self._headers.push_back({"Authorization", std::format("Bearer {}", *token)});
-         return std::forward<Self>(self);
-      }
-      template <typename Self>
       Self&& account(this Self&& self, AccountNumber account)
       {
          self._account = account;
@@ -608,28 +601,6 @@ namespace psibase
        */
       void runAll();
 
-      /**
-       * Creates a POST request
-       */
-      template <typename T>
-      HttpRequest makePost(AccountNumber                   account,
-                           std::string_view                target,
-                           const T&                        data,
-                           std::optional<std::string_view> token = std::nullopt) const
-      {
-         return HttpRequestBuilder{}.auth_bearer(token).post(account, target, data);
-      }
-
-      /**
-       * Creates a GET request
-       */
-      HttpRequest makeGet(AccountNumber                   account,
-                          std::string_view                target,
-                          std::optional<std::string_view> token = std::nullopt) const
-      {
-         return HttpRequestBuilder{}.auth_bearer(token).get(account, target);
-      }
-
       HttpClient http(AccountNumber account = {}, std::vector<HttpHeader> headers = {});
       HttpClient http(std::vector<HttpHeader> headers);
 
@@ -652,7 +623,10 @@ namespace psibase
              const T&                        data,
              std::optional<std::string_view> token = std::nullopt)
       {
-         return http<R>(makePost(account, target, data, token));
+         auto builder = HttpRequestBuilder{};
+         if (token)
+            builder.auth_bearer(*token);
+         return http<R>(builder.post(account, target, data));
       }
 
       template <typename R = HttpReply>
@@ -660,7 +634,10 @@ namespace psibase
             std::string_view                target,
             std::optional<std::string_view> token = std::nullopt)
       {
-         return http<R>(makeGet(account, target, token));
+         auto builder = HttpRequestBuilder{};
+         if (token)
+            builder.auth_bearer(*token);
+         return http<R>(builder.get(account, target));
       }
 
       template <typename R = HttpReply, typename T>
@@ -678,11 +655,11 @@ namespace psibase
       template <typename T>
       AsyncHttpReply asyncPost(AccountNumber account, std::string_view target, const T& data)
       {
-         return asyncHttp(makePost(account, target, data));
+         return asyncHttp(HttpRequestBuilder{}.post(account, target, data));
       }
       AsyncHttpReply asyncGet(AccountNumber account, std::string_view target)
       {
-         return asyncHttp(makeGet(account, target));
+         return asyncHttp(HttpRequestBuilder{}.get(account, target));
       }
 
       template <typename Action>

--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -289,9 +289,16 @@ namespace psibase
          return std::forward<Self>(self);
       }
       template <typename Self>
-      Self&& token(this Self&& self, std::string_view token)
+      Self&& auth_bearer(this Self&& self, std::string_view token)
       {
          self._headers.push_back({"Authorization", std::format("Bearer {}", token)});
+         return std::forward<Self>(self);
+      }
+      template <typename Self>
+      Self&& auth_bearer(this Self&& self, std::optional<std::string_view> token)
+      {
+         if (token)
+            self._headers.push_back({"Authorization", std::format("Bearer {}", *token)});
          return std::forward<Self>(self);
       }
       template <typename Self>
@@ -305,7 +312,9 @@ namespace psibase
       };
 
       template <typename R = Default, typename Self>
-      decltype(auto) get(this Self&& self, std::string target, std::vector<HttpHeader> headers = {})
+      decltype(auto) get(this Self&&             self,
+                         std::string_view        target,
+                         std::vector<HttpHeader> headers = {})
       {
          return std::forward<Self>(self).template request<R>(AccountNumber{}, "GET", target,
                                                              EmptyBody{}, std::move(headers));
@@ -313,7 +322,7 @@ namespace psibase
       template <typename R = Default, typename Self>
       decltype(auto) get(this Self&&             self,
                          AccountNumber           account,
-                         std::string             target,
+                         std::string_view        target,
                          std::vector<HttpHeader> headers = {})
       {
          return std::forward<Self>(self).template request<R>(account, "GET", target, EmptyBody{},
@@ -322,7 +331,7 @@ namespace psibase
       template <typename R = Default, typename Self, HttpRequestBody T>
       decltype(auto) post(this Self&&             self,
                           AccountNumber           account,
-                          std::string             target,
+                          std::string_view        target,
                           const T&                body,
                           std::vector<HttpHeader> headers = {})
       {
@@ -331,7 +340,7 @@ namespace psibase
       }
       template <typename R = Default, typename Self, HttpRequestBody T>
       decltype(auto) post(this Self&&             self,
-                          std::string             target,
+                          std::string_view        target,
                           const T&                body,
                           std::vector<HttpHeader> headers = {})
       {
@@ -341,7 +350,7 @@ namespace psibase
       template <typename R = Default, typename Self, HttpRequestBody T>
       decltype(auto) put(this Self&&             self,
                          AccountNumber           account,
-                         std::string             target,
+                         std::string_view        target,
                          const T&                body,
                          std::vector<HttpHeader> headers = {})
       {
@@ -350,7 +359,7 @@ namespace psibase
       }
       template <typename R = Default, typename Self, HttpRequestBody T>
       decltype(auto) put(this Self&&             self,
-                         std::string             target,
+                         std::string_view        target,
                          const T&                body,
                          std::vector<HttpHeader> headers = {})
       {
@@ -597,19 +606,7 @@ namespace psibase
                            const T&                        data,
                            std::optional<std::string_view> token = std::nullopt) const
       {
-         HttpRequest req{.host   = account.str() + ".psibase.io",
-                         .method = "POST",
-                         .target{target},
-                         .contentType = "application/json"};
-         if (token)
-         {
-            req.headers.push_back(
-                {.name = "Authorization", .value = std::string("Bearer ") + std::string(*token)});
-         }
-         psio::vector_stream stream{req.body};
-         using psio::to_json;
-         to_json(data, stream);
-         return req;
+         return HttpRequestBuilder{}.auth_bearer(token).post(account, target, JsonBody{data});
       }
 
       /**
@@ -621,17 +618,7 @@ namespace psibase
                            const T&                        data,
                            std::optional<std::string_view> token = std::nullopt) const
       {
-         HttpRequest req{.host   = account.str() + ".psibase.io",
-                         .method = "POST",
-                         .target{target},
-                         .contentType = data.contentType(),
-                         .body        = data.body()};
-         if (token)
-         {
-            req.headers.push_back(
-                {.name = "Authorization", .value = std::string("Bearer ") + std::string(*token)});
-         }
-         return req;
+         return HttpRequestBuilder{}.auth_bearer(token).post(account, target, data);
       }
 
       /**
@@ -641,13 +628,7 @@ namespace psibase
                           std::string_view                target,
                           std::optional<std::string_view> token = std::nullopt) const
       {
-         HttpRequest req{.host = account.str() + ".psibase.io", .method = "GET", .target{target}};
-         if (token)
-         {
-            req.headers.push_back(
-                {.name = "Authorization", .value = std::string("Bearer ") + std::string(*token)});
-         }
-         return req;
+         return HttpRequestBuilder{}.auth_bearer(token).get(account, target);
       }
 
       HttpClient http(AccountNumber account = {}, std::vector<HttpHeader> headers = {});

--- a/libraries/psibase/tester/src/tester.cpp
+++ b/libraries/psibase/tester/src/tester.cpp
@@ -731,6 +731,15 @@ psibase::HttpReply psibase::TestChain::http(const HttpRequest& request)
    return asyncHttp(request).get();
 }
 
+psibase::HttpClient psibase::TestChain::http(AccountNumber account, std::vector<HttpHeader> headers)
+{
+   return {*this, account, std::move(headers)};
+}
+psibase::HttpClient psibase::TestChain::http(std::vector<HttpHeader> headers)
+{
+   return {*this, {}, std::move(headers)};
+}
+
 namespace
 {
    struct LoginInterface

--- a/packages/local/XBasic/test/XBasic-test.cpp
+++ b/packages/local/XBasic/test/XBasic-test.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Basic auth")
    auto table = XBasic{}.open<PasswordTable>();
    table.put({"Aladdin", "$2b$05$fq6gX6Ze3Zb0MMmK8.DSge0.M47/V079Lxbre9k0L5snzcEIp1LXy"});
 
-   auto req = t.makeGet(XAdmin::service, "/config");
+   auto req = HttpRequestBuilder{}.get(XAdmin::service, "/config");
    req.headers.push_back({"X-Forwarded-For", "192.168.0.1"});
    SECTION("No auth")
    {

--- a/packages/local/XSites/CMakeLists.txt
+++ b/packages/local/XSites/CMakeLists.txt
@@ -4,6 +4,8 @@ endfunction(add)
 
 conditional_add()
 
+add_subdirectory(test)
+
 install(DIRECTORY include/ TYPE INCLUDE FILES_MATCHING PATTERN "*.hpp")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)

--- a/packages/local/XSites/include/services/local/XSites.hpp
+++ b/packages/local/XSites/include/services/local/XSites.hpp
@@ -17,6 +17,9 @@ namespace LocalService
       std::vector<char>          content         = {};
       std::optional<std::string> contentEncoding = std::nullopt;
       std::optional<std::string> csp             = std::nullopt;
+
+      using Key = psibase::CompositeKey<&ContentRow::account, &ContentRow::path>;
+
       PSIO_REFLECT(ContentRow,
                    account,
                    path,
@@ -26,7 +29,7 @@ namespace LocalService
                    contentEncoding,
                    csp)
    };
-   using ContentTable = psibase::Table<ContentRow, &ContentRow::path>;
+   using ContentTable = psibase::Table<ContentRow, ContentRow::Key{}>;
    PSIO_REFLECT_TYPENAME(ContentTable)
 
    struct XSites : psibase::Service

--- a/packages/local/XSites/src/XSites.cpp
+++ b/packages/local/XSites/src/XSites.cpp
@@ -49,7 +49,7 @@ std::optional<HttpReply> XSites::serveSys(HttpRequest req, std::optional<std::in
          return reply;
       PSIBASE_SUBJECTIVE_TX
       {
-         table.erase(target);
+         table.erase(std::tuple(service, target));
       }
       return HttpReply{.headers = allowCors(req, XAdmin::service)};
    }
@@ -58,10 +58,11 @@ std::optional<HttpReply> XSites::serveSys(HttpRequest req, std::optional<std::in
       std::optional<ContentRow> row;
       PSIBASE_SUBJECTIVE_TX
       {
-         row = table.get(target);
+         row = table.get(std::tuple(service, target));
          if (!row)
          {
-            row = table.get(target + (target.ends_with('/') ? "index.html" : "/index.html"));
+            row = table.get(std::tuple(
+                service, target + (target.ends_with('/') ? "index.html" : "/index.html")));
          }
       }
       if (row)

--- a/packages/local/XSites/test/CMakeLists.txt
+++ b/packages/local/XSites/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_local_test(XSites XSites-test.cpp)

--- a/packages/local/XSites/test/XSites-test.cpp
+++ b/packages/local/XSites/test/XSites-test.cpp
@@ -1,0 +1,33 @@
+#include <psibase/DefaultTestChain.hpp>
+#include <services/local/XHttp.hpp>
+#include <services/local/XSites.hpp>
+#include <services/system/HttpServer.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+
+using namespace psibase;
+using namespace LocalService;
+using namespace SystemService;
+
+struct TextBody
+{
+   static std::string contentType() { return "text/plain"; }
+   std::vector<char>  body() const { return {value.begin(), value.end()}; }
+   static TextBody    unpack(std::vector<char>&& data)
+   {
+      return {std::string{data.begin(), data.end()}};
+   }
+   std::string value;
+};
+
+TEST_CASE("Test XSites")
+{
+   DefaultTestChain t;
+   auto             xsites = t.http(XSites::service);
+   CHECK(xsites.put("/test", TextBody{"test"}).status == HttpStatus::ok);
+   CHECK(xsites.get<TextBody>("/test").value == "test");
+   CHECK(t.http().get(XHttp::service, "/test").status == HttpStatus::notFound);
+   CHECK(t.http().put(HttpServer::service, "/wrong-service", TextBody{"test"}).status ==
+         HttpStatus::notFound);
+}

--- a/packages/local/XSites/test/XSites-test.cpp
+++ b/packages/local/XSites/test/XSites-test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Test XSites")
    auto             xsites = t.http(XSites::service);
    CHECK(xsites.put("/test", TextBody{"test"}).status == HttpStatus::ok);
    CHECK(xsites.get<TextBody>("/test").value == "test");
-   CHECK(t.http().get(XHttp::service, "/test").status == HttpStatus::notFound);
-   CHECK(t.http().put(HttpServer::service, "/wrong-service", TextBody{"test"}).status ==
+   CHECK(t.get(XHttp::service, "/test").status == HttpStatus::notFound);
+   CHECK(t.put(HttpServer::service, "/wrong-service", TextBody{"test"}).status ==
          HttpStatus::notFound);
 }

--- a/packages/local/XSites/test/XSites-test.cpp
+++ b/packages/local/XSites/test/XSites-test.cpp
@@ -4,7 +4,6 @@
 #include <services/system/HttpServer.hpp>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_templated.hpp>
 
 using namespace psibase;
 using namespace LocalService;

--- a/packages/system/Transact/test/Transact-test.cpp
+++ b/packages/system/Transact/test/Transact-test.cpp
@@ -99,9 +99,8 @@ TEST_CASE("Test login")
 
       auto token = t.post<LoginReply>(Transact::service, "/login", FracPackBody{std::move(strx)})
                        .access_token;
-      auto req = t.makeGet(getUser, "/");
-      req.headers.push_back({"Authorization", "Bearer " + token});
-      auto user = t.http<std::optional<AccountNumber>>(req);
+      auto client = t.http(getUser).auth_bearer(token);
+      auto user   = client.get<std::optional<AccountNumber>>("/");
       CHECK(user == std::optional{alice});
    }
 
@@ -125,9 +124,8 @@ TEST_CASE("Test login")
 
       auto token = t.post<LoginReply>(Transact::service, "/login", FracPackBody{std::move(strx)})
                        .access_token;
-      auto req = t.makeGet(getUser, "/");
-      req.headers.push_back({"Authorization", "Bearer " + token});
-      auto user = t.http<std::optional<AccountNumber>>(req);
+      auto client = t.http(getUser).auth_bearer(token);
+      auto user   = client.get<std::optional<AccountNumber>>("/");
       CHECK(user == std::optional{alice});
    }
 }


### PR DESCRIPTION
`XSites` doesn't include the service in its table key, so all content is shared by all services.

Also, refactor request building in the tester and add support for `PUT`.