### PR TITLE
Remove unused clientdata WIT imports from AuthSig and Workshop plugins

### DIFF
--- a/packages/system/AuthSig/plugin/Cargo.toml
+++ b/packages/system/AuthSig/plugin/Cargo.toml
@@ -30,5 +30,4 @@ world = "impl"
 "host:crypto" = { path = "../../../user/Host/plugin/crypto/wit/world.wit" }
 "accounts:plugin" = { path = "../../Accounts/plugin/accounts/wit/world.wit" }
 "transact:plugin" = { path = "../../Transact/plugin/wit/world.wit" }
-"clientdata:plugin" = { path = "../../../user/ClientData/plugin/wit/world.wit" }
 "permissions:plugin" = { path = "../../../user/Permissions/plugin/wit/world.wit" }

--- a/packages/system/AuthSig/plugin/wit/impl.wit
+++ b/packages/system/AuthSig/plugin/wit/impl.wit
@@ -5,7 +5,6 @@ world impl {
     include transact:plugin/imports;
     include host:common/imports;
     include host:crypto/imports;
-    include clientdata:plugin/imports;
     include permissions:plugin/imports;
 
     include transact:plugin/hook-user-auth;

--- a/packages/user/Workshop/plugin/Cargo.toml
+++ b/packages/user/Workshop/plugin/Cargo.toml
@@ -29,7 +29,6 @@ world = "impl"
 "transact:plugin" = { path = "../../../system/Transact/plugin/wit/world.wit" }
 "setcode:plugin" = { path = "../../../system/SetCode/plugin/wit/world.wit" }
 "chainmail:plugin" = { path = "../../Chainmail/plugin/wit/world.wit" }
-"clientdata:plugin" = { path = "../../ClientData/plugin/wit/world.wit" }
 "registry:plugin" = { path = "../../Registry/plugin/wit/world.wit" }
 "accounts:plugin" = { path = "../../../system/Accounts/plugin/accounts/wit/world.wit" }
 "auth-delegate:plugin" = { path = "../../../system/AuthDelegate/plugin/wit/world.wit" }

--- a/packages/user/Workshop/plugin/wit/impl.wit
+++ b/packages/user/Workshop/plugin/wit/impl.wit
@@ -6,7 +6,6 @@ world impl {
     include staged-tx:plugin/imports;
     include setcode:plugin/imports;
     include chainmail:plugin/imports;
-    include clientdata:plugin/imports;
     include registry:plugin/imports;
     include auth-delegate:plugin/imports;
     include accounts:plugin/imports;


### PR DESCRIPTION
Drop clientdata:plugin from impl world includes and component target dependencies; bindings are regenerated by cargo component build.