### PR TITLE
improve blockstart query efficiency

### DIFF
--- a/libraries/psibase/common/include/psibase/serveGraphQL.hpp
+++ b/libraries/psibase/common/include/psibase/serveGraphQL.hpp
@@ -1025,8 +1025,7 @@ namespace psibase
              "   WHERE ROWID <= r.rowId"
              "   ORDER BY ROWID DESC"
              "   LIMIT 1"
-             " )"
-             " ORDER BY r.rowIndex ASC",
+             " )",
              values);
          auto json = sql_query(sql, {}, debug);
          return psio::convert_from_json<std::vector<RowBlockStart>>(json);

--- a/rust/psibase/src/graph_ql.rs
+++ b/rust/psibase/src/graph_ql.rs
@@ -498,8 +498,7 @@ fn fetch_block_start_rows(
             WHERE ROWID <= r.rowId \
             ORDER BY ROWID DESC \
             LIMIT 1 \
-        ) \
-        ORDER BY r.rowIndex ASC",
+        )",
         values
     );
 


### PR DESCRIPTION
This removes an unnecessary ORDER BY, which was causing the construction of a temporary B tree, which consumes a lot of memory

```
USE TEMP B-TREE FOR ORDER BY
```

This order-by wasn't needed, both C++ and rust inserted results into a hashmap. This dramatically decreases memory requirements of the query