### PR TITLE
FractalCore: More sensible Profiles/contacts integration

### DIFF
--- a/packages/shared-ui/components/show-contacts-button.tsx
+++ b/packages/shared-ui/components/show-contacts-button.tsx
@@ -20,7 +20,7 @@ import {
 } from "@shared/shadcn/ui/alert-dialog";
 import { Button } from "@shared/shadcn/ui/button";
 
-export const ShowContactsButton = () => {
+export const ShowContactsButton = ({ returnPath }: { returnPath?: string }) => {
     const { data: networkName } = useBranding();
     const contactsUrl = useMemo(
         () => siblingUrl(null, networkName, "contacts"),
@@ -31,7 +31,11 @@ export const ShowContactsButton = () => {
     const { data: hasProfilesReadPermission } = useHasProfilesReadPermission({
         enabled: !!currentUser,
     });
-    const { refetch: prompt } = useContacts(currentUser, { enabled: false });
+    const { refetch: prompt } = useContacts(
+        currentUser,
+        { enabled: false },
+        returnPath ? { enabled: true, returnPath } : undefined,
+    );
 
     if (hasProfilesReadPermission === false) {
         return (

--- a/packages/shared-ui/components/show-contacts-button.tsx
+++ b/packages/shared-ui/components/show-contacts-button.tsx
@@ -1,0 +1,75 @@
+import { Contact } from "lucide-react";
+import { useMemo } from "react";
+
+import { siblingUrl } from "@psibase/common-lib";
+
+import { useBranding } from "@shared/hooks/use-branding";
+import { useContacts } from "@shared/hooks/use-contacts";
+import { useCurrentUser } from "@shared/hooks/use-current-user";
+import { useHasProfilesReadPermission } from "@shared/hooks/use-has-profiles-read-permission";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@shared/shadcn/ui/alert-dialog";
+import { Button } from "@shared/shadcn/ui/button";
+
+export const ShowContactsButton = () => {
+    const { data: networkName } = useBranding();
+    const contactsUrl = useMemo(
+        () => siblingUrl(null, networkName, "contacts"),
+        [networkName],
+    );
+
+    const { data: currentUser } = useCurrentUser();
+    const { data: hasProfilesReadPermission } = useHasProfilesReadPermission({
+        enabled: !!currentUser,
+    });
+    const { refetch: prompt } = useContacts(currentUser, { enabled: false });
+
+    if (hasProfilesReadPermission === false) {
+        return (
+            <AlertDialog>
+                <AlertDialogTrigger asChild>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        aria-label="Enable contacts integration"
+                    >
+                        <Contact /> Show contacts
+                    </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            Enable contacts integration?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Enable integration with the{" "}
+                            <a href={contactsUrl} target="_blank">
+                                Contacts
+                            </a>{" "}
+                            app to see user nicknames in this app. If you
+                            continue, you will be redirected to an authorization
+                            prompt.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => prompt()}>
+                            Continue
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        );
+    }
+
+    return null;
+};

--- a/packages/shared-ui/components/tables/table-contact.tsx
+++ b/packages/shared-ui/components/tables/table-contact.tsx
@@ -1,6 +1,7 @@
 import { Avatar } from "@shared/components/avatar";
 import { useContacts } from "@shared/hooks/use-contacts";
 import { useCurrentUser } from "@shared/hooks/use-current-user";
+import { useHasProfilesReadPermission } from "@shared/hooks/use-has-profiles-read-permission";
 import { Skeleton } from "@shared/shadcn/ui/skeleton";
 
 export const TableContact = ({ account }: { account: string }) => {
@@ -12,13 +13,26 @@ export const TableContact = ({ account }: { account: string }) => {
     } = useCurrentUser();
 
     const {
+        data: hasProfilesReadPermission,
+        isPending: isPendingHasProfilesReadPermission,
+        isError: isErrorHasProfilesReadPermission,
+        error: errorHasProfilesReadPermission,
+    } = useHasProfilesReadPermission({
+        enabled: !!currentUser,
+    });
+
+    const {
         data: contacts,
-        isPending: isPendingContacts,
+        isLoading: isLoadingContacts,
         isError: isErrorContacts,
         error: errorContacts,
-    } = useContacts(currentUser);
+    } = useContacts(currentUser, { enabled: !!hasProfilesReadPermission });
 
-    if (isPendingCurrentUser || isPendingContacts) {
+    if (
+        isPendingCurrentUser ||
+        isPendingHasProfilesReadPermission ||
+        isLoadingContacts
+    ) {
         return (
             <div className="@lg:h-auto flex h-10 items-center gap-2">
                 <Skeleton className="@lg:h-5 @lg:w-5 h-8 w-8 shrink-0 rounded-full" />
@@ -27,9 +41,17 @@ export const TableContact = ({ account }: { account: string }) => {
         );
     }
 
-    if (isErrorCurrentUser || isErrorContacts) {
-        console.error(errorCurrentUser);
-        console.error(errorContacts);
+    if (
+        isErrorCurrentUser ||
+        isErrorHasProfilesReadPermission ||
+        isErrorContacts
+    ) {
+        console.error("Error fetching current user:", errorCurrentUser);
+        console.error("Error fetching contacts:", errorContacts);
+        console.error(
+            "Error fetching profiles read permission:",
+            errorHasProfilesReadPermission,
+        );
         return <div>{account}</div>;
     }
 

--- a/packages/shared-ui/hooks/use-contacts.ts
+++ b/packages/shared-ui/hooks/use-contacts.ts
@@ -1,4 +1,5 @@
 import type { QueryOptions } from "./types";
+import type { AutoRedirectConfig } from "@psibase/common-lib";
 
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { z } from "zod";
@@ -22,16 +23,22 @@ export const zProcessedContact = zLocalContact.extend({
 export type LocalContact = z.infer<typeof zLocalContact>;
 export type ProcessedContact = z.infer<typeof zProcessedContact>;
 
-export const queryContacts = (username: Account | null | undefined) =>
+export const queryContacts = (
+    username: Account | null | undefined,
+    autoRedirectConfig: AutoRedirectConfig,
+) =>
     queryOptions({
         queryKey: QueryKey.contacts(username),
         queryFn: async () => {
-            const res = await supervisor.functionCall({
-                service: zAccount.parse("profiles"),
-                method: "get",
-                params: [],
-                intf: "contacts",
-            });
+            const res = await supervisor.functionCall(
+                {
+                    service: zAccount.parse("profiles"),
+                    method: "get",
+                    params: [],
+                    intf: "contacts",
+                },
+                autoRedirectConfig,
+            );
             return zLocalContact.array().parse(res);
         },
     });
@@ -44,10 +51,14 @@ export const useContacts = (
         LocalContact[],
         ReturnType<typeof QueryKey.contacts>
     >,
+    autoRedirectConfig: AutoRedirectConfig = {
+        enabled: true,
+        returnPath: "/",
+    },
 ) => {
     const queryOptions = options ?? {};
     return useQuery({
-        ...queryContacts(username),
+        ...queryContacts(username, autoRedirectConfig),
         ...queryOptions,
         enabled: !!username && queryOptions.enabled,
     });

--- a/packages/shared-ui/hooks/use-has-profiles-read-permission.ts
+++ b/packages/shared-ui/hooks/use-has-profiles-read-permission.ts
@@ -1,10 +1,12 @@
 import { profiles, usePluginFunctionQuery } from "@shared/lib/plugins";
 
-export const useHasProfilesReadPermission = ({
-    enabled = true,
-}: {
+type Options = {
     enabled?: boolean;
-}) => {
+};
+
+export const useHasProfilesReadPermission = (
+    { enabled }: Options = { enabled: true },
+) => {
     return usePluginFunctionQuery(profiles.api.hasReadPermission, [], {
         enabled,
     });

--- a/packages/shared-ui/hooks/use-has-profiles-read-permission.ts
+++ b/packages/shared-ui/hooks/use-has-profiles-read-permission.ts
@@ -1,0 +1,11 @@
+import { profiles, usePluginFunctionQuery } from "@shared/lib/plugins";
+
+export const useHasProfilesReadPermission = ({
+    enabled = true,
+}: {
+    enabled?: boolean;
+}) => {
+    return usePluginFunctionQuery(profiles.api.hasReadPermission, [], {
+        enabled,
+    });
+};

--- a/packages/shared-ui/lib/plugins/index.ts
+++ b/packages/shared-ui/lib/plugins/index.ts
@@ -1,10 +1,18 @@
 import { usePluginFunctionMutation } from "@shared/hooks/plugin-function/use-plugin-function-mutation";
 import { usePluginFunctionQuery } from "@shared/hooks/plugin-function/use-plugin-function-query";
 
+import { Plugin as Profiles } from "./profiles";
 import { Plugin as TokenSwap } from "./token-swap";
 import { Plugin as Tokens } from "./tokens";
 
 const tokenSwap = new TokenSwap("token-swap");
 const tokens = new Tokens("tokens");
+const profiles = new Profiles("profiles");
 
-export { tokenSwap, tokens, usePluginFunctionMutation, usePluginFunctionQuery };
+export {
+    tokenSwap,
+    tokens,
+    profiles,
+    usePluginFunctionMutation,
+    usePluginFunctionQuery,
+};

--- a/packages/shared-ui/lib/plugins/profiles.ts
+++ b/packages/shared-ui/lib/plugins/profiles.ts
@@ -1,0 +1,20 @@
+import { PluginInterface } from "@shared/hooks/plugin-function";
+import { Account } from "@shared/lib/schemas/account";
+
+class Api extends PluginInterface {
+    protected override readonly _intf = "api" as const;
+
+    get hasReadPermission() {
+        return this._call<[]>("hasReadPermission");
+    }
+}
+
+export class Plugin {
+    readonly api: Api;
+
+    constructor(readonly service: Account) {
+        // Initialize all interfaces with the correct service
+        this.api = new Api();
+        Object.assign(this.api, { _service: service });
+    }
+}

--- a/packages/user/FractalCore/ui/src/lib/paths.ts
+++ b/packages/user/FractalCore/ui/src/lib/paths.ts
@@ -5,5 +5,13 @@ export const paths = {
         evaluations: (guild: Account) => `/guild/${guild}/evaluations/upcoming`,
         evaluationGroup: (guild: Account, groupNumber: number) =>
             `/guild/${guild}/evaluations/group/${groupNumber}`,
+        membership: {
+            applicants: (guild: Account) =>
+                `/guild/${guild}/membership/applicants`,
+            members: (guild: Account) => `/guild/${guild}/membership/members`,
+        },
+    },
+    fractal: {
+        members: () => `/fractal/members`,
     },
 };

--- a/packages/user/FractalCore/ui/src/lib/paths.ts
+++ b/packages/user/FractalCore/ui/src/lib/paths.ts
@@ -12,6 +12,6 @@ export const paths = {
         },
     },
     fractal: {
-        members: () => `/fractal/members`,
+        members: () => `/members`,
     },
 };

--- a/packages/user/FractalCore/ui/src/pages/fractal/members.tsx
+++ b/packages/user/FractalCore/ui/src/pages/fractal/members.tsx
@@ -3,6 +3,7 @@ import { Users } from "lucide-react";
 
 import { useFractalAccount } from "@/hooks/fractals/use-fractal-account";
 import { useMembers } from "@/hooks/fractals/use-members";
+import { paths } from "@/lib/paths";
 
 import { GlowingCard } from "@shared/components/glowing-card";
 import { PageContainer } from "@shared/components/page-container";
@@ -48,7 +49,9 @@ export const Members = () => {
                 <CardHeader>
                     <CardTitle>All Members</CardTitle>
                     <CardAction>
-                        <ShowContactsButton />
+                        <ShowContactsButton
+                            returnPath={paths.fractal.members()}
+                        />
                     </CardAction>
                 </CardHeader>
                 <CardContent className="@container">

--- a/packages/user/FractalCore/ui/src/pages/fractal/members.tsx
+++ b/packages/user/FractalCore/ui/src/pages/fractal/members.tsx
@@ -6,11 +6,17 @@ import { useMembers } from "@/hooks/fractals/use-members";
 
 import { GlowingCard } from "@shared/components/glowing-card";
 import { PageContainer } from "@shared/components/page-container";
+import { ShowContactsButton } from "@shared/components/show-contacts-button";
 import { TableContact } from "@shared/components/tables/table-contact";
 import { COUNCIL_SEATS } from "@shared/domains/fractal/lib/constants";
 import { getMemberLabel } from "@shared/domains/fractal/lib/get-member-label";
 import { Badge } from "@shared/shadcn/ui/badge";
-import { CardContent, CardHeader, CardTitle } from "@shared/shadcn/ui/card";
+import {
+    CardAction,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from "@shared/shadcn/ui/card";
 import {
     Table,
     TableBody,
@@ -41,6 +47,9 @@ export const Members = () => {
             <GlowingCard>
                 <CardHeader>
                     <CardTitle>All Members</CardTitle>
+                    <CardAction>
+                        <ShowContactsButton />
+                    </CardAction>
                 </CardHeader>
                 <CardContent className="@container">
                     <Table>

--- a/packages/user/FractalCore/ui/src/pages/guilds/evaluations/evaluation-deliberation.tsx
+++ b/packages/user/FractalCore/ui/src/pages/guilds/evaluations/evaluation-deliberation.tsx
@@ -10,8 +10,10 @@ import { useRanking } from "@/hooks/fractals/use-ranking";
 
 import { GlowingCard } from "@shared/components/glowing-card";
 import { PageContainer } from "@shared/components/page-container";
+import { ShowContactsButton } from "@shared/components/show-contacts-button";
 import { useContacts } from "@shared/hooks/use-contacts";
 import { useCurrentUser } from "@shared/hooks/use-current-user";
+import { useHasProfilesReadPermission } from "@shared/hooks/use-has-profiles-read-permission";
 import {
     CardAction,
     CardContent,
@@ -35,8 +37,17 @@ const usePageParams = () => {
 
 export const EvaluationDeliberation = () => {
     const { groupNumber } = usePageParams();
+
     const { data: currentUser } = useCurrentUser();
-    const { data: contacts } = useContacts(currentUser);
+
+    const { data: hasProfilesReadPermission } = useHasProfilesReadPermission({
+        enabled: !!currentUser,
+    });
+
+    const { data: contacts } = useContacts(currentUser, {
+        enabled: !!hasProfilesReadPermission,
+    });
+
     const {
         add,
         remove,
@@ -56,7 +67,10 @@ export const EvaluationDeliberation = () => {
                         Evaluate participants in your group
                     </CardDescription>
                     <CardAction>
-                        <StatusBadges rankingStatus={status} />
+                        <div className="flex items-center gap-2">
+                            <StatusBadges rankingStatus={status} />
+                            <ShowContactsButton />
+                        </div>
                     </CardAction>
                 </CardHeader>
                 <CardContent className="space-y-6">

--- a/packages/user/FractalCore/ui/src/pages/guilds/evaluations/evaluation-deliberation.tsx
+++ b/packages/user/FractalCore/ui/src/pages/guilds/evaluations/evaluation-deliberation.tsx
@@ -7,6 +7,7 @@ import { StatusBadges } from "@/components/evaluations/deliberation/status-badge
 import { UnrankedAccountChip } from "@/components/evaluations/deliberation/unranked-account-chip";
 
 import { useRanking } from "@/hooks/fractals/use-ranking";
+import { paths } from "@/lib/paths";
 
 import { GlowingCard } from "@shared/components/glowing-card";
 import { PageContainer } from "@shared/components/page-container";
@@ -36,7 +37,7 @@ const usePageParams = () => {
 };
 
 export const EvaluationDeliberation = () => {
-    const { groupNumber } = usePageParams();
+    const { guildAccount, groupNumber } = usePageParams();
 
     const { data: currentUser } = useCurrentUser();
 
@@ -69,7 +70,12 @@ export const EvaluationDeliberation = () => {
                     <CardAction>
                         <div className="flex items-center gap-2">
                             <StatusBadges rankingStatus={status} />
-                            <ShowContactsButton />
+                            <ShowContactsButton
+                                returnPath={paths.guild.evaluationGroup(
+                                    guildAccount!,
+                                    groupNumber,
+                                )}
+                            />
                         </div>
                     </CardAction>
                 </CardHeader>

--- a/packages/user/FractalCore/ui/src/pages/guilds/membership/applicants.tsx
+++ b/packages/user/FractalCore/ui/src/pages/guilds/membership/applicants.tsx
@@ -7,6 +7,7 @@ import { ApplyGuildModal } from "@/components/modals/apply-guild-modal";
 import { useGuildApplications } from "@/hooks/fractals/use-guild-applications";
 import { useGuildMembershipsOfUser } from "@/hooks/fractals/use-guild-memberships";
 import { useGuildAccount } from "@/hooks/use-guild-account";
+import { paths } from "@/lib/paths";
 
 import { EmptyBlock } from "@shared/components/empty-block";
 import { GlowingCard } from "@shared/components/glowing-card";
@@ -55,7 +56,11 @@ export const GuildApplicants = () => {
                     <CardHeader>
                         <CardTitle>Guild applicants</CardTitle>
                         <CardAction>
-                            <ShowContactsButton />
+                            <ShowContactsButton
+                                returnPath={paths.guild.membership.applicants(
+                                    guildAccount!,
+                                )}
+                            />
                         </CardAction>
                     </CardHeader>
                     <CardContent className="@container">

--- a/packages/user/FractalCore/ui/src/pages/guilds/membership/applicants.tsx
+++ b/packages/user/FractalCore/ui/src/pages/guilds/membership/applicants.tsx
@@ -10,9 +10,15 @@ import { useGuildAccount } from "@/hooks/use-guild-account";
 
 import { EmptyBlock } from "@shared/components/empty-block";
 import { GlowingCard } from "@shared/components/glowing-card";
+import { ShowContactsButton } from "@shared/components/show-contacts-button";
 import { TableContact } from "@shared/components/tables/table-contact";
 import { useCurrentUser } from "@shared/hooks/use-current-user";
-import { CardContent, CardHeader, CardTitle } from "@shared/shadcn/ui/card";
+import {
+    CardAction,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from "@shared/shadcn/ui/card";
 import {
     Table,
     TableBody,
@@ -48,6 +54,9 @@ export const GuildApplicants = () => {
                 <GlowingCard>
                     <CardHeader>
                         <CardTitle>Guild applicants</CardTitle>
+                        <CardAction>
+                            <ShowContactsButton />
+                        </CardAction>
                     </CardHeader>
                     <CardContent className="@container">
                         <Table>
@@ -81,7 +90,8 @@ export const GuildApplicants = () => {
                                             ).format("llll")}
                                         </TableCell>
                                         <TableCell className="text-end">
-                                            {application.score.current} / {application.score.required}
+                                            {application.score.current} /{" "}
+                                            {application.score.required}
                                         </TableCell>
                                     </TableRow>
                                 ))}
@@ -102,8 +112,8 @@ export const GuildApplicants = () => {
                         isGuildMember || isPending
                             ? undefined
                             : () => {
-                                setShowGuildModal(true);
-                            }
+                                  setShowGuildModal(true);
+                              }
                     }
                 />
             )}

--- a/packages/user/FractalCore/ui/src/pages/guilds/membership/members.tsx
+++ b/packages/user/FractalCore/ui/src/pages/guilds/membership/members.tsx
@@ -7,9 +7,15 @@ import { useScores } from "@/hooks/fractals/use-scores";
 import { useGuild } from "@/hooks/use-guild";
 
 import { GlowingCard } from "@shared/components/glowing-card";
+import { ShowContactsButton } from "@shared/components/show-contacts-button";
 import { TableContact } from "@shared/components/tables/table-contact";
 import { Badge } from "@shared/shadcn/ui/badge";
-import { CardContent, CardHeader, CardTitle } from "@shared/shadcn/ui/card";
+import {
+    CardAction,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from "@shared/shadcn/ui/card";
 import {
     Table,
     TableBody,
@@ -43,6 +49,9 @@ export const GuildMembers = () => {
         <GlowingCard>
             <CardHeader>
                 <CardTitle>Guild members</CardTitle>
+                <CardAction>
+                    <ShowContactsButton />
+                </CardAction>
             </CardHeader>
             <CardContent className="@container">
                 <Table>

--- a/packages/user/FractalCore/ui/src/pages/guilds/membership/members.tsx
+++ b/packages/user/FractalCore/ui/src/pages/guilds/membership/members.tsx
@@ -5,6 +5,7 @@ import dayjs from "dayjs";
 
 import { useScores } from "@/hooks/fractals/use-scores";
 import { useGuild } from "@/hooks/use-guild";
+import { paths } from "@/lib/paths";
 
 import { GlowingCard } from "@shared/components/glowing-card";
 import { ShowContactsButton } from "@shared/components/show-contacts-button";
@@ -50,7 +51,11 @@ export const GuildMembers = () => {
             <CardHeader>
                 <CardTitle>Guild members</CardTitle>
                 <CardAction>
-                    <ShowContactsButton />
+                    <ShowContactsButton
+                        returnPath={paths.guild.membership.members(
+                            guild?.account ?? "",
+                        )}
+                    />
                 </CardAction>
             </CardHeader>
             <CardContent className="@container">


### PR DESCRIPTION
Issue #1768

Before this, if you navigated to a screen listing members in FractalCore for the first time, you would automatically get redirected to a permissions prompt requesting access to the Profiles (contacts) app, so that the FractalCore UI could display friendly nicknames from your contacts for members. This was jarring for the user.

This introduces a hook that reads (without a prompt) whether or not the app has been granted Profiles permissions. If it has not, we now display a button in strategic places in the app (as a `CardAction` at the top of members/applicants table cards and the evaluation deliberation screen) to allow the user to manually enable contacts/Profiles integration.

It also ensures that the user is redirected to the page they came from after the prompt is resolved.

<img width="1077" height="283" alt="image" src="https://github.com/user-attachments/assets/d91054a0-5217-4dea-97b4-54fd31f12542" />

<img width="1144" height="273" alt="image" src="https://github.com/user-attachments/assets/10bf04df-76b4-4002-938b-0c44be69502b" />
