### PR TITLE
Improvement to Quantity

### DIFF
--- a/packages/shared-ui/components/form/field-token-amount.tsx
+++ b/packages/shared-ui/components/form/field-token-amount.tsx
@@ -168,6 +168,6 @@ const zTokenAmount = ({
             // Skip when the input doesn't parse cleanly; the precision
             // refinement above already produced a more specific error.
             if (input === null) return true;
-            return !balance.isLessThan(input); // input <= balance
+            return !balance.lt(input); // input <= balance
         }, `Insufficient balance`);
 };

--- a/packages/shared-ui/components/form/field-token-amount.tsx
+++ b/packages/shared-ui/components/form/field-token-amount.tsx
@@ -1,6 +1,8 @@
 import { useRef } from "react";
 import { z } from "zod";
 
+import { Quantity } from "../../lib/quantity";
+
 import { withFieldGroup } from "./app-form";
 
 /**
@@ -40,7 +42,8 @@ import { withFieldGroup } from "./app-form";
  * ```
  *
  * @param precision - The precision of the token; null skips validation
- * @param balance - The balance of the token; null skips validation
+ * @param balance - The user's balance as a `Quantity`; null skips the
+ *                  insufficient-balance check
  * @param disabled - Whether the field is disabled
  * @param description - Optional description text (specify null to ignore)
  * @param onMaxAmountClick - Optional function to call when the max amount button is clicked; set to `null` to omit Max button
@@ -52,7 +55,7 @@ export const FieldTokenAmount = withFieldGroup({
     },
     props: {
         precision: null as number | null,
-        balance: null as number | null,
+        balance: null as Quantity | null,
         disabled: false,
         description: null as string | null,
         onMaxAmountClick: null as
@@ -91,7 +94,9 @@ export const FieldTokenAmount = withFieldGroup({
                         type="button"
                         onClick={handleSetMaxAmount}
                         disabled={
-                            disabled || balance === 0 || precision === undefined
+                            disabled ||
+                            balance?.raw === 0n ||
+                            precision === undefined
                         }
                     >
                         Max
@@ -131,7 +136,7 @@ const zTokenAmount = ({
     balance,
 }: {
     precision: number | null;
-    balance: number | null;
+    balance: Quantity | null;
 }) => {
     return z
         .string()
@@ -156,7 +161,14 @@ const zTokenAmount = ({
         }, `Amount cannot have more than ${precision} decimal places`)
         .refine((val) => {
             if (balance === null) return true; // not checking balance if balance is not set
-            const num = Number(val);
-            return num <= balance; // Check if amount is less than balance
+            const input = Quantity.tryFromDecimal(
+                val,
+                balance.precision,
+                balance.tokenId,
+            );
+            // Skip when the input doesn't parse cleanly; the precision
+            // refinement above already produced a more specific error.
+            if (input === null) return true;
+            return !balance.isLessThan(input); // input <= balance
         }, `Insufficient balance`);
 };

--- a/packages/shared-ui/components/form/field-token-amount.tsx
+++ b/packages/shared-ui/components/form/field-token-amount.tsx
@@ -2,7 +2,6 @@ import { useRef } from "react";
 import { z } from "zod";
 
 import { Quantity } from "../../lib/quantity";
-
 import { withFieldGroup } from "./app-form";
 
 /**

--- a/packages/shared-ui/lib/quantity.ts
+++ b/packages/shared-ui/lib/quantity.ts
@@ -198,7 +198,7 @@ export class Quantity {
      * True iff `raw`, `precision`, and `tokenId` all match. `symbol` is ignored
      * (it's display metadata, not identity).
      */
