### PR TITLE
update the create-guild whitelist

### DIFF
--- a/packages/user/Guilds/plugin/src/lib.rs
+++ b/packages/user/Guilds/plugin/src/lib.rs
@@ -205,7 +205,7 @@ impl AdminGuild for GuildsPlugin {
         )
     }
 
-    #[psibase_plugin::authorized(Medium, whitelist = ["fractals"])]
+    #[psibase_plugin::authorized(Medium, whitelist = ["fractals", &fractal])]
     fn create_guild(
         display_name: String,
         fractal: String,


### PR DESCRIPTION
Allows the fractal UI to create a guild without a user permission prompt