### PR TITLE
Fix lost transactions after a change to verify services

### DIFF
--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -494,6 +494,7 @@ namespace psibase
          {
             tc.execNonTrxAction(0, action, atrace);
          }
+         BOOST_LOG_SCOPED_LOGGER_TAG(trxLogger, "Trace", trace);
          PSIBASE_LOG(trxLogger, debug)
              << "async " << action.service.str() << "::" << action.method.str() << " succeeded";
       }

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -1333,6 +1333,7 @@ void RTransact::requeue()
          break;
       while (true)
       {
+         std::uint64_t foundSequence;
          PSIBASE_SUBJECTIVE_TX
          {
             auto iter = pendingBySequence.lower_bound(nextSequence);
@@ -1346,8 +1347,9 @@ void RTransact::requeue()
 
                scheduleVerify(item.id, data->trx, true, item.speculative);
             }
-            nextSequence = item.sequence + 1;
+            foundSequence = item.sequence;
          }
+         nextSequence = foundSequence + 1;
          if (nextSequence >= endSequence)
             break;
       }

--- a/programs/psitest/main.cpp
+++ b/programs/psitest/main.cpp
@@ -1278,34 +1278,46 @@ struct callbacks
       BOOST_LOG_SCOPED_THREAD_TAG("Host", chain.getName());
       psibase::TransactionTrace trace;
       trace.actionTraces.emplace_back();
+
+      auto exec = [&](psibase::BlockContext& bc)
+      {
+         psibase::SignedTransaction  trx;
+         psibase::TransactionContext tc{bc, trx, trace, dbMode};
+
+         try
+         {
+            tc.execNonTrxAction(0, act, trace.actionTraces.back());
+            PSIBASE_LOG(bc.trxLogger, debug)
+                << act.service.str() << "::" << act.method.str() << " succeeded";
+         }
+         catch (std::exception& e)
+         {
+            if (!trace.error)
+            {
+               trace.error = e.what();
+            }
+            BOOST_LOG_SCOPED_LOGGER_TAG(bc.trxLogger, "Trace", trace);
+            PSIBASE_LOG(bc.trxLogger, debug)
+                << act.service.str() << "::" << act.method.str() << " failed: " << e.what();
+         }
+      };
+
       try
       {
          if (head)
          {
             psibase::BlockContext bc{*chain.sys, chain.head, chain.writer, true};
             bc.start();
-
-            psibase::SignedTransaction  trx;
-            psibase::TransactionContext tc{bc, trx, trace, dbMode};
-
-            tc.execNonTrxAction(0, act, trace.actionTraces.back());
+            exec(bc);
          }
          else
          {
-            auto* bc = chain.readBlockContext();
-
-            psibase::SignedTransaction  trx;
-            psibase::TransactionContext tc{*bc, trx, trace, dbMode};
-
-            tc.execNonTrxAction(0, act, trace.actionTraces.back());
+            exec(*chain.readBlockContext());
          }
       }
       catch (const std::exception& e)
       {
-         if (!trace.error)
-         {
-            trace.error = e.what();
-         }
+         trace.error = e.what();
       }
 
       state.result_value = psio::convert_to_frac(trace);


### PR DESCRIPTION
Symptoms
==

Boot hangs until the boot transactions time out. This only happens some of the time, depending on the timing of transaction submission. Whenever it fails, the log shows that `x-http::serve` completes shortly after a 1 second boundary, but before the block is finished and that the block triggers a `requeue` event.

Background
==

Transaction signatures are verified asynchronously. After any verify service is changed, signature verification has to run again to ensure that it is correct for the current services. This causes all pending transactions to be removed from the queue and re-added.

Cause
==

The usage of `PSIBASE_SUBJECTIVE_TX` in `requeue` is incorrect. If another thread modifies any of the rows that the subjective tx accesses, it will be retried. When this happens, the `nextSequence` variable has already been updated to point to the next row, which effectively causes `requeue` to skip the current row.

Solution
==

Add a temporary variable to avoid updating `nextSequence` until after the subjective tx succeeds.
