### PR TITLE
Fix FractalGen and create FractalTester package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,12 @@ cargo_psibase_package(
 )
 
 cargo_psibase_package(
+    OUTPUT ${SERVICE_DIR}/FractalTester.psi
+    PATH packages/user/FractalTester
+    TARGET_DIR ${USER_WORKSPACE_TARGET}
+)
+
+cargo_psibase_package(
     OUTPUT ${SERVICE_DIR}/Branding.psi
     PATH packages/user/Branding
     TARGET_DIR ${USER_WORKSPACE_TARGET}
@@ -1185,7 +1191,7 @@ endfunction()
 
 write_package_index(package-index ${SERVICE_DIR}
     Accounts Aes AuthAny AuthDyn AuthDelegate AuthSig Base64 Branding BrotliCodec BrotliSvc Chainmail ClientData CommonApi CpuLimit Credentials Db DevDefault ProdDefault ProdWithFG
-    Docs DiffAdjust Events Evaluations FaucetTok Fractals FractalCore FractalGen Explorer Host Identity Invite Kdf Kvtests Nft Nop Minimal Packages Permissions Producers Profiles TestDefault HttpServer Registry 
+    Docs DiffAdjust Events Evaluations FaucetTok Fractals FractalCore FractalGen FractalTester Explorer Host Identity Invite Kdf Kvtests Nft Nop Minimal Packages Permissions Producers Profiles TestDefault HttpServer Registry 
     Sites SetCode StagedTx Subgroups Supervisor Symbol TokenUsers Tokens TokenStream TokenSwap Transact Homepage VirtualServer WebCrypto Workshop Config
     XAdmin XBasic XDb XDefault XHttp XPackages XPeers XProxy XRun XSites XTimer XTransact)
 
@@ -1219,6 +1225,7 @@ install(
           ${SERVICE_DIR}/Fractals.psi
           ${SERVICE_DIR}/FractalCore.psi
           ${SERVICE_DIR}/FractalGen.psi
+          ${SERVICE_DIR}/FractalTester.psi
           ${SERVICE_DIR}/Host.psi
           ${SERVICE_DIR}/HttpServer.psi
           ${SERVICE_DIR}/Homepage.psi

--- a/packages/user/Cargo.lock
+++ b/packages/user/Cargo.lock
@@ -1251,6 +1251,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "frac-tester"
+version = "0.23.0"
+dependencies = [
+ "frac-tester-pkg",
+ "psibase",
+ "psibase-user-workspace-hack",
+ "psibase_service",
+ "serde",
+]
+
+[[package]]
+name = "frac-tester-pkg"
+version = "0.23.0"
+dependencies = [
+ "frac-tester",
+ "psibase-user-workspace-hack",
+]
+
+[[package]]
 name = "fracpack"
 version = "0.23.0"
 dependencies = [

--- a/packages/user/Cargo.toml
+++ b/packages/user/Cargo.toml
@@ -21,6 +21,8 @@ members = [
     "FaucetTok/plugin",
     "FractalGen",
     "FractalGen/service",
+    "FractalTester",
+    "FractalTester/service",
     "Fractals",
     "Fractals/service",
     "Fractals/plugin",

--- a/packages/user/FractalGen/service/src/lib.rs
+++ b/packages/user/FractalGen/service/src/lib.rs
@@ -33,8 +33,8 @@ mod service {
     };
     use psibase::*;
 
-    const SYS_FRACTAL: AccountNumber = account!("core-frac");
-    const SYS_GUILD: AccountNumber = account!("core-g1");
+    const SYS_FRACTAL: AccountNumber = account!("core-fract");
+    const SYS_GUILD: AccountNumber = account!("core-gld-1");
     const ROOT: AccountNumber = account!("root");
 
     #[action]

--- a/packages/user/FractalTester/Cargo.toml
+++ b/packages/user/FractalTester/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "frac-tester-pkg"
+description = "Creates 18 auth-any test accounts and adds them as members of the system guild. Depends on FractalGen. Not for production use."
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[package.metadata.psibase]
+package-name = "FractalTester"
+services = ["frac-tester"]
+
+[package.metadata.psibase.dependencies]
+Sites = "0.23.0"
+HttpServer = "0.23.0"
+FractalGen = "0.23.0"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+frac-tester = { path = "service", version = "0.23.0" }
+psibase-user-workspace-hack.workspace = true

--- a/packages/user/FractalTester/Cargo.toml
+++ b/packages/user/FractalTester/Cargo.toml
@@ -13,8 +13,6 @@ package-name = "FractalTester"
 services = ["frac-tester"]
 
 [package.metadata.psibase.dependencies]
-Sites = "0.23.0"
-HttpServer = "0.23.0"
 FractalGen = "0.23.0"
 
 [lib]

--- a/packages/user/FractalTester/Cargo.toml
+++ b/packages/user/FractalTester/Cargo.toml
@@ -12,9 +12,6 @@ publish.workspace = true
 package-name = "FractalTester"
 services = ["frac-tester"]
 
-[package.metadata.psibase.dependencies]
-FractalGen = "0.23.0"
-
 [lib]
 crate-type = ["rlib"]
 

--- a/packages/user/FractalTester/service/Cargo.toml
+++ b/packages/user/FractalTester/service/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "frac-tester"
+version.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[package.metadata.psibase]
+flags = ["isPrivileged"]
+postinstall = [
+    { sender = "frac-tester", service = "frac-tester", method = "setup" },
+]
+
+[dependencies]
+psibase.workspace = true
+psibase_service.workspace = true
+psibase-user-workspace-hack.workspace = true
+serde.workspace = true
+
+[package.metadata.psibase.dependencies]
+Sites = "0.23.0"
+HttpServer = "0.23.0"
+Tokens = "0.23.0"
+Symbol = "0.23.0"
+Transact = "0.23.0"
+Nft = "0.23.0"
+VirtualServer = "0.23.0"
+Fractals = "0.23.0"
+Accounts = "0.23.0"
+Producers = "0.23.0"
+
+[dev-dependencies]
+frac-tester-pkg = { path = "..", version = "0.23.0" }

--- a/packages/user/FractalTester/service/Cargo.toml
+++ b/packages/user/FractalTester/service/Cargo.toml
@@ -19,5 +19,11 @@ psibase_service.workspace = true
 psibase-user-workspace-hack.workspace = true
 serde.workspace = true
 
+[package.metadata.psibase.dependencies]
+Accounts = "0.23.0"
+Fractals = "0.23.0"
+FractalGen = "0.23.0"
+Producers = "0.23.0"
+
 [dev-dependencies]
 frac-tester-pkg = { path = "..", version = "0.23.0" }

--- a/packages/user/FractalTester/service/Cargo.toml
+++ b/packages/user/FractalTester/service/Cargo.toml
@@ -19,17 +19,5 @@ psibase_service.workspace = true
 psibase-user-workspace-hack.workspace = true
 serde.workspace = true
 
-[package.metadata.psibase.dependencies]
-Sites = "0.23.0"
-HttpServer = "0.23.0"
-Tokens = "0.23.0"
-Symbol = "0.23.0"
-Transact = "0.23.0"
-Nft = "0.23.0"
-VirtualServer = "0.23.0"
-Fractals = "0.23.0"
-Accounts = "0.23.0"
-Producers = "0.23.0"
-
 [dev-dependencies]
 frac-tester-pkg = { path = "..", version = "0.23.0" }

--- a/packages/user/FractalTester/service/src/lib.rs
+++ b/packages/user/FractalTester/service/src/lib.rs
@@ -1,0 +1,94 @@
+/// Creates 18 auth-any test accounts and adds them as guild members of the
+/// system fractal's genesis guild (created by FractalGen).
+/// Not for production use.
+///
+/// Accounts created: `testfrac01` through `testfrac18`.
+///
+/// The setup flow:
+/// 1. Create 18 accounts with `auth-any`.
+/// 2. Apply each to the system guild (`core-gld-1`).
+/// 3. Look up the first producer and attest each application as that producer.
+
+#[psibase::service_tables]
+pub mod tables {
+    use psibase::{Fracpack, Table, ToSchema};
+    use serde::{Deserialize, Serialize};
+
+    #[table(name = "ConfigTable", index = 0)]
+    #[derive(Default, Fracpack, ToSchema, Serialize, Deserialize, Debug)]
+    pub struct ConfigRow {}
+    impl ConfigRow {
+        #[primary_key]
+        fn pk(&self) {}
+    }
+    impl ConfigRow {
+        pub fn is_init() -> bool {
+            ConfigTable::read().get_index_pk().get(&()).is_some()
+        }
+
+        pub fn init() {
+            ConfigTable::read_write().put(&ConfigRow {}).unwrap();
+        }
+    }
+}
+
+#[psibase::service(name = "frac-tester", tables = "tables")]
+mod service {
+    use crate::tables::ConfigRow;
+    use psibase::services::{
+        accounts::Wrapper as Accounts, fractals::Wrapper as Fractals,
+        producers::Wrapper as Producers,
+    };
+    use psibase::*;
+
+    const TEST_ACCOUNTS: [AccountNumber; 18] = [
+        account!("testfrac01"),
+        account!("testfrac02"),
+        account!("testfrac03"),
+        account!("testfrac04"),
+        account!("testfrac05"),
+        account!("testfrac06"),
+        account!("testfrac07"),
+        account!("testfrac08"),
+        account!("testfrac09"),
+        account!("testfrac10"),
+        account!("testfrac11"),
+        account!("testfrac12"),
+        account!("testfrac13"),
+        account!("testfrac14"),
+        account!("testfrac15"),
+        account!("testfrac16"),
+        account!("testfrac17"),
+        account!("testfrac18"),
+    ];
+
+    const SYS_GUILD: AccountNumber = account!("core-gld-1");
+
+    #[action]
+    fn setup() {
+        check(get_sender() == Wrapper::SERVICE, "Unauthorized");
+
+        if ConfigRow::is_init() {
+            return;
+        }
+        ConfigRow::init();
+
+        // 1. Create accounts with auth-any
+        for &acct in &TEST_ACCOUNTS {
+            Accounts::call().newAccount(acct, account!("auth-any"), true);
+        }
+
+        // 2. Apply each account to the system guild
+        for &acct in &TEST_ACCOUNTS {
+            Fractals::call_from(acct).apply_guild(SYS_GUILD, String::new());
+        }
+
+        // 3. Attest each application as the first producer (who is a guild member)
+        let prods = Producers::call().getProducers();
+        let producer = *prods.first().unwrap();
+
+        for &acct in &TEST_ACCOUNTS {
+            Fractals::call_from(producer).at_mem_app(SYS_GUILD, acct, String::new(), true);
+        }
+    }
+}

--- a/packages/user/FractalTester/src/lib.rs
+++ b/packages/user/FractalTester/src/lib.rs
@@ -1,0 +1,1 @@
+pub use frac_tester;

--- a/packages/user/Fractals/service/Cargo.toml
+++ b/packages/user/Fractals/service/Cargo.toml
@@ -13,6 +13,9 @@ postinstall = [
     { sender = "fractals", service = "sites", method = "enablespa", rawData = "010001" },
 ]
 
+[package.metadata.psibase.dependencies]
+TokenStream = "0.23.0"
+
 [dependencies]
 psibase.workspace = true
 psibase_service.workspace = true


### PR DESCRIPTION
Bootstrap the system fractal with 18 test accounts as core guild members. This helps with testing evaluations and other fractal facilities.