### PR TITLE
Add --proposer param to cargo-psibase (issue #1696)

### DIFF
--- a/rust/cargo-psibase/src/main.rs
+++ b/rust/cargo-psibase/src/main.rs
@@ -59,11 +59,6 @@ enum PsibaseCommand {
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// Sign transactions with one or more keys.
-    /// Each KEY may be a PKCS #11 URI or a path to a PEM/DER-encoded private key file.
-    #[clap(short = 's', long, value_name = "KEY")]
-    sign: Vec<String>,
-
     /// Path to Cargo.toml
     #[clap(long, global = true, value_name = "PATH")]
     manifest_path: Option<PathBuf>,
@@ -92,6 +87,20 @@ struct Args {
     command: Command,
 }
 
+/// Signing and staged-transaction options, using the same flags as `psibase`'s `SigArgs` (flattened the same way).
+#[derive(clap::Args, Debug)]
+#[clap(long_about = None)]
+struct SigArgs {
+    /// Sign transactions with one or more keys.
+    /// Each KEY may be a PKCS #11 URI or a path to a PEM/DER-encoded private key file.
+    #[clap(short = 's', long, value_name = "KEY")]
+    sign: Vec<String>,
+
+    /// Stages transactions instead of executing them immediately
+    #[clap(long, value_name = "ACCOUNT")]
+    proposer: Option<ExactAccountNumber>,
+}
+
 #[derive(Parser, Debug)]
 struct InstallCommand {
     /// API Endpoint URL (ie https://psibase-api.example.com) or a Host Alias (ie prod, dev). See `psibase config --help` for more details.
@@ -102,6 +111,9 @@ struct InstallCommand {
         env = "PSINODE_URL"
     )]
     api: Option<String>,
+
+    #[command(flatten)]
+    sig_args: SigArgs,
 
     /// Sender to use for installing. The packages and all accounts
     /// that they create will be owned by this account.
@@ -1122,8 +1134,11 @@ async fn install(
     let mut command = std::process::Command::new(&args.psibase);
 
     command.arg("install");
-    for key in &args.sign {
+    for key in &opts.sig_args.sign {
         command.args(["--sign", key]);
+    }
+    if let Some(proposer) = &opts.sig_args.proposer {
+        command.args(["--proposer", &proposer.to_string()]);
     }
     if let Some(api) = &opts.api {
         command.args(["--api", api.as_str()]);


### PR DESCRIPTION
#1696 
add --proposer param
relocate --sign to mirror command/param ordering/ergonomics of `psibase`, namely

reference: `psibase install --sign KEY --proposer ACCOUNT`

former: `cargo-psibase --sign KEY install`
now: `cargo-psibase install --sign KEY --proposer ACCOUNT`