### PR TITLE
add a function in profiles to check if the caller has read permissions

### DIFF
--- a/packages/user/Permissions/plugin/src/lib.rs
+++ b/packages/user/Permissions/plugin/src/lib.rs
@@ -72,6 +72,63 @@ fn validate_caller(caller: &str) -> bool {
     allowed_callers.contains(&caller.to_string())
 }
 
+enum AuthResult {
+    Authorized,
+    Denied,
+    NeedsPrompt { user: String },
+}
+
+fn auth_check(
+    caller: &str,
+    callee: &str,
+    level: TrustLevel,
+    whitelist: &[String],
+    debug_label: &str,
+) -> Result<AuthResult, Error> {
+    // Auto approve for trust level: none
+    if level == TrustLevel::None {
+        return Ok(AuthResult::Authorized);
+    }
+
+    // Whitelisted accounts are authorized
+    if whitelist.iter().any(|w| w == caller) {
+        return Ok(AuthResult::Authorized);
+    }
+
+    // Callee is always authorized to call itself
+    if caller == callee {
+        return Ok(AuthResult::Authorized);
+    }
+
+    // Max trust level is only allowed when caller == callee
+    // TODO incorporate security groups for TrustLevel::Max
+    if level == TrustLevel::Max {
+        return Ok(AuthResult::Denied);
+    }
+
+    if !validate_caller(caller) {
+        return Err(ErrorType::InvalidCaller(
+            caller.to_string(),
+            callee.to_string(),
+            debug_label.to_string(),
+        )
+        .into());
+    }
+
+    let user = Accounts::get_current_user().ok_or_else(|| {
+        ErrorType::LoggedInUserDNE(
+            caller.to_string(),
+            callee.to_string(),
+            debug_label.to_string(),
+        )
+    })?;
+    if is_already_authorized(&user, caller, callee, level) {
+        Ok(AuthResult::Authorized)
+    } else {
+        Ok(AuthResult::NeedsPrompt { user })
+    }
+}
+
 impl Api for PermissionsPlugin {
     fn set_allowed_callers(callers: Vec<String>) {
         assert_eq!(
@@ -83,6 +140,14 @@ impl Api for PermissionsPlugin {
         AllowedCallers::set(callers);
     }
 
+    fn has_auth(caller: String, level: TrustLevel, whitelist: Vec<String>) -> bool {
+        let callee = HostClient::get_sender();
+        matches!(
+            auth_check(&caller, &callee, level, &whitelist, ""),
+            Ok(AuthResult::Authorized)
+        )
+    }
+
     fn is_authorized(
         caller: String,
         level: TrustLevel,
@@ -92,46 +157,18 @@ impl Api for PermissionsPlugin {
     ) -> Result<bool, Error> {
         let callee = HostClient::get_sender();
 
-        if level == TrustLevel::None {
-            // Auto approve for trust level: none
-            return Ok(true);
-        }
-        if whitelist.contains(&caller) {
-            // Whitelisted accounts are authorized
-            return Ok(true);
-        }
-        if caller == callee {
-            // Callee is always authorized to call itself
-            return Ok(true);
-        }
-        if level == TrustLevel::Max {
-            // Max trust level is only allowed when caller == callee
-            // TODO incorporate security groups for TrustLevel::Max
-            return Ok(false);
-        }
-
-        if !validate_caller(&caller) {
-            return Err(ErrorType::InvalidCaller(
-                caller.clone(),
-                callee.clone(),
-                debug_label.clone(),
-            )
-            .into());
-        }
-
-        let user = Accounts::get_current_user().ok_or_else(|| {
-            ErrorType::LoggedInUserDNE(caller.clone(), callee.clone(), debug_label.clone())
-        })?;
-        if is_already_authorized(&user, &caller, &callee, level) {
-            return Ok(true);
-        }
+        let user = match auth_check(&caller, &callee, level, &whitelist, debug_label.as_str())? {
+            AuthResult::Authorized => return Ok(true),
+            AuthResult::Denied => return Ok(false),
+            AuthResult::NeedsPrompt { user } => user,
+        };
 
         HostPrompt::prompt(
             "permissions",
             Some(&PackablePromptContext {
                 user: user.to_string(),
-                caller: caller.to_string(),
-                callee: callee.to_string(),
+                caller: caller.clone(),
+                callee: callee.clone(),
                 level,
                 descriptions,
             }),

--- a/packages/user/Permissions/plugin/wit/world.wit
+++ b/packages/user/Permissions/plugin/wit/world.wit
@@ -7,9 +7,9 @@ interface types {
     ///   will result in an automatic approval.
     /// - `low`: Can consume client-side user resources or make some authenticated queries.
     ///   Using this level prompts the user if the caller lacks sufficient trust level.
-    /// - `medium`: Can consume server-side resources or modify app-local user data. 
-    ///    "app-local data" means that modifying it will not have any side-effects outside 
-    ///    of your app. Using this level prompts the user if the caller lacks sufficient trust 
+    /// - `medium`: Can consume server-side resources or modify app-local user data.
+    ///    "app-local data" means that modifying it will not have any side-effects outside
+    ///    of your app. Using this level prompts the user if the caller lacks sufficient trust
     ///    level.
     /// - `high`: access to data or functionality that can affect the user outside of your app
     ///    or involves other users (e.g., sending messages, updating keys, reading private user-data).
@@ -25,7 +25,7 @@ interface types {
     }
 
     /// Descriptions for low, medium, and high trust (respectively) in the context of your
-    ///   app. These are shown to the user to help them determine if they should trust the 
+    ///   app. These are shown to the user to help them determine if they should trust the
     ///   requesting app.
     type descriptions = tuple<string, string, string>;
 }
@@ -35,28 +35,28 @@ interface api {
     use types.{trust-level, descriptions};
 
     /// # Summary
-    /// 
+    ///
     /// Check if the user has granted the caller a sufficient trust level to access the callee's data/functionality.
-    /// 
+    ///
     /// # Terminology
-    /// 
+    ///
     /// - "user":   The currently logged in user of the active app.
     /// - "caller": An app or plugin that makes a call to another app's plugin.
     /// - "callee": An app that gets called into and uses this `is-authorized` function to check authorization.
     /// - "trust level": How strongly the user should trust the caller, as defined by the callee.
-    /// 
+    ///
     /// # Details
-    /// 
+    ///
     /// The caller of this function (the "callee") wants to check if the user has granted the specified `caller` app
-    ///     a sufficient permission level to use callee's plugin. If the caller has insufficient permissions, this 
+    ///     a sufficient permission level to use callee's plugin. If the caller has insufficient permissions, this
     ///     function will attempt to prompt the user to consider the request.
-    /// 
+    ///
     /// # Return Values
-    /// 
+    ///
     /// - Ok(`true`): The caller is authorized to perform the action.
     /// - Ok(`false`): The caller is not authorized to perform the action.
     /// - Err: The permissions request was invalid (e.g. invalid caller, no user logged in to handle prompt, etc.)
-    /// 
+    ///
     /// # Arguments
     ///
     /// - `caller`: The app requesting permission.
@@ -68,39 +68,52 @@ interface api {
     ///   granting the requesting application should they approve the request.
     /// - `whitelist`: A list of accounts that are pre-authorized to perform this action.
     ///   These accounts are not generally authorized at the specified `trust` level but will pass this check.
-    /// 
+    ///
     /// # Final Notes
-    /// 
-    /// Plugins not meant for white-labeling or embedding should simply assert that the caller is the expected 
+    ///
+    /// Plugins not meant for white-labeling or embedding should simply assert that the caller is the expected
     /// sender (typically `host:common/client::get_sender()` == `host:common/client::get_receiver()`).
-    /// 
-    /// Plugins intended for embedding, however, often need to request user authorization (similar to OAuth) to permit 
+    ///
+    /// Plugins intended for embedding, however, often need to request user authorization (similar to OAuth) to permit
     /// interactions. This plugin provides a convenient way to handle such "OAuth-like" permission flows.
-    /// 
-    /// This plugin is not privileged or special; it only manages simple hierarchical user authorizations. For more 
+    ///
+    /// This plugin is not privileged or special; it only manages simple hierarchical user authorizations. For more
     /// complex or dynamic approval scenarios, a different or custom authorization plugin may be required.
     is-authorized: func(caller: string, level: trust-level, descriptions: descriptions, debug-label: string, whitelist: list<string>) -> result<bool, error>;
 
     /// # Summary
-    /// 
-    /// This function allows the active app to set the list of allowed caller apps that may attempt to perform 
+    ///
+    /// Read-only check of whether `is-authorized` would currently return `Ok(true)` for the given `caller`,
+    /// `level`, and `whitelist`, without prompting the user.
+    ///
+    /// # Return Values
+    ///
+    /// - `true`: The caller is already authorized; `is-authorized` would return `Ok(true)` without prompting.
+    /// - `false`: The caller is not currently authorized. This includes cases where `is-authorized` would
+    ///   return `Err` (e.g. invalid caller, no user logged in), so `false` does not necessarily mean
+    ///   "only a user grant is missing".
+    has-auth: func(caller: string, level: trust-level, whitelist: list<string>) -> bool;
+
+    /// # Summary
+    ///
+    /// This function allows the active app to set the list of allowed caller apps that may attempt to perform
     /// actions that result in user prompts for permission.
-    /// 
+    ///
     /// # Details
-    /// 
-    /// By using this plugin, the user may be tasked with defining how much they trust the caller app in a particular 
+    ///
+    /// By using this plugin, the user may be tasked with defining how much they trust the caller app in a particular
     /// context. The user should only be given such a task when they are familiar with the caller app and are therefore
     /// able to make an informed decision.
-    /// 
+    ///
     /// Therefore, by default this plugin restricts the caller app to:
     /// - The currently active app, or
     /// - The currently active app's defined list of "allowed caller" apps
-    /// 
-    /// This function allows the active app to manage such a set of apps that may attempt to perform actions that 
+    ///
+    /// This function allows the active app to manage such a set of apps that may attempt to perform actions that
     /// result in user prompts for permission.
-    /// 
+    ///
     /// # Lifetime
-    /// 
+    ///
     /// The list of allowed callers for a particular active app is stored permanently until deleted. The active
     /// app can delete the list by calling this function with an empty list.
     set-allowed-callers: func(callers: list<string>);

--- a/packages/user/Profiles/plugin/src/lib.rs
+++ b/packages/user/Profiles/plugin/src/lib.rs
@@ -1,20 +1,17 @@
 #[allow(warnings)]
 mod bindings;
 
-use bindings::exports::profiles::plugin::api::Guest as Api;
-use bindings::exports::profiles::plugin::contacts::Guest as Contacts;
-
-use bindings::exports::profiles::plugin::contacts::Contact;
-
-use bindings::profiles::plugin::types::Profile as PluginProfile;
-
-use bindings::profiles::plugin::types::Avatar;
-
-use bindings::sites::plugin::types::File;
-
-use bindings::accounts::plugin::api::{get_account, get_current_user};
-use bindings::host::types::types::Error;
-use bindings::transact::plugin::intf::add_action_to_transaction;
+use bindings::{
+    accounts::plugin::api::{get_account, get_current_user},
+    exports::profiles::plugin::{
+        api::Guest as Api, contacts::Contact, contacts::Guest as Contacts,
+    },
+    host::{self, types::types::Error},
+    permissions,
+    profiles::plugin::types::{Avatar, Profile as PluginProfile},
+    sites::plugin::types::File,
+    transact::plugin::intf::add_action_to_transaction,
+};
 
 use psibase::fracpack::Pack;
 
@@ -130,6 +127,14 @@ impl Api for ProfilesPlugin {
         assert_authorized_with_whitelist(FunctionName::remove_avatar, vec!["homepage".into()])?;
 
         bindings::sites::plugin::api::remove("/profile/avatar")
+    }
+
+    fn has_read_permission() -> bool {
+        permissions::plugin::api::has_auth(
+            &host::common::client::get_sender(),
+            permissions::plugin::types::TrustLevel::High,
+            &["homepage".into()],
+        )
     }
 }
 

--- a/packages/user/Profiles/plugin/wit/world.wit
+++ b/packages/user/Profiles/plugin/wit/world.wit
@@ -40,6 +40,8 @@ interface api {
     upload-avatar: func(avatar: avatar) -> result<_, error>;
     remove-avatar: func() -> result<_, error>;
 
+    has-read-permission: func() -> bool;
+
 }
 
 

--- a/rust/psibase_plugin/src/wasm/permissions.rs
+++ b/rust/psibase_plugin/src/wasm/permissions.rs
@@ -12,6 +12,10 @@ pub mod api {
     ) -> Result<bool, Error> {
         api::is_authorized(caller, level, descriptions, debug_label, whitelist)
     }
+
+    pub fn has_auth(caller: &str, level: TrustLevel, whitelist: &[String]) -> bool {
+        api::has_auth(caller, level, whitelist)
+    }
 }
 
 pub mod types {


### PR DESCRIPTION
Adds a `has_auth` function to the permissions plugin. Returns true if the authority has already been granted, or false if the authority has not been granted (and any attempt to use a function that requires such authority may result in a user prompt).
