### PR TITLE
Update vite configs for x-proxy and hot reloading

### DIFF
--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/ui/index.html
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/ui/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="../../../shared-ui/styles/globals.css" rel="stylesheet">
     <title>{{project-name | title_case}}</title>
   </head>
   <body>

--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/ui/src/main.tsx
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/ui/src/main.tsx
@@ -5,14 +5,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
 import { ThemeProvider } from "@/components/theme-provider";
 
+import "@shared/styles/globals.css";
+
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-    <React.StrictMode>
-        <QueryClientProvider client={queryClient}>
-            <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
-                <App />
-            </ThemeProvider>
-        </QueryClientProvider>
-    </React.StrictMode>,
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
+        <App />
+      </ThemeProvider>
+    </QueryClientProvider>
+  </React.StrictMode>,
 );

--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/ui/vite.config.mts
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/ui/vite.config.mts
@@ -8,23 +8,14 @@ import {
   verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-const serviceName = "{{project-name}}";
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
   plugins: [
-    createSharedViteConfig({
-      projectDir: serviceDir,
-    }),
-    createPsibaseConfig({
-      service: serviceName,
-      serviceDir: serviceDir,
-      isServing: command === "serve",
-      useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-    }),
+    createSharedViteConfig(),
+    createPsibaseConfig(config, { appDirectory }),
     ...getSharedUIPlugins(),
   ],
   build: {

--- a/packages/local/XAdmin/ui/index.html
+++ b/packages/local/XAdmin/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Psibase Admin Panel</title>
     </head>
     <body>

--- a/packages/local/XAdmin/ui/src/main.tsx
+++ b/packages/local/XAdmin/ui/src/main.tsx
@@ -6,6 +6,8 @@ import { Toaster } from "@/components/ui/toaster";
 
 import { ThemeProvider } from "@/components/theme-provider";
 
+import "@shared/styles/globals.css";
+
 import { Routing } from "./routing";
 
 export const queryClient = new QueryClient();

--- a/packages/local/XAdmin/ui/vite.config.mts
+++ b/packages/local/XAdmin/ui/vite.config.mts
@@ -10,46 +10,32 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "x-admin",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
+        createPsibaseConfig(config, {
+            appDirectory,
             additionalAliases: [
                 {
                     find: "wasm-transpiled",
                     replacement: path.resolve(
-                        serviceDir,
+                        appDirectory,
                         "./wasm-transpiled/x_admin",
                     ),
                 },
             ],
-            additionalProxies: {
-                "^/ws/.*": {
-                    target: "ws://localhost:8080/",
-                    ws: true,
-                    rewrite: (path) => path.replace(/^\/ws/, ""),
-                    timeout: 10000,
-                },
-            },
-            additionalProxyBypassConditions: [(req) => req.method !== "PUT"],
         }),
+        ...getSharedUIPlugins(),
         wasm(),
         topLevelAwait(),
-        ...getSharedUIPlugins(),
     ],
     build: {
         minify: true,

--- a/packages/local/XProxy/ui/index.html
+++ b/packages/local/XProxy/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>X-Proxy</title>
     </head>
     <body>

--- a/packages/local/XProxy/ui/src/main.tsx
+++ b/packages/local/XProxy/ui/src/main.tsx
@@ -1,6 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ReactDOM from "react-dom/client";
 
+import "@shared/styles/globals.css";
+
 import App from "./App";
 
 const queryClient = new QueryClient();

--- a/packages/local/XProxy/ui/src/vite-env.d.ts
+++ b/packages/local/XProxy/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/local/XProxy/ui/vite.config.mts
+++ b/packages/local/XProxy/ui/vite.config.mts
@@ -8,25 +8,13 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
-verifyViteCache(serviceDir);
-
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
-        createSharedViteConfig({
-            projectDir: serviceDir,
-            manualChunks: {
-                vendor: ["react", "react-dom"],
-            },
-        }),
-        createPsibaseConfig({
-            service: "x-proxy",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-            bundleCommonLib: true,
-        }),
+        createSharedViteConfig(),
+        createPsibaseConfig(config, { appDirectory, bundleCommonLib: true }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/system/Accounts/ui/index.html
+++ b/packages/system/Accounts/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Accounts</title>
     </head>
     <body>

--- a/packages/system/Accounts/ui/src/main.tsx
+++ b/packages/system/Accounts/ui/src/main.tsx
@@ -7,6 +7,7 @@ import { getSupervisor } from "@psibase/common-lib";
 
 import { ThemeProvider } from "@shared/components/theme-provider";
 import { Toaster } from "@shared/shadcn/ui/sonner";
+import "@shared/styles/globals.css";
 
 import Router from "./router";
 

--- a/packages/system/Accounts/ui/src/vite-env.d.ts
+++ b/packages/system/Accounts/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/system/Accounts/ui/vite.config.mts
+++ b/packages/system/Accounts/ui/vite.config.mts
@@ -8,25 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "accounts",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/user/Config/ui/index.html
+++ b/packages/user/Config/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Config</title>
     </head>
     <body>

--- a/packages/user/Config/ui/src/main.tsx
+++ b/packages/user/Config/ui/src/main.tsx
@@ -4,8 +4,8 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
 import { ThemeProvider } from "@shared/components/theme-provider";
-
 import { Toaster } from "@shared/shadcn/ui/sonner";
+import "@shared/styles/globals.css";
 
 import { queryClient } from "./queryClient";
 import { router } from "./router";

--- a/packages/user/Config/ui/src/vite-env.d.ts
+++ b/packages/user/Config/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/user/Config/ui/vite.config.mts
+++ b/packages/user/Config/ui/vite.config.mts
@@ -8,25 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "config",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/user/Evaluations/ui/index.html
+++ b/packages/user/Evaluations/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Evaluations</title>
     </head>
     <body>

--- a/packages/user/Evaluations/ui/src/main.tsx
+++ b/packages/user/Evaluations/ui/src/main.tsx
@@ -5,6 +5,8 @@ import { RouterProvider } from "react-router-dom";
 
 import { ThemeProvider } from "@/components/theme-provider";
 
+import "@shared/styles/globals.css";
+
 import { router } from "./router";
 
 export const queryClient = new QueryClient();

--- a/packages/user/Evaluations/ui/vite.config.mts
+++ b/packages/user/Evaluations/ui/vite.config.mts
@@ -8,25 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "evaluations",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/user/Explorer/ui/vite.config.ts
+++ b/packages/user/Explorer/ui/vite.config.ts
@@ -6,27 +6,23 @@ import { isoImport } from "vite-plugin-iso-import";
 import svg from "@poppanator/sveltekit-svg";
 import { verifyViteCache, createPsibaseConfig, createSharedViteConfig } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         isoImport(),
         sveltekit(),
         createSharedViteConfig({
-            projectDir: serviceDir,
             uiFramework: 'svelte',
             manualChunks: {
                 vendor: ['svelte', '@sveltejs/kit']
             }
         }),
-        createPsibaseConfig({
-            service: "explorer",
-            serviceDir,
+        createPsibaseConfig(config, {
+            appDirectory,
             uiFramework: 'svelte',
-            isServing: command === "serve",
         }),
         // @ts-ignore
         svg({

--- a/packages/user/FractalCore/ui/index.html
+++ b/packages/user/FractalCore/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Fractals</title>
     </head>
     <body>

--- a/packages/user/FractalCore/ui/src/main.tsx
+++ b/packages/user/FractalCore/ui/src/main.tsx
@@ -12,6 +12,7 @@ import { RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "@shared/components/theme-provider";
 import { queryClient } from "@shared/lib/queryClient";
 import { Toaster } from "@shared/shadcn/ui/sonner";
+import "@shared/styles/globals.css";
 
 import { router } from "./router";
 

--- a/packages/user/FractalCore/ui/src/vite-env.d.ts
+++ b/packages/user/FractalCore/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/user/FractalCore/ui/vite.config.mts
+++ b/packages/user/FractalCore/ui/vite.config.mts
@@ -8,25 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "fractals",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/user/Fractals/ui/index.html
+++ b/packages/user/Fractals/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Fractals</title>
     </head>
     <body>

--- a/packages/user/Fractals/ui/src/main.tsx
+++ b/packages/user/Fractals/ui/src/main.tsx
@@ -11,6 +11,7 @@ import { RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "@/components/theme-provider";
 
 import { Toaster } from "@shared/shadcn/ui/sonner";
+import "@shared/styles/globals.css";
 
 import { queryClient } from "./queryClient";
 import { router } from "./router";

--- a/packages/user/Fractals/ui/src/vite-env.d.ts
+++ b/packages/user/Fractals/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/user/Fractals/ui/vite.config.mts
+++ b/packages/user/Fractals/ui/vite.config.mts
@@ -8,23 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
 export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig(config, {
-            service: "fractals",
-            serviceDir: serviceDir,
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/user/Fractals/ui/vite.config.mts
+++ b/packages/user/Fractals/ui/vite.config.mts
@@ -13,7 +13,7 @@ const serviceDir = path.resolve(__dirname);
 verifyViteCache(serviceDir);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
             projectDir: serviceDir,
@@ -21,11 +21,9 @@ export default defineConfig(({ command }) => ({
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
+        createPsibaseConfig(config, {
             service: "fractals",
             serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
         }),
         ...getSharedUIPlugins(),
     ],

--- a/packages/user/Homepage/ui/index.html
+++ b/packages/user/Homepage/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Psibase Dashboard</title>
 
         <style>

--- a/packages/user/Homepage/ui/src/main.tsx
+++ b/packages/user/Homepage/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from "react-router-dom";
 
 import { ThemeProvider } from "@shared/components/theme-provider";
 import { Toaster } from "@shared/shadcn/ui/sonner";
+import "@shared/styles/globals.css";
 
 import router from "./router";
 

--- a/packages/user/Homepage/ui/vite.config.mts
+++ b/packages/user/Homepage/ui/vite.config.mts
@@ -9,25 +9,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "homepage",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
         svgr(),
     ],

--- a/packages/user/Identity/ui/index.html
+++ b/packages/user/Identity/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Identity</title>
     </head>
     <body>

--- a/packages/user/Identity/ui/src/main.tsx
+++ b/packages/user/Identity/ui/src/main.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 
+import "@shared/styles/globals.css";
+
 import App from "./App.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/packages/user/Identity/ui/vite.config.mts
+++ b/packages/user/Identity/ui/vite.config.mts
@@ -8,25 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "identity",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/user/Packages/ui/index.html
+++ b/packages/user/Packages/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Packages</title>
     </head>
     <body>

--- a/packages/user/Packages/ui/src/main.tsx
+++ b/packages/user/Packages/ui/src/main.tsx
@@ -4,6 +4,8 @@ import ReactDOM from "react-dom/client";
 
 import { ThemeProvider } from "@/components/theme-provider";
 
+import "@shared/styles/globals.css";
+
 import { App } from "./App";
 
 const queryClient = new QueryClient();

--- a/packages/user/Packages/ui/vite.config.mts
+++ b/packages/user/Packages/ui/vite.config.mts
@@ -8,23 +8,14 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-const serviceName = "packages";
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
-        createSharedViteConfig({
-            projectDir: serviceDir,
-        }),
-        createPsibaseConfig({
-            service: serviceName,
-            serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createSharedViteConfig(),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/user/Permissions/ui/index.html
+++ b/packages/user/Permissions/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Permissions</title>
     </head>
     <body>

--- a/packages/user/Permissions/ui/plugin/web/prompt/permissions/index.html
+++ b/packages/user/Permissions/ui/plugin/web/prompt/permissions/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../../../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Permissions Grant</title>
     </head>
     <body>

--- a/packages/user/Permissions/ui/src/main.tsx
+++ b/packages/user/Permissions/ui/src/main.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { ThemeProvider } from "@shared/components/theme-provider";
+import "@shared/styles/globals.css";
 
 import { App } from "./app";
 

--- a/packages/user/Permissions/ui/src/prompt/main.tsx
+++ b/packages/user/Permissions/ui/src/prompt/main.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { ThemeProvider } from "@shared/components/theme-provider";
+import "@shared/styles/globals.css";
 
 import { App } from "./app";
 

--- a/packages/user/Permissions/ui/vite.config.mts
+++ b/packages/user/Permissions/ui/vite.config.mts
@@ -8,25 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "permissions",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {
@@ -34,8 +27,11 @@ export default defineConfig(({ command }) => ({
         sourcemap: false,
         rollupOptions: {
             input: {
-                main: path.resolve(serviceDir, "index.html"),
-                permissions: path.resolve(serviceDir, "plugin/web/prompt/permissions/index.html"),
+                main: path.resolve(appDirectory, "index.html"),
+                permissions: path.resolve(
+                    appDirectory,
+                    "plugin/web/prompt/permissions/index.html",
+                ),
             },
         },
     },

--- a/packages/user/Supervisor/ui/prompt.html
+++ b/packages/user/Supervisor/ui/prompt.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet">
         <title>Prompt</title>
     </head>
     <body>

--- a/packages/user/Supervisor/ui/prompt/src/main.tsx
+++ b/packages/user/Supervisor/ui/prompt/src/main.tsx
@@ -2,6 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
+import "@shared/styles/globals.css";
+
 import { App } from "./App";
 import { ThemeProvider } from "./components/theme-provider";
 

--- a/packages/user/Supervisor/ui/vite.config.mts
+++ b/packages/user/Supervisor/ui/vite.config.mts
@@ -8,22 +8,14 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
-        createSharedViteConfig({
-            projectDir: serviceDir,
-        }),
-        createPsibaseConfig({
-            service: "supervisor",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createSharedViteConfig(),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {
@@ -33,8 +25,8 @@ export default defineConfig(({ command }) => ({
         rollupOptions: {
             external: ["hash.js", "elliptic"],
             input: {
-                main: path.resolve(serviceDir, "index.html"),
-                prompt: path.resolve(serviceDir, "prompt.html"),
+                main: path.resolve(appDirectory, "index.html"),
+                prompt: path.resolve(appDirectory, "prompt.html"),
             },
             output: {
                 entryFileNames: "assets/[name].js",

--- a/packages/user/TokenStream/ui/index.html
+++ b/packages/user/TokenStream/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Token Stream</title>
     </head>
     <body>

--- a/packages/user/TokenStream/ui/src/main.tsx
+++ b/packages/user/TokenStream/ui/src/main.tsx
@@ -6,6 +6,7 @@ import { RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "@/components/theme-provider";
 
 import { Toaster } from "@shared/shadcn/ui/sonner";
+import "@shared/styles/globals.css";
 
 import { router } from "./router";
 

--- a/packages/user/TokenStream/ui/vite.config.mts
+++ b/packages/user/TokenStream/ui/vite.config.mts
@@ -8,23 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-const serviceName = "token-stream";
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
+            manualChunks: {
+                vendor: ["react", "react-dom", "react-router-dom"],
+            },
         }),
-        createPsibaseConfig({
-            service: serviceName,
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/user/Workshop/ui/index.html
+++ b/packages/user/Workshop/ui/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="../../../shared-ui/styles/globals.css" rel="stylesheet" />
         <title>Workshop</title>
     </head>
     <body>

--- a/packages/user/Workshop/ui/src/main.tsx
+++ b/packages/user/Workshop/ui/src/main.tsx
@@ -6,6 +6,7 @@ import { RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "@/components/theme-provider";
 
 import { Toaster } from "@shared/shadcn/ui/sonner";
+import "@shared/styles/globals.css";
 
 import { queryClient } from "./queryClient";
 import { router } from "./router";

--- a/packages/user/Workshop/ui/src/vite-env.d.ts
+++ b/packages/user/Workshop/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/user/Workshop/ui/vite.config.mts
+++ b/packages/user/Workshop/ui/vite.config.mts
@@ -8,25 +8,18 @@ import {
     verifyViteCache,
 } from "../../../vite.shared";
 
-const serviceDir = path.resolve(__dirname);
-
-verifyViteCache(serviceDir);
+const appDirectory = path.resolve(__dirname);
+verifyViteCache(appDirectory);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig((config) => ({
     plugins: [
         createSharedViteConfig({
-            projectDir: serviceDir,
             manualChunks: {
                 vendor: ["react", "react-dom", "react-router-dom"],
             },
         }),
-        createPsibaseConfig({
-            service: "workshop",
-            serviceDir: serviceDir,
-            isServing: command === "serve",
-            useHttps: process.env.VITE_SECURE_LOCAL_DEV === "true",
-        }),
+        createPsibaseConfig(config, { appDirectory }),
         ...getSharedUIPlugins(),
     ],
     build: {

--- a/packages/vite.shared.ts
+++ b/packages/vite.shared.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import type { Alias, Plugin, UserConfig } from "vite";
+import type { Alias, ConfigEnv, Plugin, UserConfig } from "vite";
 
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -74,7 +74,7 @@ export function createSharedViteConfig(
           };
 }
 
-export function verifyViteCache(dirname: any) {
+export function verifyViteCache(dirname: string) {
     // Ensure cache directory exists
     const cacheDir = path.resolve(dirname, ".vite-cache");
     if (!fs.existsSync(cacheDir)) {
@@ -86,56 +86,24 @@ export interface PsibaseConfigOptions {
     uiFramework?: string;
     service: string;
     serviceDir: string;
-    isServing?: boolean;
-    useHttps?: boolean;
-    proxyPort?: number;
     bundleCommonLib?: boolean;
     additionalAliases?: Array<{ find: string | RegExp; replacement: string }>;
-    additionalProxyBypassConditions?: Array<(req: any) => boolean>;
-    additionalProxies?: Record<
-        string,
-        {
-            target: string;
-            ws?: boolean;
-            timeout?: number;
-            rewrite?: (path: string) => string;
-        }
-    >;
-}
-
-interface ServerConfig {
-    host: string;
-    port: number;
-    proxy: {
-        "/": {
-            target: string;
-            changeOrigin: boolean;
-            secure: boolean;
-            autoRewrite: boolean;
-            timeout?: number;
-            bypass: (req: any, _res: any, _opt: any) => any;
-        };
-    };
-    https?: {
-        key: string;
-        cert: string;
-    };
 }
 
 const servicesDir = path.resolve(__dirname);
 
-export function createPsibaseConfig(options: PsibaseConfigOptions): Plugin {
+export function createPsibaseConfig(
+    config: ConfigEnv,
+    options: PsibaseConfigOptions,
+): Plugin {
+    const isDevServer = config.command === "serve";
+
     const {
         uiFramework = "react",
         service,
         serviceDir,
-        isServing = false,
-        useHttps = process.env.VITE_SECURE_LOCAL_DEV === "true",
-        proxyPort = 8080,
         bundleCommonLib = false,
         additionalAliases = [],
-        additionalProxyBypassConditions = [],
-        additionalProxies = [],
     } = options;
 
     const commonLibSourcePath = path.resolve(
@@ -155,76 +123,21 @@ export function createPsibaseConfig(options: PsibaseConfigOptions): Plugin {
         },
         {
             find: /^@psibase\/common-lib.*$/,
-            replacement: bundleCommonLib
-                ? commonLibSourcePath
-                : "/common/common-lib.js",
+            replacement:
+                isDevServer || bundleCommonLib
+                    ? commonLibSourcePath
+                    : "/common/common-lib.js",
         },
         ...additionalAliases,
     ];
 
-    if (isServing && !bundleCommonLib) {
-        // TODO: this is contradictory to the above alias
-        buildAliases.push({
-            find: /^@psibase\/common-lib.*$/,
-            replacement: commonLibSourcePath,
-        });
-    }
-
-    const baseServerConfig: ServerConfig = {
-        host: `${service}.psibase.127.0.0.1.sslip.io`,
-        port: 8081,
-        proxy: {
-            ...additionalProxies,
-            "/": {
-                target: `${useHttps ? "https" : "http"}://psibase.127.0.0.1.sslip.io:${proxyPort}/`,
-                changeOrigin: true,
-                secure: !useHttps,
-                autoRewrite: true,
-                timeout: 10000,
-                bypass: (req: any, _res: any, _opt: any) => {
-                    const host = req.headers.host || "";
-                    const subdomain = host.split(".")[0];
-                    const baseConditions = [
-                        subdomain === service,
-                        req.method !== "POST",
-                        req.headers.accept !== "application/json",
-                        !req.url.startsWith("/common"),
-                        !req.url.startsWith("/api"),
-                    ];
-                    return req.url === "/" ||
-                        [
-                            ...baseConditions,
-                            ...additionalProxyBypassConditions,
-                        ].every((condition) =>
-                            typeof condition === "function"
-                                ? condition(req)
-                                : condition,
-                        )
-                        ? req.url
-                        : undefined;
-                },
-            },
-        },
-    };
-
-    const pathToCerts: string = process.env.VITE_SECURE_PATH_TO_CERTS ?? "";
-
-    if (useHttps) {
-        baseServerConfig.https = {
-            key: fs.readFileSync(
-                `${pathToCerts}psibase.127.0.0.1.sslip.io+1-key.pem`,
-                "utf8",
-            ),
-            cert: fs.readFileSync(
-                `${pathToCerts}psibase.127.0.0.1.sslip.io+1.pem`,
-                "utf8",
-            ),
-        };
-    }
-
     return {
         name: "psibase",
         config: () => ({
+            server: {
+                host: `${service}.psibase.localhost`,
+                port: 8081,
+            },
             build: {
                 ...(uiFramework !== "svelte" ? outDirParams : {}),
                 assetsDir: "",
@@ -232,14 +145,11 @@ export function createPsibaseConfig(options: PsibaseConfigOptions): Plugin {
                 rollupOptions: {
                     external: [
                         "/common/rootdomain.mjs",
-                        ...(bundleCommonLib
-                            ? []
-                            : ["/common/common-lib.js"]),
+                        ...(bundleCommonLib ? [] : ["/common/common-lib.js"]),
                     ],
                     makeAbsoluteExternalsRelative: false,
                 },
             },
-            server: baseServerConfig,
             resolve: {
                 alias: buildAliases,
             },

--- a/packages/vite.shared.ts
+++ b/packages/vite.shared.ts
@@ -13,7 +13,6 @@ const outDirParams = {
 };
 
 export interface SharedViteConfigOptions {
-    projectDir: string;
     manualChunks?: Record<string, string[]>;
     additionalManualChunks?: Record<string, string[]>;
     uiFramework?: string;
@@ -84,8 +83,7 @@ export function verifyViteCache(dirname: string) {
 
 export interface PsibaseConfigOptions {
     uiFramework?: string;
-    service: string;
-    serviceDir: string;
+    appDirectory: string;
     bundleCommonLib?: boolean;
     additionalAliases?: Array<{ find: string | RegExp; replacement: string }>;
 }
@@ -100,8 +98,7 @@ export function createPsibaseConfig(
 
     const {
         uiFramework = "react",
-        service,
-        serviceDir,
+        appDirectory,
         bundleCommonLib = false,
         additionalAliases = [],
     } = options;
@@ -113,7 +110,7 @@ export function createPsibaseConfig(
     const buildAliases: Alias[] = [
         {
             find: "@",
-            replacement: path.resolve(serviceDir, "./src"),
+            replacement: path.resolve(appDirectory, "./src"),
         },
         {
             find: /^\/common(?!\/(?:fonts))(.*)$/,
@@ -135,7 +132,6 @@ export function createPsibaseConfig(
         name: "psibase",
         config: () => ({
             server: {
-                host: `${service}.psibase.localhost`,
                 port: 8081,
             },
             build: {

--- a/packages/vite.shared.ts
+++ b/packages/vite.shared.ts
@@ -19,7 +19,7 @@ export interface SharedViteConfigOptions {
 }
 
 export function createSharedViteConfig(
-    options: SharedViteConfigOptions,
+    options?: SharedViteConfigOptions,
 ): Plugin {
     const {
         uiFramework = "react",
@@ -27,7 +27,7 @@ export function createSharedViteConfig(
             vendor: ["react", "react-dom"],
         },
         additionalManualChunks = {},
-    } = options;
+    } = options ?? {};
 
     const rollupOptions = {
         cache: true,


### PR DESCRIPTION
This simplifies the shared vite config. Now running `yarn dev` on an app client works with x-proxy, giving us hot reloading nirvana.

I've updated a few app's vite configs to use the new shared config for demonstration and feedback-gathering purposes. If we're happy, I'll add a commit updating the remaining vite configs.

- [x] Test with fractal-core, given subdomain is dynamic (fixed by removing subdomain/service name from vite config entirely)
- [x] Roll out changes to app vite configs

## Subsequent PRs
- Figure out what we're going to do about homepage (no sub-sub-domain)
- Update x-proxy UI to support origin removal