### PR TITLE
Remove option to install packages with a public key

### DIFF
--- a/doc/src/run-infrastructure/cli/psibase.md
+++ b/doc/src/run-infrastructure/cli/psibase.md
@@ -10,7 +10,7 @@ psibase - The psibase blockchain command line client
 `psibase` `create` [`-a` *url*] [`-i` | `-k` *public-key* | `-o` *account*] [`-S` *sender*] *name*  
 `psibase` `deploy` [`-a` *url*] [`-p`] *account* *wasm* *schema*  
 `psibase` `info` [`-a` *url*] *packages*\.\.\.  
-`psibase` `install` [`-a` *url*] [`-k` *public-key*] *packages*\.\.\.  
+`psibase` `install` [`-a` *url*] [`-S` *sender*] *packages*\.\.\.  
 `psibase` `list` [`-a` *url*] [`--all` | `--available` | `--installed` | `--updates`]  
 `psibase` `login` [`-a` *url*] *account*  
 `psibase` `modify` [`-a` *url*] [`-i` | `-k` *public-key* | `-o` *account*] *account*  
@@ -183,19 +183,13 @@ Displays the contents of packages
 
 ### install
 
-`psibase` `install` [`-a` *url*] [`-k` *public-key*] *packages*\.\.\.  
+`psibase` `install` [`-a` *url*] [`-S` *sender*] *packages*\.\.\.  
 
 Install packages to the chain along with all dependencies. If any of the requested packages are already installed, they will be updated if a newer version is available.
 
 - *packages*
 
   Packages to install
-
-- `-k`, `--key` *public-key*
-
-  Set all accounts created by the new packages to authenticate using this key. The public key can be any of the following:
-  - A file containing a PEM or DER encoded public key
-  - A PKCS #11 URI
 
 - `--local`
 
@@ -340,12 +334,6 @@ Upgrade installed packages. This will not upgrade packages to a new major versio
 - *packages*
 
   The names of packages to upgrade. The default is to upgrade all packages that are currently installed.
-
-- `-k`, `--key` *public-key*
-
-  Set all accounts created by new packages to authenticate using this key. The public key can be any of the following:
-  - A file containing a PEM or DER encoded public key
-  - A PKCS #11 URI
 
 - `--latest`
 

--- a/packages/user/Packages/plugin/src/lib.rs
+++ b/packages/user/Packages/plugin/src/lib.rs
@@ -368,7 +368,7 @@ fn apply_packages<
             ));
             let mut account_actions = vec![];
             package
-                .install_accounts(&mut account_actions, Some(&mut uploader), sender, &None)
+                .install_accounts(&mut account_actions, Some(&mut uploader), sender)
                 .map_err(|e| ErrorType::PackageFormatError(e.to_string()))?;
             out.push_all(account_actions).unwrap();
             let mut actions = vec![];

--- a/rust/psibase/src/main.rs
+++ b/rust/psibase/src/main.rs
@@ -336,10 +336,6 @@ struct InstallArgs {
     #[clap(required = true)]
     packages: Vec<OsString>,
 
-    /// Set all accounts to authenticate using this key
-    #[clap(short = 'k', long, value_name = "KEY")]
-    key: Option<AnyPublicKey>,
-
     /// A URL or path to a package repository (repeatable)
     #[clap(long, value_name = "URL")]
     package_source: Vec<String>,
@@ -380,10 +376,6 @@ struct UpgradeArgs {
 
     /// Packages to update
     packages: Vec<OsString>,
-
-    /// Set all accounts to authenticate using this key
-    #[clap(short = 'k', long, value_name = "KEY")]
-    key: Option<AnyPublicKey>,
 
     /// A URL or path to a package repository (repeatable)
     #[clap(long, value_name = "URL")]
@@ -1621,7 +1613,6 @@ async fn apply_packages<
     out: &mut TransactionBuilder<SignedTransaction, F>,
     files: &mut TransactionBuilder<SignedTransaction, G>,
     sender: AccountNumber,
-    key: &Option<AnyPublicKey>,
     compression_level: u32,
     existing: PackageList,
 ) -> Result<SchemaMap, anyhow::Error> {
@@ -1642,7 +1633,7 @@ async fn apply_packages<
                     package.version()
                 ));
                 let mut account_actions = vec![];
