### PR TITLE
Accounts: Fix padding on switch-account button

### DIFF
--- a/packages/system/Accounts/ui/src/components/account-list-item.tsx
+++ b/packages/system/Accounts/ui/src/components/account-list-item.tsx
@@ -31,13 +31,13 @@ export const AccountListItem = ({
     return (
         <li
             className={cn(
-                "flex select-none items-center rounded-md px-2 py-4",
+                "flex select-none items-center rounded-md",
                 canLogin && "hover:bg-sidebar-accent",
             )}
         >
             <button
                 onClick={onLogin}
-                className="flex flex-1 items-center gap-2"
+                className="flex flex-1 items-center gap-2 px-2 py-5"
             >
                 <Avatar account={name} className="size-6" />
                 {name}


### PR DESCRIPTION
UX nit: I noticed that I often had to hit the account button multiple times to get it to register when switching accounts. The padding was on the list item and not the button element it contained. This moves the padding to the button so that the top and bottom of the button are also clickable.

<img width="650" height="357" alt="image" src="https://github.com/user-attachments/assets/c93fc0ec-9573-446d-9668-b6f79a8541cb" />
