### PR TITLE
Fix missing reflected field

### DIFF
--- a/libraries/psibase/common/include/psibase/schema.hpp
+++ b/libraries/psibase/common/include/psibase/schema.hpp
@@ -173,7 +173,7 @@ namespace psibase
                return i;
             ++i;
          }
-         throw std::runtime_error("Member is not reflected");
+         abortMessage("Member is not reflected");
       }
 
       template <bool Last, auto K, typename T, typename M>

--- a/libraries/psibase/common/include/psibase/schema.hpp
+++ b/libraries/psibase/common/include/psibase/schema.hpp
@@ -173,7 +173,7 @@ namespace psibase
                return i;
             ++i;
          }
-         return i;
+         throw std::runtime_error("Member is not reflected");
       }
 
       template <bool Last, auto K, typename T, typename M>
@@ -195,8 +195,9 @@ namespace psibase
          {
             static_assert(!std::is_function_v<M>,
                           "Member function keys not supported. Use CompositeKey instead.");
-            prefix.path.push_back(
-                get_member_index<K>((typename psio::reflect<T>::data_members*)nullptr));
+            constexpr auto idx =
+                get_member_index<K>((typename psio::reflect<T>::data_members*)nullptr);
+            prefix.path.push_back(idx);
             if constexpr (Last)
             {
                out.push_back(std::move(prefix));

--- a/packages/user/Packages/include/services/user/Packages.hpp
+++ b/packages/user/Packages/include/services/user/Packages.hpp
@@ -42,6 +42,7 @@ namespace UserService
                                         &PublishedPackage::version>;
    };
    PSIO_REFLECT(PublishedPackage,
+                owner,
                 name,
                 version,
                 scope,


### PR DESCRIPTION
This was causing updates of `Packages` to fail.

Also adds a compile error if a non-reflected field is used as a key.