-                package.install_accounts(&mut account_actions, Some(&mut uploader), sender, key)?;
+                package.install_accounts(&mut account_actions, Some(&mut uploader), sender)?;
                 out.push_all(account_actions)?;
                 let mut actions = vec![];
                 package.install(
@@ -1676,7 +1667,7 @@ async fn apply_packages<
                 old_manifest.upgrade(package.manifest(), out)?;
                 // Install the new package
                 let mut account_actions = vec![];
-                package.install_accounts(&mut account_actions, Some(&mut uploader), sender, key)?;
+                package.install_accounts(&mut account_actions, Some(&mut uploader), sender)?;
                 out.push_all(account_actions)?;
                 let mut actions = vec![];
                 package.install(
@@ -1709,7 +1700,6 @@ async fn do_install<T: Read + Seek>(
     node_args: &NodeArgs,
     sig_args: &SigArgs,
     tx_args: &TxArgs,
-    key: &Option<AnyPublicKey>,
     compression_level: u32,
     existing: PackageList,
 ) -> Result<(), anyhow::Error> {
@@ -1761,7 +1751,6 @@ async fn do_install<T: Read + Seek>(
         &mut trx_builder,
         &mut upload_builder,
         sender,
-        key,
         compression_level,
         existing,
     )
@@ -1927,7 +1916,6 @@ async fn install(args: &InstallArgs) -> Result<(), anyhow::Error> {
             &args.node_args,
             &args.sig_args,
             &args.tx_args,
-            &args.key,
             args.compression_level,
             installed,
         )
@@ -2229,7 +2217,6 @@ async fn upgrade(args: &UpgradeArgs) -> Result<(), anyhow::Error> {
             &args.node_args,
             &args.sig_args,
             &args.tx_args,
-            &args.key,
             args.compression_level,
             installed,
         )

--- a/rust/psibase/src/package.rs
+++ b/rust/psibase/src/package.rs
@@ -1,14 +1,14 @@
 #![cfg_attr(target_family = "wasm", allow(dead_code))]
 
 use crate::services::{
-    accounts, auth_sig, brotli_svc::brotli_impl, http_server, packages, producers, setcode, sites,
-    transact, verify_sig, x_sites,
+    accounts, brotli_svc::brotli_impl, http_server, packages, producers, setcode, sites, transact,
+    x_sites,
 };
 use crate::{
     new_account_owned_action, preapprove_action, reg_server, schema_types, set_code_action,
-    solve_dependencies, version_match, AccountNumber, Action, AnyPublicKey, Checksum256, CodeRow,
-    GenesisService, Hex, MethodNumber, MethodString, Pack, PackageDisposition, PackageOp,
-    PackagePreference, Schema, ToSchema, Unpack, Version,
+    solve_dependencies, version_match, AccountNumber, Action, Checksum256, CodeRow, GenesisService,
+    Hex, MethodNumber, MethodString, Pack, PackageDisposition, PackageOp, PackagePreference,
+    Schema, ToSchema, Unpack, Version,
 };
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
@@ -626,24 +626,13 @@ impl<R: Read + Seek> PackagedService<R> {
     pub fn create_account(
         &self,
         account: AccountNumber,
-        key: &Option<AnyPublicKey>,
         sender: AccountNumber,
         actions: &mut Vec<Action>,
     ) -> Result<(), anyhow::Error> {
         if let Some(preapprove) = preapprove_action(sender, account) {
             actions.push(preapprove)
         }
-        if let Some(key) = key {
-            if key.key.service != verify_sig::SERVICE {
-                return Err(Error::InvalidVerifyService)?;
-            }
-            actions.push(
-                auth_sig::Wrapper::pack_from(sender)
-                    .newAccount(account, key.key.rawData.0.clone().into()),
-            );
-        } else {
-            actions.push(new_account_owned_action(sender, account, sender));
-        }
+        actions.push(new_account_owned_action(sender, account, sender));
         Ok(())
     }
 
@@ -652,12 +641,11 @@ impl<R: Read + Seek> PackagedService<R> {
         actions: &mut Vec<Vec<Action>>,
         mut uploader: Option<&mut StagedUpload>,
         sender: AccountNumber,
-        key: &Option<AnyPublicKey>,
     ) -> Result<(), anyhow::Error> {
         // service accounts
         for (account, index, info) in &self.services {
             let mut group = vec![];
-            self.create_account(*account, key, sender, &mut group)?;
+            self.create_account(*account, sender, &mut group)?;
             let code = read(&mut self.archive.by_index(*index)?)?;
             let code_hash: [u8; 32] = Sha256::digest(&code).into();
             if let Some(uploader) = &mut uploader {
@@ -693,7 +681,7 @@ impl<R: Read + Seek> PackagedService<R> {
         for account in self.get_accounts() {
             if !self.has_service(*account) {
                 let mut group = vec![];
-                self.create_account(*account, key, sender, &mut group)?;
+                self.create_account(*account, sender, &mut group)?;
                 actions.push(group);
             }
         }

--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -701,7 +701,7 @@ impl Chain {
                         package.version()
                     ));
                     let mut account_actions = vec![];
-                    package.install_accounts(&mut account_actions, None, sender, &None)?;
+                    package.install_accounts(&mut account_actions, None, sender)?;
                     builder.push_all(account_actions)?;
                     let mut actions = vec![];
                     package.install(


### PR DESCRIPTION
We're not using it, and it works poorly with package updates.