### PR TITLE
Allow reinstalling producers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,7 +754,6 @@ psibase_package(
     SERVICE r-producers
         WASM ${CMAKE_CURRENT_BINARY_DIR}/RProducers.wasm
         SCHEMA ${CMAKE_CURRENT_BINARY_DIR}/RProducers-schema.json
-    ACCOUNTS prods-weak prods-strong
     POSTINSTALL ${CMAKE_CURRENT_SOURCE_DIR}/packages/system/Producers/src/postinstall.json
     DEPENDS wasm
     PACKAGE_DEPENDS "HttpServer(^${PSIBASE_VERSION}.0)" "Accounts(^${PSIBASE_VERSION}.0)" "Sites(^${PSIBASE_VERSION}.0)" "StagedTx(^${PSIBASE_VERSION}.0)" "Transact(^${PSIBASE_VERSION}.0)" "AuthSig(^${PSIBASE_VERSION}.0)"

--- a/packages/system/Producers/src/postinstall.json
+++ b/packages/system/Producers/src/postinstall.json
@@ -1,1 +1,4 @@
-[{"sender":"prods-weak","service":"accounts","method":"setauthserv","data":{"authService":"producers"}},{"sender":"prods-strong","service":"accounts","method":"setauthserv","data":{"authService":"producers"}}]
+[
+    {"sender":"accounts","service":"accounts","method":"newAccount","data":{"name":"prods-weak","authService":"producers","requireMatch":true}},
+    {"sender":"accounts","service":"accounts","method":"newAccount","data":{"name":"prods-strong","authService":"producers","requireMatch":true}}
+]


### PR DESCRIPTION
The previous implementation of creating `prods-weak` and `prods-strong` with `AuthDelegate` and then setting their auth doesn't work when upgrading, because creating the account will fail when the auth has been changed. Call `accounts::newAccount` directly instead.