-    public equals(other: Quantity): boolean {
+    public eq(other: Quantity): boolean {
         return (
             this.raw === other.raw &&
             this.precision === other.precision &&
@@ -206,12 +206,12 @@ export class Quantity {
         );
     }
 
-    public isGreaterThan(other: Quantity): boolean {
+    public gt(other: Quantity): boolean {
         this.assertSameToken(other, "compare");
         return this.raw > other.raw;
     }
 
-    public isLessThan(other: Quantity): boolean {
+    public lt(other: Quantity): boolean {
         this.assertSameToken(other, "compare");
         return this.raw < other.raw;
     }

--- a/packages/shared-ui/lib/quantity.ts
+++ b/packages/shared-ui/lib/quantity.ts
@@ -1,20 +1,113 @@
-import { z } from "zod";
+// ── Quantity helpers ────────────────────────────────────────────────────────
+//
+// `Quantity` is the FE counterpart to the on-chain Rust `Quantity` in
+// `rust/psibase/src/services/tokens/quantity.rs`. It stores the raw integer
+// (smallest-unit count) as a `bigint` plus the token's display metadata
+// (`precision`, `tokenId`, `symbol`).
+//
+// The free functions `decimalToRaw` / `rawToDecimal` are sync local mirrors
+// of the WIT plugin helpers `tokens:plugin/helpers/decimal-to-u64` /
+// `u64-to-decimal` (see `packages/user/Tokens/plugin/wit/world.wit`).
+// We mirror rather than call them because:
+//   - render is sync; the WIT helpers are async (supervisor / wasm boundary).
+//   - WIT helpers take `token-id` and re-resolve precision on chain; we
+//     usually already have `precision` in hand.
+//   - same algorithm, single source of truth: outputs MUST match the WIT helpers.
+//
+// ── Canonical decimal string format ────────────────────────────────────────
+// Mirrors the on-chain `Decimal` representation:
+//   - integer part has no leading zeros (literal "0" when zero);
+//   - if `precision > 0`, exactly `precision` fractional digits after a "."
+//     (always present);
+//   - if `precision == 0`, no "." is present.
+// e.g. precision 4: "0.0000", "0.0001", "1.2345", "12345.0000".
+// NOT "007.5000", ".1000", "1.5", or "1.50000".
+//
+// Related on-chain analogs (kept in mind for cross-checking behavior):
+//   - Rust `Quantity::from_str` in `rust/psibase/src/services/tokens/quantity.rs`:
+//     strict parse; returns `TokensError::PrecisionOverflow` where
+//     `parseDecimal` returns `null`.
+//   - Rust `to_fixed` in `packages/user/Tokens/service/src/helpers.rs`:
+//     truncating normalizer used for query-range bounds; NOT chain-safe
+//     (silently drops digits past `precision`). Intentionally not provided here.
+//   - Display formatter `formatThousands` in
+//     `packages/shared-ui/lib/format-number.ts`: human display only; still
+//     operates on `number` (used by `AnimateNumber`).
 
-import { formatThousands } from "./format-number";
+const DIGITS_ONLY = /^\d+$/;
+
+/** One whole token unit as a canonical decimal string, e.g. precision 4 → `"1.0000"`. */
+export function oneAsDecimal(precision: number): string {
+    return precision <= 0 ? "1" : `1.${"0".repeat(precision)}`;
+}
 
 /**
- * LIMITS (address in a follow-up PR; keep ctor/method signatures stable):
- * - `amount` is `number`: not every u64 smallest-unit value fits in `Number` (`MAX_SAFE_INTEGER`); parsing via `Number(string)` can round.
- * - Comparisons and add/subtract use float paths → rounding; scaled *integer* math avoids float error but u64 magnitudes still cause limit issues unless using `bigint`.
- * - Target: store exact value as `bigint` (or fixed-scale decimal string), derive `number` only for safe display, add `toCanonicalDecimal` / plugin helpers.
+ * Pad/validate a (lenient) user-typed decimal to canonical form.
+ *
+ * Matches Rust `Quantity::from_str` validity: rejects when the fractional
+ * part exceeds `precision` (returns `null` rather than truncating).
+ *
+ * Accepts: "9", "9.", "9.125", ".125" (= "0.125"), "007.5" (leading zeros
+ * stripped on output).
+ * Rejects: "", ".", multiple dots, non-digit characters, fraction longer
+ * than `precision`.
  */
-const Decimal = z.number().or(z.string());
+export function parseDecimal(
+    amount: string,
+    precision: number,
+): string | null {
+    const t = amount.trim();
+    if (t.length === 0) return null;
 
-type QuantityInput = string | number;
+    const parts = t.split(".");
+    if (parts.length > 2) return null;
+    const rawInt = parts[0];
+    const rawFrac = parts[1] ?? "";
+
+    if (rawInt === "" && rawFrac === "") return null;
+    if (rawInt !== "" && !DIGITS_ONLY.test(rawInt)) return null;
+    if (rawFrac !== "" && !DIGITS_ONLY.test(rawFrac)) return null;
+
+    const intPart = rawInt === "" ? "0" : rawInt.replace(/^0+/, "") || "0";
+
+    if (precision <= 0) {
+        return rawFrac === "" ? intPart : null;
+    }
+    if (rawFrac.length > precision) return null;
+    return `${intPart}.${rawFrac.padEnd(precision, "0")}`;
+}
 
 /**
- * Format configuration options for Quantity formatting
+ * Decimal string → smallest-unit count as `bigint`. Lenient input (anything
+ * `parseDecimal` accepts). Sync mirror of WIT `tokens:plugin/helpers/decimal-to-u64`.
  */
+export function decimalToRaw(
+    amount: string,
+    precision: number,
+): bigint | null {
+    const canonical = parseDecimal(amount, precision);
+    if (canonical === null) return null;
+    if (precision <= 0) return BigInt(canonical);
+    const [whole, frac] = canonical.split(".");
+    const scale = 10n ** BigInt(precision);
+    return BigInt(whole) * scale + BigInt(frac);
+}
+
+/**
+ * Smallest-unit `bigint` → canonical decimal string.
+ * Sync mirror of WIT `tokens:plugin/helpers/u64-to-decimal`.
+ */
+export function rawToDecimal(raw: bigint, precision: number): string {
+    const negative = raw < 0n;
+    const abs = negative ? -raw : raw;
+    if (precision <= 0) return `${negative ? "-" : ""}${abs.toString()}`;
+    const scale = 10n ** BigInt(precision);
+    const whole = (abs / scale).toString();
+    const frac = (abs % scale).toString().padStart(precision, "0");
+    return `${negative ? "-" : ""}${whole}.${frac}`;
+}
+
+/** Format options for `Quantity.format`. */
 interface FormatConfig {
     includeLabel?: boolean;
     fullPrecision?: boolean;
@@ -22,134 +115,125 @@ interface FormatConfig {
 }
 
 export class Quantity {
-    /**
-     * The amount as a number
-     */
-    public readonly amount: number;
+    /** The Quantity as an integer (i.e. quantity = raw * 10^-precision). Mirrors Rust `Quantity.value`. */
+    public readonly raw: bigint;
 
-    /**
-     * The precision (number of decimal places)
-     */
+    /** Number of decimal places for the token. */
     public readonly precision: number;
 
-    /**
-     * The token number identifier
-     */
-    public readonly tokenNumber: number;
+    /** Token identifier. Aligns with WIT `token-id` / Rust `token_id`. */
+    public readonly tokenId: number;
+
+    /** Token symbol (optional; e.g. "SYS"). */
+    public readonly symbol?: string | null;
 
     /**
-     * The token symbol (optional)
-     */
-    public readonly tokenSymbol?: string | null;
-
-    /**
-     * Creates a new Quantity instance
-     * @param amount - The amount as a string (e.g., "9000.0000") or number (e.g., 9000)
-     * @param precision - Number of decimal places for the token
-     * @param tokenNumber - Token identifier number
-     * @param tokenSymbol - Optional token symbol
-     * @throws {Error} If inputs are invalid
+     * @param raw       Smallest-unit integer count (see field doc).
+     * @param precision Non-negative integer.
+     * @param tokenId   Non-negative integer token id.
+     * @param symbol    Optional token symbol.
      */
     constructor(
-        amount: QuantityInput,
+        raw: bigint,
         precision: number,
-        tokenNumber: number,
-        tokenSymbol?: string | null,
+        tokenId: number,
+        symbol?: string | null,
     ) {
+        if (typeof raw !== "bigint") {
+            throw new Error(`raw must be a bigint, got ${typeof raw}`);
+        }
         if (precision < 0 || !Number.isInteger(precision)) {
             throw new Error("Precision must be a non-negative integer");
         }
-        if (tokenNumber < 0 || !Number.isInteger(tokenNumber)) {
-            throw new Error("Token number must be a non-negative integer");
+        if (tokenId < 0 || !Number.isInteger(tokenId)) {
+            throw new Error("Token ID must be a non-negative integer");
         }
 
-        // Handle amount input
-        let amountNum: number;
-
-        if (typeof amount === "string") {
-            // LOSSY for large integers — see file header.
-            const parsed = Number(amount);
-            if (!Number.isFinite(parsed)) {
-                throw new Error(`Invalid amount string: "${amount}"`);
-            }
-            amountNum = parsed;
-        } else if (typeof amount === "number") {
-            // Validate number amount
-            if (!Number.isFinite(amount)) {
-                throw new Error(`Invalid amount number: ${amount}`);
-            }
-            amountNum = amount;
-        } else {
-            throw new Error(
-                `Amount must be a string or number, got ${typeof amount}`,
-            );
-        }
-
-        this.amount = amountNum;
+        this.raw = raw;
         this.precision = precision;
-        this.tokenNumber = tokenNumber;
-        this.tokenSymbol = tokenSymbol;
+        this.tokenId = tokenId;
+        this.symbol = symbol;
     }
 
     /**
-     * Check if this quantity equals another
+     * Build a `Quantity` from a (lenient) decimal string. Throws on invalid
+     * input; use `tryFromDecimal` for a nullable variant.
+     */
+    public static fromDecimal(
+        decimal: string,
+        precision: number,
+        tokenId: number,
+        symbol?: string | null,
+    ): Quantity {
+        const raw = decimalToRaw(decimal, precision);
+        if (raw === null) {
+            throw new Error(
+                `Invalid decimal "${decimal}" for precision ${precision}`,
+            );
+        }
+        return new Quantity(raw, precision, tokenId, symbol);
+    }
+
+    /**
+     * Like `fromDecimal`, but returns `null` for inputs that don't parse
+     * cleanly (rather than throwing). Useful in form validators / mid-edit
+     * input fields.
+     */
+    public static tryFromDecimal(
+        decimal: string,
+        precision: number,
+        tokenId: number,
+        symbol?: string | null,
+    ): Quantity | null {
+        const raw = decimalToRaw(decimal, precision);
+        if (raw === null) return null;
+        return new Quantity(raw, precision, tokenId, symbol);
+    }
+
+    /** Canonical decimal string (no symbol, no thousands separator). */
+    public toDecimal(): string {
+        return rawToDecimal(this.raw, this.precision);
+    }
+
+    public hasTokenSymbol(): boolean {
+        return !!this.symbol;
+    }
+
+    /** Display label: uppercase `symbol` if present, otherwise `ID:<tokenId>`. */
+    public getDisplayLabel(): string {
+        return this.symbol?.toUpperCase() || `ID:${this.tokenId}`;
+    }
+
+    /**
+     * True iff `raw`, `precision`, and `tokenId` all match. `symbol` is ignored
+     * (it's display metadata, not identity).
      */
     public equals(other: Quantity): boolean {
         return (
-            this.amount === other.amount &&
+            this.raw === other.raw &&
             this.precision === other.precision &&
-            this.tokenNumber === other.tokenNumber
+            this.tokenId === other.tokenId
         );
     }
 
-    /**
-     * Check if this quantity is greater than another
-     */
     public isGreaterThan(other: Quantity): boolean {
-        if (this.precision !== other.precision) {
-            throw new Error(
-                "Cannot compare quantities with different precisions",
-            );
-        }
-        return this.amount > other.amount;
+        this.assertSameToken(other, "compare");
+        return this.raw > other.raw;
     }
 
-    /**
-     * Check if this quantity is less than another
-     */
     public isLessThan(other: Quantity): boolean {
-        if (this.precision !== other.precision) {
-            throw new Error(
-                "Cannot compare quantities with different precisions",
-            );
-        }
-        return this.amount < other.amount;
+        this.assertSameToken(other, "compare");
+        return this.raw < other.raw;
     }
 
     /**
-     * Check if this quantity has a token symbol
-     */
-    public hasTokenSymbol(): boolean {
-        return !!this.tokenSymbol;
-    }
-
-    /**
-     * Get the display label for the token
-     */
-    public getDisplayLabel(): string {
-        return this.tokenSymbol?.toUpperCase() || `ID:${this.tokenNumber}`;
-    }
-
-    /**
-     * Format the quantity for display
-     * TODO: i18n
-     */
-    /**
-     * Format the quantity for display
-     * @param config Configuration options for formatting
-     * @param config.includeLabel Whether to include the token label in the output (default: true)
-     * @param config.fullPrecision Whether to show all decimal places (default: false)
-     * @param config.showThousandsSeparator Whether to separate thousands with commas (default: true)
+     * Format for human display.
+     * @param config.includeLabel            include the token label (default `true`)
+     * @param config.fullPrecision           keep all `precision` fractional digits (default `false`)
+     * @param config.showThousandsSeparator  insert commas in the integer part (default `true`)
+     *
+     * Output is intended for display only; for machine-readable canonical form
+     * (e.g. plugin call args) use `toDecimal()`.
      */
     public format(config: FormatConfig = {}): string {
         const {
@@ -158,208 +242,57 @@ export class Quantity {
             showThousandsSeparator = true,
         } = config;
 
-        try {
-            let formattedAmount: string;
+        const negative = this.raw < 0n;
+        const abs = negative ? -this.raw : this.raw;
+        const scale = 10n ** BigInt(this.precision);
+        const whole = abs / scale;
+        const frac = abs % scale;
 
-            if (showThousandsSeparator) {
-                formattedAmount = formatThousands(
-                    this.amount,
-                    this.precision,
-                    fullPrecision,
-                );
-            } else {
-                // Simple number formatting without thousands separator
-                formattedAmount = fullPrecision
-                    ? this.amount.toFixed(this.precision)
-                    : this.amount.toString();
-            }
+        const wholeStr = showThousandsSeparator
+            ? new Intl.NumberFormat("en-US").format(whole)
+            : whole.toString();
 
-            return `${formattedAmount}${includeLabel ? ` ${this.getDisplayLabel()}` : ""}`;
-        } catch {
-            return "Invalid amount";
+        let amountStr: string;
+        if (this.precision === 0) {
+            amountStr = wholeStr;
+        } else {
+            let fracStr = frac.toString().padStart(this.precision, "0");
+            if (!fullPrecision) fracStr = fracStr.replace(/0+$/, "");
+            amountStr =
+                fracStr.length > 0 ? `${wholeStr}.${fracStr}` : wholeStr;
+        }
+        if (negative) amountStr = `-${amountStr}`;
+
+        return includeLabel
+            ? `${amountStr} ${this.getDisplayLabel()}`
+            : amountStr;
+    }
+
+    /** Add `raw` smallest units (caller is responsible for matching precision). */
+    public add(raw: bigint): Quantity {
+        return this.withRaw(this.raw + raw);
+    }
+
+    /** Subtract `raw` smallest units; throws if the result would be negative. */
+    public subtract(raw: bigint): Quantity {
+        const result = this.raw - raw;
+        if (result < 0n) throw new Error("Result cannot be negative");
+        return this.withRaw(result);
+    }
+
+    /** Clone with the same token metadata and a different `raw`. */
+    public withRaw(raw: bigint): Quantity {
+        return new Quantity(raw, this.precision, this.tokenId, this.symbol);
+    }
+
+    private assertSameToken(other: Quantity, op: string): void {
+        if (
+            this.precision !== other.precision ||
+            this.tokenId !== other.tokenId
+        ) {
+            throw new Error(
+                `Cannot ${op} quantities of different tokens (precision/tokenId mismatch)`,
+            );
         }
     }
-
-    /**
-     * Subtract an amount from this quantity
-     */
-    public subtract(decimalAmount: QuantityInput): Quantity {
-        Decimal.parse(decimalAmount);
-        const amountToSubtract =
-            typeof decimalAmount === "string"
-                ? Number(decimalAmount)
-                : decimalAmount;
-
-        const newAmount = this.amount - amountToSubtract;
-        if (newAmount < 0) {
-            throw new Error("Result cannot be negative");
-        }
-
-        return new Quantity(
-            newAmount,
-            this.precision,
-            this.tokenNumber,
-            this.tokenSymbol,
-        );
-    }
-
-    /**
-     * Add an amount to this quantity
-     */
-    public add(amount: QuantityInput): Quantity {
-        Decimal.parse(amount);
-        const amountToAdd =
-            typeof amount === "string" ? Number(amount) : amount;
-
-        const newAmount = this.amount + amountToAdd;
-        if (!Number.isFinite(newAmount)) {
-            throw new Error("Addition would overflow");
-        }
-
-        return new Quantity(
-            newAmount,
-            this.precision,
-            this.tokenNumber,
-            this.tokenSymbol,
-        );
-    }
-
-    /**
-     * Create a new Quantity with a different amount but same token properties
-     */
-    public withAmount(newAmount: QuantityInput): Quantity {
-        return new Quantity(
-            newAmount,
-            this.precision,
-            this.tokenNumber,
-            this.tokenSymbol,
-        );
-    }
-}
-
-// --- Canonical decimal strings (fixed fraction digits) for Tokens / plugin Quantity rules ---
-//
-// Canonical form mirrors the Rust on-chain `Decimal` representation:
-//   - integer part is always present and has no leading zeros (literal "0" when zero);
-//   - if `precision > 0`, a "." is always present followed by exactly `precision` digits;
-//   - if `precision == 0`, no "." is present.
-// e.g. precision 4: "0.0000", "0.0001", "1.2345", "12345.0000". NOT "007.5000", ".1000",
-// "1.5", or "1.50000".
-//
-// Related helpers elsewhere in the codebase (kept in mind for a future refactor that
-// consolidates these into a shared decimal module):
-//   - Strict parse (reject excess fractional digits): Rust `Quantity::from_str`
-//     in `rust/psibase/src/services/tokens/quantity.rs` — the on-chain analog of
-//     `expandToCanonicalTokenDecimal` below; returns `TokensError::PrecisionOverflow`
-//     where this function returns `null`.
-//   - Truncating normalizer: Rust `to_fixed` in
-//     `packages/user/Tokens/service/src/helpers.rs` (used for query-range bounds in
-//     `Tokens/query-service`); silently drops digits past `precision`. NOT suitable
-//     for values destined for the chain.
-//   - Rounding display formatter: TS `formatThousands` in
-//     `packages/shared-ui/lib/format-number.ts` (wraps `Intl.NumberFormat` with
-//     `maximumFractionDigits`); used by `Quantity.format(...)` for human display only.
-
-const DIGITS_ONLY = /^\d+$/;
-const CANONICAL_DECIMAL_SHAPE = /^(0|[1-9]\d*)\.(\d+)$/;
-const CANONICAL_INTEGER = /^(0|[1-9]\d*)$/;
-
-/** One whole token unit as canonical decimal, e.g. precision 4 → `"1.0000"`. */
-export function unitTokenAmountCanonical(precision: number): string {
-    if (precision <= 0) {
-        return "1";
-    }
-    return `1.${"0".repeat(precision)}`;
-}
-
-/**
- * Pad/validate user input to canonical form.
- * Equvalent of the Rust `Quantity::from_str` — both return null / `PrecisionOverflow`
- * when the user provides more fractional digits than `precision` allows.
- * TODO: Truncation or rounding should be separate fns (mirroring Rust).
- *
- * Accepts (input lenience): "9", "9.", "9.125", ".125" (treated as "0.125"),
- * "007.5" (leading zeros stripped on output).
- * Rejects: "", ".", multiple dots, non-digit characters, and fraction longer than
- * `precision`.
- *
- * Output is always canonical (see header above)
- */
-export function expandToCanonicalTokenDecimal(
-    amount: string,
-    precision: number,
-): string | null {
-    const t = amount.trim();
-    if (t.length === 0) {
-        return null;
-    }
-
-    const parts = t.split(".");
-    if (parts.length > 2) {
-        return null;
-    }
-    const rawInt = parts[0];
-    const rawFrac = parts[1] ?? "";
-
-    // Reject "." (dot present with no digits on either side).
-    if (rawInt === "" && rawFrac === "") {
-        return null;
-    }
-    // Each present side must be all digits.
-    if (rawInt !== "" && !DIGITS_ONLY.test(rawInt)) {
-        return null;
-    }
-    if (rawFrac !== "" && !DIGITS_ONLY.test(rawFrac)) {
-        return null;
-    }
-
-    // Normalize integer part to canonical form (no leading zeros; "0" when empty/zero).
-    const intPart = rawInt === "" ? "0" : rawInt.replace(/^0+/, "") || "0";
-
-    if (precision <= 0) {
-        return rawFrac === "" ? intPart : null;
-    }
-    if (rawFrac.length > precision) {
-        return null;
-    }
-    return `${intPart}.${rawFrac.padEnd(precision, "0")}`;
-}
-
-export function isCanonicalTokenDecimal(
-    amount: string,
-    precision: number,
-): boolean {
-    const t = amount.trim();
-    if (t.length === 0) {
-        return false;
-    }
-    if (precision <= 0) {
-        return CANONICAL_INTEGER.test(t);
-    }
-    const m = CANONICAL_DECIMAL_SHAPE.exec(t);
-    return m !== null && m[2].length === precision;
-}
-
-export function formatCanonicalTokenAmount(
-    canonicalDecimal: string,
-    symbol?: string,
-): string {
-    return symbol ? `${canonicalDecimal} ${symbol}` : canonicalDecimal;
-}
-
-/** Smallest-unit count as `bigint` from a canonical decimal; `null` if not canonical. */
-export function canonicalTokenAmountToRaw(
-    canonical: string,
-    precision: number,
-): bigint | null {
-    const t = canonical.trim();
-    if (!isCanonicalTokenDecimal(t, precision)) {
-        return null;
-    }
-    if (precision <= 0) {
-        return BigInt(t);
-    }
-    const [whole, frac] = t.split(".");
-    const scale = BigInt(10) ** BigInt(precision);
-    return BigInt(whole) * scale + BigInt(frac);
 }

--- a/packages/shared-ui/lib/quantity.ts
+++ b/packages/shared-ui/lib/quantity.ts
@@ -1,11 +1,12 @@
 // ── Quantity helpers ────────────────────────────────────────────────────────
 //
-// Terms:
-// - Quantity: chain abstraction for storing/operating on token amounts.
-// - Decimal: canonical string representation of a token amount.
+// On-chain Terms:
+// - Decimal: struct that holds a Quantity (and precision) and
+// can produce a canonical string representation of a token amount.
+// - Quantity: chain abstraction for the integer representation of a token amount.
 //
-// `Quantity` is the FE counterpart to the on-chain Rust `Quantity` in
-// `rust/psibase/src/services/tokens/quantity.rs`. It stores the raw integer
+// `Quantity` is the FE counterpart to the on-chain Rust `Decimal` (and some of the Quantity struct) in
+// `rust/psibase/src/services/tokens/decimal.rs`. It stores the raw integer
 // (smallest-unit count) as a `bigint` plus the token's display metadata
 // (`precision`, `tokenId`, `symbol`).
 // API is modeled as closely as possible on the Rust API.

--- a/packages/shared-ui/lib/quantity.ts
+++ b/packages/shared-ui/lib/quantity.ts
@@ -1,61 +1,53 @@
 // ── Quantity helpers ────────────────────────────────────────────────────────
 //
+// Terms:
+// - Quantity: chain abstraction for storing/operating on token amounts.
+// - Decimal: canonical string representation of a token amount.
+//
 // `Quantity` is the FE counterpart to the on-chain Rust `Quantity` in
 // `rust/psibase/src/services/tokens/quantity.rs`. It stores the raw integer
 // (smallest-unit count) as a `bigint` plus the token's display metadata
 // (`precision`, `tokenId`, `symbol`).
+// API is modeled as closely as possible on the Rust API.
 //
-// The free functions `decimalToRaw` / `rawToDecimal` are sync local mirrors
-// of the WIT plugin helpers `tokens:plugin/helpers/decimal-to-u64` /
-// `u64-to-decimal` (see `packages/user/Tokens/plugin/wit/world.wit`).
-// We mirror rather than call them because:
-//   - render is sync; the WIT helpers are async (supervisor / wasm boundary).
+// `decimalToRaw` and `rawToDecimal` are independent client-side reimplementation
+// of the canonical chain logic. The source of truth lives in Rust:
+//   - `rust/psibase/src/services/tokens/quantity.rs` (`Quantity::from_str`)
+//   - `rust/psibase/src/services/tokens/decimal.rs`  (`Decimal::to_string`)
+// `tokens:plugin/helpers/decimal-to-u64` / `u64-to-decimal` are
+// async server-side wrappers that delegate to those Rust types after
+// resolving precision on chain.
+//
+// Motivation to reimplement in the frontend:
+//   - React render() is sync; the WIT helpers are async (supervisor / wasm boundary).
 //   - WIT helpers take `token-id` and re-resolve precision on chain; we
 //     usually already have `precision` in hand.
-//   - same algorithm, single source of truth: outputs MUST match the WIT helpers.
 //
-// ── Canonical decimal string format ────────────────────────────────────────
+// ── Canonical token decimal string format ──────────────────────────────────
 // Mirrors the on-chain `Decimal` representation:
-//   - integer part has no leading zeros (literal "0" when zero);
-//   - if `precision > 0`, exactly `precision` fractional digits after a "."
-//     (always present);
-//   - if `precision == 0`, no "." is present.
+//   - integer part has no leading zeros;
+//   - exactly `precision` digits after a "." (always present);
+//   - unless `precision == 0`, then no "." is present.
 // e.g. precision 4: "0.0000", "0.0001", "1.2345", "12345.0000".
-// NOT "007.5000", ".1000", "1.5", or "1.50000".
-//
-// Related on-chain analogs (kept in mind for cross-checking behavior):
-//   - Rust `Quantity::from_str` in `rust/psibase/src/services/tokens/quantity.rs`:
-//     strict parse; returns `TokensError::PrecisionOverflow` where
-//     `parseDecimal` returns `null`.
-//   - Rust `to_fixed` in `packages/user/Tokens/service/src/helpers.rs`:
-//     truncating normalizer used for query-range bounds; NOT chain-safe
-//     (silently drops digits past `precision`). Intentionally not provided here.
-//   - Display formatter `formatThousands` in
-//     `packages/shared-ui/lib/format-number.ts`: human display only; still
-//     operates on `number` (used by `AnimateNumber`).
+// NOT "007.5000", ".1000", "9.", "1.5", or "1.50000".
 
 const DIGITS_ONLY = /^\d+$/;
 
-/** One whole token unit as a canonical decimal string, e.g. precision 4 → `"1.0000"`. */
-export function oneAsDecimal(precision: number): string {
-    return precision <= 0 ? "1" : `1.${"0".repeat(precision)}`;
-}
+/** Upper bound for a chain `Quantity` (its raw value is a `u64`). */
+const U64_MAX = (1n << 64n) - 1n;
 
 /**
  * Pad/validate a (lenient) user-typed decimal to canonical form.
  *
- * Matches Rust `Quantity::from_str` validity: rejects when the fractional
- * part exceeds `precision` (returns `null` rather than truncating).
+ * Matches Rust `Quantity::from_str` validity: rejects (returns null)
+ * when the fractional part exceeds `precision`
  *
  * Accepts: "9", "9.", "9.125", ".125" (= "0.125"), "007.5" (leading zeros
  * stripped on output).
  * Rejects: "", ".", multiple dots, non-digit characters, fraction longer
  * than `precision`.
  */
-export function parseDecimal(
-    amount: string,
-    precision: number,
-): string | null {
+export function parseDecimal(amount: string, precision: number): string | null {
     const t = amount.trim();
     if (t.length === 0) return null;
 
@@ -81,10 +73,7 @@ export function parseDecimal(
  * Decimal string → smallest-unit count as `bigint`. Lenient input (anything
  * `parseDecimal` accepts). Sync mirror of WIT `tokens:plugin/helpers/decimal-to-u64`.
  */
-export function decimalToRaw(
-    amount: string,
-    precision: number,
-): bigint | null {
+export function decimalToRaw(amount: string, precision: number): bigint | null {
     const canonical = parseDecimal(amount, precision);
     if (canonical === null) return null;
     if (precision <= 0) return BigInt(canonical);
@@ -268,21 +257,21 @@ export class Quantity {
             : amountStr;
     }
 
-    /** Add `raw` smallest units (caller is responsible for matching precision). */
+    /**
+     * Add `raw` smallest units (caller is responsible for matching precision).
+     * Throws on overflow past `u64::MAX` to mirror the chain's checked arithmetic.
+     */
     public add(raw: bigint): Quantity {
-        return this.withRaw(this.raw + raw);
+        const result = this.raw + raw;
+        if (result > U64_MAX) throw new Error("Quantity overflow");
+        return new Quantity(result, this.precision, this.tokenId, this.symbol);
     }
 
     /** Subtract `raw` smallest units; throws if the result would be negative. */
     public subtract(raw: bigint): Quantity {
         const result = this.raw - raw;
         if (result < 0n) throw new Error("Result cannot be negative");
-        return this.withRaw(result);
-    }
-
-    /** Clone with the same token metadata and a different `raw`. */
-    public withRaw(raw: bigint): Quantity {
-        return new Quantity(raw, this.precision, this.tokenId, this.symbol);
+        return new Quantity(result, this.precision, this.tokenId, this.symbol);
     }
 
     private assertSameToken(other: Quantity, op: string): void {

--- a/packages/user/Homepage/ui/src/apps/token-swap/components/amount-field.tsx
+++ b/packages/user/Homepage/ui/src/apps/token-swap/components/amount-field.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from "lucide-react";
 
 import { stringToNum } from "@/lib/string-to-num";
 
-import { Quantity, decimalToRaw } from "@shared/lib/quantity";
+import { Quantity } from "@shared/lib/quantity";
 import { cn } from "@shared/lib/utils";
 import { Button } from "@shared/shadcn/ui/button";
 import { Input } from "@shared/shadcn/ui/input";
@@ -33,8 +33,12 @@ export const AmountField = ({
 }) => {
     const isOverMaxBalance = (() => {
         if (!balance || stringToNum(amount) === undefined) return false;
-        const raw = decimalToRaw(amount, balance.precision);
-        return raw === null ? false : balance.isLessThan(balance.withRaw(raw));
+        const input = Quantity.tryFromDecimal(
+            amount,
+            balance.precision,
+            balance.tokenId,
+        );
+        return input !== null && balance.isLessThan(input);
     })();
 
     return (

--- a/packages/user/Homepage/ui/src/apps/token-swap/components/amount-field.tsx
+++ b/packages/user/Homepage/ui/src/apps/token-swap/components/amount-field.tsx
@@ -38,7 +38,7 @@ export const AmountField = ({
             balance.precision,
             balance.tokenId,
         );
-        return input !== null && balance.isLessThan(input);
+        return input !== null && balance.lt(input);
     })();
 
     return (

--- a/packages/user/Homepage/ui/src/apps/token-swap/components/amount-field.tsx
+++ b/packages/user/Homepage/ui/src/apps/token-swap/components/amount-field.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from "lucide-react";
 
 import { stringToNum } from "@/lib/string-to-num";
 
-import { Quantity } from "@shared/lib/quantity";
+import { Quantity, decimalToRaw } from "@shared/lib/quantity";
 import { cn } from "@shared/lib/utils";
 import { Button } from "@shared/shadcn/ui/button";
 import { Input } from "@shared/shadcn/ui/input";
@@ -31,10 +31,11 @@ export const AmountField = ({
     setAmount: (text: string) => void;
     onMaxBalance?: () => void;
 }) => {
-    const isOverMaxBalance =
-        balance && stringToNum(amount) !== undefined
-            ? balance.isLessThan(balance.withAmount(amount))
-            : false;
+    const isOverMaxBalance = (() => {
+        if (!balance || stringToNum(amount) === undefined) return false;
+        const raw = decimalToRaw(amount, balance.precision);
+        return raw === null ? false : balance.isLessThan(balance.withRaw(raw));
+    })();
 
     return (
         <div className="space-y-2">

--- a/packages/user/Homepage/ui/src/apps/token-swap/hooks/use-amount.ts
+++ b/packages/user/Homepage/ui/src/apps/token-swap/hooks/use-amount.ts
@@ -25,8 +25,12 @@ export const useAmount = () => {
     const { data: tokenConfig } = useToken(tokenId);
     const precision = tokenConfig?.precision || 4;
 
+    // `amount` is a free-typing string (e.g. "" or "1." mid-edit), so use
+    // the nullable factory rather than throwing during a render.
     const amountQuantity =
-        tokenId !== undefined && new Quantity(amount, precision || 4, tokenId);
+        tokenId !== undefined
+            ? Quantity.tryFromDecimal(amount, precision || 4, tokenId)
+            : null;
 
     const obj = tokenId
         ? {

--- a/packages/user/Homepage/ui/src/apps/token-swap/hooks/use-amount.ts
+++ b/packages/user/Homepage/ui/src/apps/token-swap/hooks/use-amount.ts
@@ -61,7 +61,7 @@ export const useAmount = () => {
         amountNumber,
         isOverBalance:
             amountQuantity && balance
-                ? amountQuantity.isGreaterThan(balance)
+                ? amountQuantity.gt(balance)
                 : false,
     };
 };

--- a/packages/user/Homepage/ui/src/apps/token-swap/liquidity.tsx
+++ b/packages/user/Homepage/ui/src/apps/token-swap/liquidity.tsx
@@ -22,7 +22,11 @@ import { useQuoteSingleSidedRemove } from "./hooks/use-quote-single-sided-remove
 const pureDecimalToQuantity = (tokenAmount: TokenAmount): Quantity => {
     const [_, precPart] = tokenAmount.amount.split(".");
     const precision = precPart?.length ?? 0;
-    return new Quantity(tokenAmount.amount, precision, tokenAmount.tokenId);
+    return Quantity.fromDecimal(
+        tokenAmount.amount,
+        precision,
+        tokenAmount.tokenId,
+    );
 };
 
 export const Liquidity = () => {
@@ -84,9 +88,7 @@ export const Liquidity = () => {
     const poolTokenBalance = userBalances?.find(
         (balance) => balance.id == focusedPool?.id,
     );
-    const poolTokenBalanceDec = poolTokenBalance?.balance?.format({
-        includeLabel: false,
-    });
+    const poolTokenBalanceDec = poolTokenBalance?.balance?.toDecimal();
 
     const { data: maxWithdrawableLiquidity } = useQuoteRemoveLiquidity(
         !!poolTokenBalance && !isAddingLiquidity,
@@ -155,7 +157,7 @@ export const Liquidity = () => {
     const { data: quotedRemove } = useQuoteSingleSidedRemove(
         validQuote && !isAddingLiquidity,
         focusedPool,
-        poolTokenBalance?.balance?.format({ includeLabel: false }),
+        poolTokenBalance?.balance?.toDecimal(),
         lastTouched,
     );
 

--- a/packages/user/Homepage/ui/src/apps/tokens/components/pending/button-accept.tsx
+++ b/packages/user/Homepage/ui/src/apps/tokens/components/pending/button-accept.tsx
@@ -50,9 +50,9 @@ export const AcceptButton = ({
     const handleClaim = async (pt: PendingBalance) => {
         try {
             await mutateAsync({
-                tokenId: pt.balance.tokenNumber.toString(),
+                tokenId: pt.balance.tokenId.toString(),
                 sender: pt.creditor,
-                amount: pt.balance.amount.toString(),
+                amount: pt.balance.toDecimal(),
                 memo: memo,
             });
             toast.success("Pending balance successfully claimed");

--- a/packages/user/Homepage/ui/src/apps/tokens/components/pending/button-cancel.tsx
+++ b/packages/user/Homepage/ui/src/apps/tokens/components/pending/button-cancel.tsx
@@ -50,9 +50,9 @@ export const CancelButton = ({
     const handleRecall = async (pt: PendingBalance) => {
         try {
             await mutateAsync({
-                tokenId: pt.balance.tokenNumber.toString(),
+                tokenId: pt.balance.tokenId.toString(),
                 debitor: pt.debitor,
-                amount: pt.balance.amount.toString(),
+                amount: pt.balance.toDecimal(),
                 memo: memo,
             });
             toast.success("Pending balance successfully recalled");

--- a/packages/user/Homepage/ui/src/apps/tokens/components/pending/button-reject.tsx
+++ b/packages/user/Homepage/ui/src/apps/tokens/components/pending/button-reject.tsx
@@ -50,7 +50,7 @@ export const RejectButton = ({
     const handleReject = async (pt: PendingBalance) => {
         try {
             await mutateAsync({
-                tokenId: pt.balance.tokenNumber.toString(),
+                tokenId: pt.balance.tokenId.toString(),
                 creditor: pt.creditor,
                 memo: memo,
             });

--- a/packages/user/Homepage/ui/src/apps/tokens/components/token-selector.tsx
+++ b/packages/user/Homepage/ui/src/apps/tokens/components/token-selector.tsx
@@ -101,7 +101,12 @@ const AvailableBalance = ({
             </span>
             <span className="text-foreground/90 font-mono text-xl font-medium">
                 <AnimateNumber
-                    n={selectedToken?.balance?.amount ?? 0}
+                    n={
+                        selectedToken?.balance
+                            ? Number(selectedToken.balance.raw) /
+                              10 ** selectedToken.balance.precision
+                            : 0
+                    }
                     precision={selectedToken?.balance?.precision ?? 0}
                     className="hover:cursor-pointer hover:underline"
                     onClick={onClick}

--- a/packages/user/Homepage/ui/src/apps/tokens/components/transfer-modal.tsx
+++ b/packages/user/Homepage/ui/src/apps/tokens/components/transfer-modal.tsx
@@ -97,7 +97,12 @@ export const TransferModal = withForm({
             if (!selectedToken) return null;
             const { precision, id, symbol } = selectedToken;
             try {
-                return new Quantity(amount.amount, precision, id, symbol);
+                return Quantity.fromDecimal(
+                    amount.amount,
+                    precision,
+                    id,
+                    symbol,
+                );
             } catch (error) {
                 console.log(error);
                 return null;

--- a/packages/user/Homepage/ui/src/apps/tokens/hooks/tokens-plugin/use-pending-balances.ts
+++ b/packages/user/Homepage/ui/src/apps/tokens/hooks/tokens-plugin/use-pending-balances.ts
@@ -31,7 +31,7 @@ export const useUserPendingBalance = (
                 tokenId,
             );
             const xformSharedBalNode = (sbn: SharedBalNode): PendingBalance => {
-                const quan = new Quantity(
+                const quan = Quantity.fromDecimal(
                     sbn.balance,
                     sbn.token.precision,
                     sbn.token.id,

--- a/packages/user/Homepage/ui/src/apps/tokens/hooks/tokens-plugin/use-user-token-balance-changes.ts
+++ b/packages/user/Homepage/ui/src/apps/tokens/hooks/tokens-plugin/use-user-token-balance-changes.ts
@@ -48,7 +48,7 @@ export const useUserTokenBalanceChanges = (
                         throw new Error("Token ID mismatch");
                     }
 
-                    const quantity = new Quantity(
+                    const quantity = Quantity.fromDecimal(
                         balance.amount,
                         token.precision,
                         balance.tokenId,

--- a/packages/user/Homepage/ui/src/apps/tokens/hooks/tokens-plugin/use-user-token-balances.ts
+++ b/packages/user/Homepage/ui/src/apps/tokens/hooks/tokens-plugin/use-user-token-balances.ts
@@ -10,7 +10,7 @@ import { useCurrentUser } from "@/hooks/use-current-user";
 import QueryKey from "@/lib/query-keys";
 import { updateArray } from "@/lib/update-array";
 
-import { Quantity } from "@shared/lib/quantity";
+import { Quantity, decimalToRaw } from "@shared/lib/quantity";
 import { queryClient } from "@shared/lib/query-client";
 import { type Account, zAccount } from "@shared/lib/schemas/account";
 
@@ -42,7 +42,7 @@ export const useUserTokenBalances = (
             // END TODO
 
             const userTokenBalances: Token[] = res.map((balance): Token => {
-                const quan = new Quantity(
+                const quan = Quantity.fromDecimal(
                     balance.balance,
                     balance.precision,
                     balance.tokenId,
@@ -88,13 +88,20 @@ export const updateUserTokenBalancesCache = (
                     balances,
                     (token) =>
                         token.id.toString() === tokenId && !!token.balance,
-                    (token) => ({
-                        ...token,
-                        balance:
-                            operation == "Add"
-                                ? token.balance!.add(amount)
-                                : token.balance!.subtract(amount),
-                    }),
+                    (token) => {
+                        const raw = decimalToRaw(
+                            amount,
+                            token.balance!.precision,
+                        );
+                        if (raw === null) return token;
+                        return {
+                            ...token,
+                            balance:
+                                operation == "Add"
+                                    ? token.balance!.add(raw)
+                                    : token.balance!.subtract(raw),
+                        };
+                    },
                 );
             }
         },

--- a/packages/user/Homepage/ui/src/apps/tokens/pending.tsx
+++ b/packages/user/Homepage/ui/src/apps/tokens/pending.tsx
@@ -49,8 +49,7 @@ export const PendingPageContents = () => {
     );
 
     const pendingBalances: PendingBalance[] =
-        data?.filter((pt) => pt.balance.tokenNumber === selectedToken?.id) ??
-        [];
+        data?.filter((pt) => pt.balance.tokenId === selectedToken?.id) ?? [];
 
     if (isLoading || isPending) {
         return (

--- a/packages/user/Homepage/ui/src/apps/tokens/transfer.tsx
+++ b/packages/user/Homepage/ui/src/apps/tokens/transfer.tsx
@@ -128,7 +128,7 @@ const TransferPageContents = () => {
         (e: React.MouseEvent<HTMLButtonElement>) => {
             e.preventDefault();
             form.setFieldValue("amount", {
-                amount: selectedToken?.balance?.amount.toString() ?? "",
+                amount: selectedToken?.balance?.toDecimal() ?? "",
             });
             form.validateField("amount.amount", "change");
         },
@@ -202,7 +202,7 @@ const TransferPageContents = () => {
                                             selectedToken?.precision ?? 0
                                         }
                                         balance={
-                                            selectedToken?.balance?.amount ?? 0
+                                            selectedToken?.balance ?? null
                                         }
                                         disabled={disableForm}
                                         description={null}

--- a/packages/user/Homepage/ui/src/apps/tokens/transfer.tsx
+++ b/packages/user/Homepage/ui/src/apps/tokens/transfer.tsx
@@ -9,6 +9,7 @@ import { supervisor } from "@/supervisor";
 import { useAppForm } from "@shared/components/form/app-form";
 import { FieldTokenAmount } from "@shared/components/form/field-token-amount";
 import { GlowingCard } from "@shared/components/glowing-card";
+import { Quantity } from "@shared/lib/quantity";
 import { CardContent } from "@shared/shadcn/ui/card";
 import { toast } from "@shared/shadcn/ui/sonner";
 
@@ -202,7 +203,14 @@ const TransferPageContents = () => {
                                             selectedToken?.precision ?? 0
                                         }
                                         balance={
-                                            selectedToken?.balance ?? null
+                                            selectedToken?.balance ??
+                                            (selectedToken
+                                                ? new Quantity(
+                                                      0n,
+                                                      selectedToken.precision,
+                                                      selectedToken.id,
+                                                  )
+                                                : null)
                                         }
                                         disabled={disableForm}
                                         description={null}

--- a/packages/user/PremAccounts/ui/src/pages/buy-page.tsx
+++ b/packages/user/PremAccounts/ui/src/pages/buy-page.tsx
@@ -10,11 +10,7 @@ import {
 import { PREM_ACCOUNTS_SERVICE, doesAccountExist } from "@/lib/prem-service";
 
 import { graphql } from "@shared/lib/graphql";
-import {
-    decimalToRaw,
-    oneAsDecimal,
-    parseDecimal,
-} from "@shared/lib/quantity";
+import { Quantity, decimalToRaw, parseDecimal } from "@shared/lib/quantity";
 import {
     MAX_ACCOUNT_NAME_LENGTH,
     MIN_ACCOUNT_NAME_LENGTH,
@@ -37,6 +33,16 @@ export function BuyPage() {
         id?: number;
     } | null>(null);
     const [maxCost, setMaxCost] = useState("1.0000");
+
+    /** Canonical decimal string for one whole system token, or "1.0000" if not yet loaded. */
+    const oneAsDecimal = (): string =>
+        systemToken?.id != null
+            ? Quantity.fromDecimal(
+                  "1",
+                  systemToken.precision,
+                  systemToken.id,
+              ).toDecimal()
+            : "1.0000";
     const [priceByLength, setPriceByLength] = useState<Map<number, string>>(
         () => new Map(),
     );
@@ -91,7 +97,13 @@ export function BuyPage() {
                     id: sysTid,
                 });
                 if (!maxCostDefaultSynced.current) {
-                    setMaxCost(oneAsDecimal(token.precision));
+                    setMaxCost(
+                        Quantity.fromDecimal(
+                            "1",
+                            token.precision,
+                            sysTid,
+                        ).toDecimal(),
+                    );
                     maxCostDefaultSynced.current = true;
                 }
             }
@@ -217,11 +229,7 @@ export function BuyPage() {
             setAccountName("");
             setAccountExists(null);
             setPrice(null);
-            setMaxCost(
-                systemToken != null
-                    ? oneAsDecimal(systemToken.precision)
-                    : "1.0000",
-            );
+            setMaxCost(oneAsDecimal());
             await loadPrices();
             bumpHistory();
             setTimeout(() => setBuySuccessMessage(""), 5000);
@@ -293,11 +301,7 @@ export function BuyPage() {
                             setError("");
                             setBuySuccessMessage("");
                         }}
-                        placeholder={
-                            systemToken != null
-                                ? oneAsDecimal(systemToken.precision)
-                                : "1.0000"
-                        }
+                        placeholder={oneAsDecimal()}
                     />
                 </div>
                 <div className="col-span-6 mt-6 font-medium">

--- a/packages/user/PremAccounts/ui/src/pages/buy-page.tsx
+++ b/packages/user/PremAccounts/ui/src/pages/buy-page.tsx
@@ -11,10 +11,9 @@ import { PREM_ACCOUNTS_SERVICE, doesAccountExist } from "@/lib/prem-service";
 
 import { graphql } from "@shared/lib/graphql";
 import {
-    canonicalTokenAmountToRaw,
-    expandToCanonicalTokenDecimal,
-    formatCanonicalTokenAmount,
-    unitTokenAmountCanonical,
+    decimalToRaw,
+    oneAsDecimal,
+    parseDecimal,
 } from "@shared/lib/quantity";
 import {
     MAX_ACCOUNT_NAME_LENGTH,
@@ -92,7 +91,7 @@ export function BuyPage() {
                     id: sysTid,
                 });
                 if (!maxCostDefaultSynced.current) {
-                    setMaxCost(unitTokenAmountCanonical(token.precision));
+                    setMaxCost(oneAsDecimal(token.precision));
                     maxCostDefaultSynced.current = true;
                 }
             }
@@ -192,13 +191,10 @@ export function BuyPage() {
         const purchasedName = trimmed;
 
         const maxCostForTx =
-            expandToCanonicalTokenDecimal(maxCost, token.precision) ??
-            maxCost.trim();
-        const maxRaw = canonicalTokenAmountToRaw(maxCostForTx, token.precision);
+            parseDecimal(maxCost, token.precision) ?? maxCost.trim();
+        const maxRaw = decimalToRaw(maxCostForTx, token.precision);
         const priceRaw =
-            price != null
-                ? canonicalTokenAmountToRaw(price, token.precision)
-                : null;
+            price != null ? decimalToRaw(price, token.precision) : null;
         if (maxRaw != null && priceRaw != null && maxRaw < priceRaw) {
             setError(
                 "Max cost is below the current price. Raise max cost to at least the displayed price.",
@@ -223,7 +219,7 @@ export function BuyPage() {
             setPrice(null);
             setMaxCost(
                 systemToken != null
-                    ? unitTokenAmountCanonical(systemToken.precision)
+                    ? oneAsDecimal(systemToken.precision)
                     : "1.0000",
             );
             await loadPrices();
@@ -245,7 +241,7 @@ export function BuyPage() {
         (systemToken?.id != null ? `token ${systemToken.id}` : "SysToken");
     const maxCostCanonical =
         systemToken != null
-            ? expandToCanonicalTokenDecimal(maxCost, systemToken.precision)
+            ? parseDecimal(maxCost, systemToken.precision)
             : null;
     const isBuyEnabled =
         systemToken != null &&
@@ -299,9 +295,7 @@ export function BuyPage() {
                         }}
                         placeholder={
                             systemToken != null
-                                ? unitTokenAmountCanonical(
-                                      systemToken.precision,
-                                  )
+                                ? oneAsDecimal(systemToken.precision)
                                 : "1.0000"
                         }
                     />
@@ -339,11 +333,10 @@ export function BuyPage() {
                                 )}
                                 {accountExists === false && price !== null && (
                                     <p className="text-green-600">
-                                        Buy for{" "}
-                                        {formatCanonicalTokenAmount(
-                                            price,
-                                            systemToken?.symbol,
-                                        )}
+                                        Buy for {price}
+                                        {systemToken?.symbol
+                                            ? ` ${systemToken.symbol}`
+                                            : ""}
                                     </p>
                                 )}
                                 {accountExists === false &&


### PR DESCRIPTION
Quantity was based on JS's Number, which isn't big enough to handle the full spectrum of chain-side u64 amounts. With this switch to using BigInt internatlly, all quantities can now round-trip to/from the chain successfully.
along the way, I've tried to tighten up the naming of the functions, shortened the comparator functions, and synced up with the chain's paradigms as much as possible without blowing what I think are typical frontend expectations.

I'm sure we will debate naming. Let's start with the idea that Quantity and Decimal are *terribly* generic terms to be used for what will always be an asset amount. The abstractions also work slightly differently on the frontend, so I didn't faithfully replicate the backend concepts verbatim. Note also that there's the wit decimal-to-u64 naming to take into account. So there wasn't 100% 1:1 mapping that I thought made sense. But I've put a lengthy comment at the top of the quantity.ts file to walk through the definitions and reference to the chain and wit ideas.