### PR TITLE
Miscellaneous CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1193,7 +1193,7 @@ function(write_package_index target dir)
     add_custom_command(
         OUTPUT ${dir}/index.json
         DEPENDS ${deps}
-        COMMAND /usr/bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/make_package_index.sh ${CMAKE_COMMAND} ${dir} ${ARGN} >${dir}/index.json
+        COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/make_package_index.sh ${CMAKE_COMMAND} ${dir} ${ARGN} >${dir}/index.json
     )
     add_custom_target(${target} ALL DEPENDS ${dir}/index.json)
 endfunction()

--- a/libraries/psibase/native/tests/CMakeLists.txt
+++ b/libraries/psibase/native/tests/CMakeLists.txt
@@ -1,8 +1,7 @@
 find_package(Threads REQUIRED)
 
-
-link_directories(WatchdogTests ${ICU_LIBRARY_DIR} )
 add_executable(WatchdogTests WatchdogTests.cpp)
+target_link_directories(WatchdogTests PUBLIC ${ICU_LIBRARY_DIR})
 target_link_libraries(WatchdogTests psibase Catch2::Catch2WithMain Threads::Threads)
 add_test(NAME WatchdogTests COMMAND WatchdogTests)
 


### PR DESCRIPTION
These are two of the real issues identified in #1805, but fixed correctly here.

- The canonical location of bash is `/bin/bash`
- `link_directories` doesn't take a target. `target_link_directories` does.