### PR TITLE
Automatically invalidate staged-tx approvals when an account's auth is changed

### DIFF
--- a/packages/system/Accounts/include/services/system/Accounts.hpp
+++ b/packages/system/Accounts/include/services/system/Accounts.hpp
@@ -26,8 +26,16 @@ namespace SystemService
    {
       psibase::AccountNumber accountNum;
       psibase::AccountNumber authService;
+      /// authSequence is used to prevent authorization for actions
+      /// from carrying over when an account's authorization is changed.
+      /// Services such as staged-tx that remember approvals should
+      /// also record the current authSequence when the approval was
+      /// given and invalidate the approval if the authSequence
+      /// has changed. The sequence is 64 bits, to make cycling it
+      /// infeasible.
+      std::uint64_t authSequence;
    };
-   PSIO_REFLECT(Account, accountNum, authService)
+   PSIO_REFLECT(Account, accountNum, authService, authSequence)
    using AccountTable = psibase::Table<Account, &Account::accountNum>;
    PSIO_REFLECT_TYPENAME(AccountTable)
 
@@ -86,6 +94,11 @@ namespace SystemService
 
       /// Return value indicates whether the account `name` exists
       bool exists(psibase::AccountNumber name);
+
+      /// An auth service should call this whenever an account's
+      /// auth rules change. Has no effect if the sender is not
+      /// the account's auth service.
+      void incAuthSeq(psibase::AccountNumber name);
    };
 
    PSIO_REFLECT(Accounts,
@@ -96,6 +109,7 @@ namespace SystemService
                 method(getAccount, name),
                 method(getAuthOf, account),
                 method(exists, name),
+                method(incAuthSeq, name),
                 //
    )
 

--- a/packages/system/Accounts/src/Accounts.cpp
+++ b/packages/system/Accounts/src/Accounts.cpp
@@ -98,8 +98,9 @@ namespace SystemService
       check(accountIndex.get(authService) != std::nullopt, "unknown auth service");
 
       Account account{
-          .accountNum  = name,
-          .authService = authService,
+          .accountNum   = name,
+          .authService  = authService,
+          .authSequence = 0,
       };
       accountTable.put(account);
 
@@ -119,6 +120,7 @@ namespace SystemService
       to<AuthInterface>(authService).canAuthUserSys(getSender());
 
       account->authService = authService;
+      ++account->authSequence;
       accountTable.put(*account);
    }
 
@@ -135,6 +137,17 @@ namespace SystemService
       auto accountRow = getAccount(account);
       check(accountRow.has_value(), "account " + account.str() + " does not exist");
       return accountRow->authService;
+   }
+
+   void Accounts::incAuthSeq(psibase::AccountNumber name)
+   {
+      auto accountTable = open<AccountTable>();
+      auto accountRow   = accountTable.getIndex<0>().get(name);
+      if (accountRow && accountRow->authService == getSender())
+      {
+         ++accountRow->authSequence;
+         accountTable.put(*accountRow);
+      }
    }
 
    bool Accounts::exists(AccountNumber name)

--- a/packages/system/AuthDelegate/src/AuthDelegate.cpp
+++ b/packages/system/AuthDelegate/src/AuthDelegate.cpp
@@ -89,6 +89,8 @@ namespace SystemService
          abortMessage("circular ownership");
       }
 
+      to<Accounts>().incAuthSeq(sender);
+
       table.put(AuthDelegateRecord{.account = getSender(), .owner = owner});
    }
 

--- a/packages/system/StagedTx/service/cpp/include/services/system/StagedTx.hpp
+++ b/packages/system/StagedTx/service/cpp/include/services/system/StagedTx.hpp
@@ -26,6 +26,7 @@ namespace SystemService
    {
       uint32_t               id;
       psibase::AccountNumber account;
+      uint64_t               seq;
       bool                   accepted;
    };
    PSIO_REFLECT(Response, id, account, accepted)

--- a/packages/system/StagedTx/service/src/db.rs
+++ b/packages/system/StagedTx/service/src/db.rs
@@ -77,6 +77,9 @@ pub mod tables {
         /// The account that responded to the staged transaction
         pub account: AccountNumber,
 
+        /// The account's authSequence when the response was made
+        pub seq: u64,
+
         /// Whether the response is an acceptance or rejection
         pub accepted: bool,
     }
@@ -229,7 +232,7 @@ pub mod impls {
             ResponseTable::new()
                 .get_index_pk()
                 .range((self.id, AccountNumber::MIN)..=(self.id, AccountNumber::MAX))
-                .filter(|response| response.accepted)
+                .filter(|response| response.accepted && response.is_valid())
                 .map(|response| response.account)
                 .collect()
         }
@@ -238,7 +241,7 @@ pub mod impls {
             ResponseTable::new()
                 .get_index_pk()
                 .range((self.id, AccountNumber::MIN)..=(self.id, AccountNumber::MAX))
-                .filter(|response| !response.accepted)
+                .filter(|response| !response.accepted && response.is_valid())
                 .map(|response| response.account)
                 .collect()
         }
@@ -258,20 +261,24 @@ pub mod impls {
     impl Response {
         fn upsert(id: u32, accepted: bool) {
             let table = ResponseTable::new();
-            let response = table
-                .get_index_pk()
-                .get(&(id, get_sender()))
-                .map(|mut response| {
-                    response.accepted = accepted;
-                    response
-                })
-                .unwrap_or_else(|| Response {
-                    id,
-                    account: get_sender(),
-                    accepted,
-                });
+            let account = get_sender();
+            let seq = Accounts::call().getAccount(account).unwrap().authSequence;
 
-            table.put(&response).unwrap();
+            table
+                .put(&Response {
+                    id,
+                    account,
+                    seq,
+                    accepted,
+                })
+                .unwrap();
+        }
+        fn is_valid(&self) -> bool {
+            return Accounts::call()
+                .getAccount(self.account)
+                .unwrap()
+                .authSequence
+                == self.seq;
         }
     }
 

--- a/packages/system/StagedTx/service/src/tests.rs
+++ b/packages/system/StagedTx/service/src/tests.rs
@@ -4,6 +4,8 @@
 mod tests {
     use crate::Wrapper;
     use psibase::fracpack::Pack;
+    use psibase::services::accounts::Wrapper as Accounts;
+    use psibase::services::auth_delegate::Wrapper as AuthDelegate;
     use psibase::services::nft as Nft;
     use psibase::*;
     use serde::Deserialize;
@@ -83,11 +85,200 @@ mod tests {
 
         let txid = Wrapper::push(&chain).get_staged_tx(id).get()?.txid;
 
-        Wrapper::push_from(&chain, bob)
-            .accept(id, txid)
-            .get()?;
+        Wrapper::push_from(&chain, bob).accept(id, txid).get()?;
 
         assert_eq!(get_nr_nfts(&chain, bob)?, 1);
+
+        Ok(())
+    }
+
+    struct TestTransaction<'a> {
+        chain: &'a Chain,
+        id: u32,
+        account: AccountNumber,
+    }
+
+    impl<'a> TestTransaction<'a> {
+        // Creates a new staged transaction that must be approved
+        // by all the given accounts
+        pub fn new(chain: &'a Chain, accounts: &[AccountNumber]) -> Result<Self, Error> {
+            let id = Wrapper::push(&chain)
+                .propose(
+                    accounts
+                        .iter()
+                        .map(|account| Nft::Wrapper::pack_from(*account).mint())
+                        .collect(),
+                    true,
+                )
+                .get()?;
+            Ok(Self {
+                chain,
+                id,
+                account: accounts[0],
+            })
+        }
+        // Returns true if the staged transaction was executed
+        pub fn approve(&self, account: AccountNumber) -> Result<bool, Error> {
+            let prev_nfts = get_nr_nfts(self.chain, self.account)?;
+            let txid = Wrapper::push(self.chain).get_staged_tx(self.id).get()?.txid;
+            Wrapper::push_from(self.chain, account)
+                .accept(self.id, txid)
+                .get()?;
+            Ok(get_nr_nfts(self.chain, self.account)? != prev_nfts)
+        }
+    }
+
+    #[psibase::test_case(packages("StagedTx"))]
+    fn test_change_auth_serv(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let alice = account!("alice");
+        chain.new_account(alice)?;
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+        let carol = account!("carol");
+        chain.new_account(carol)?;
+
+        let tx = TestTransaction::new(&chain, &[alice, bob])?;
+        assert!(!tx.approve(alice)?);
+
+        // Setting the account owner should invalidate the approval from alice
+        AuthDelegate::push_from(&chain, alice)
+            .setOwner(carol)
+            .get()?;
+        Accounts::push_from(&chain, alice)
+            .setAuthServ(AuthDelegate::SERVICE)
+            .get()?;
+
+        assert!(!tx.approve(bob)?);
+        assert!(tx.approve(carol)?);
+        Ok(())
+    }
+
+    #[psibase::test_case(packages("StagedTx"))]
+    fn test_change_set_unused_owner(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let alice = account!("alice");
+        chain.new_account(alice)?;
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+        let carol = account!("carol");
+        chain.new_account(carol)?;
+
+        let tx = TestTransaction::new(&chain, &[alice, bob])?;
+        assert!(!tx.approve(alice)?);
+
+        // This should have no effect, because auth-delegate is not alice's
+        // auth service
+        AuthDelegate::push_from(&chain, alice)
+            .setOwner(carol)
+            .get()?;
+
+        assert!(tx.approve(bob)?);
+
+        Ok(())
+    }
+
+    #[psibase::test_case(packages("StagedTx"))]
+    fn test_change_owner(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let alice = account!("alice");
+        chain.new_account(alice)?;
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+        let carol = account!("carol");
+        chain.new_account(carol)?;
+        let dave = account!("dave");
+        chain.new_account(dave)?;
+
+        AuthDelegate::push_from(&chain, alice)
+            .setOwner(carol)
+            .get()?;
+        Accounts::push_from(&chain, alice)
+            .setAuthServ(AuthDelegate::SERVICE)
+            .get()?;
+
+        let tx = TestTransaction::new(&chain, &[alice, bob])?;
+        assert!(!tx.approve(alice)?);
+
+        // Changing the account owner should invalidate the approval from alice
+        AuthDelegate::push_from(&chain, alice)
+            .setOwner(dave)
+            .get()?;
+
+        assert!(!tx.approve(bob)?);
+        assert!(tx.approve(dave)?);
+
+        Ok(())
+    }
+
+    #[psibase::test_case(packages("StagedTx"))]
+    fn test_change_auth_chained(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let alice = account!("alice");
+        chain.new_account(alice)?;
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+        let carol = account!("carol");
+        chain.new_account(carol)?;
+        let dave = account!("dave");
+        chain.new_account(dave)?;
+
+        AuthDelegate::push_from(&chain, alice)
+            .setOwner(carol)
+            .get()?;
+        Accounts::push_from(&chain, alice)
+            .setAuthServ(AuthDelegate::SERVICE)
+            .get()?;
+
+        let tx = TestTransaction::new(&chain, &[alice, bob])?;
+        assert!(!tx.approve(carol)?);
+
+        // Changing the account owner should invalidate the approval from carol
+        AuthDelegate::push_from(&chain, carol)
+            .setOwner(dave)
+            .get()?;
+        Accounts::push_from(&chain, carol)
+            .setAuthServ(AuthDelegate::SERVICE)
+            .get()?;
+
+        assert!(!tx.approve(bob)?);
+        assert!(tx.approve(dave)?);
+
+        Ok(())
+    }
+
+    #[psibase::test_case(packages("StagedTx"))]
+    fn test_change_owner_chained(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        let alice = account!("alice");
+        chain.new_account(alice)?;
+        let bob = account!("bob");
+        chain.new_account(bob)?;
+        let carol = account!("carol");
+        chain.new_account(carol)?;
+        let dave = account!("dave");
+        chain.new_account(dave)?;
+        let eliza = account!("eliza");
+        chain.new_account(eliza)?;
+
+        AuthDelegate::push_from(&chain, alice)
+            .setOwner(carol)
+            .get()?;
+        Accounts::push_from(&chain, alice)
+            .setAuthServ(AuthDelegate::SERVICE)
+            .get()?;
+        AuthDelegate::push_from(&chain, carol)
+            .setOwner(dave)
+            .get()?;
+        Accounts::push_from(&chain, carol)
+            .setAuthServ(AuthDelegate::SERVICE)
+            .get()?;
+
+        let tx = TestTransaction::new(&chain, &[alice, bob])?;
+        assert!(!tx.approve(carol)?);
+
+        // Changing the account owner should invalidate the approval from carol
+        AuthDelegate::push_from(&chain, carol)
+            .setOwner(eliza)
+            .get()?;
+
+        assert!(!tx.approve(bob)?);
+        assert!(tx.approve(eliza)?);
 
         Ok(())
     }

--- a/rust/psibase/src/services/accounts.rs
+++ b/rust/psibase/src/services/accounts.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub struct Account {
     pub accountNum: AccountNumber,
     pub authService: AccountNumber,
+    pub authSequence: u64,
 }
 
 #[crate::service(name = "accounts", dispatch = false, psibase_mod = "crate")]
@@ -49,6 +50,11 @@ mod service {
 
     #[action]
     fn getAuthOf(account: AccountNumber) -> AccountNumber {
+        unimplemented!()
+    }
+
+    #[action]
+    fn incAuthSeq(num: AccountNumber) {
         unimplemented!()
     }
 }


### PR DESCRIPTION
When a package is installed it will create new accounts if they don't exist and will verify that any existing accounts have the correct auth (auth-delegate to account used to install).

The problem: Any account can have its auth changed to match what package installation expects, while still having undesirable state.

Cancelling any pending staged transaction approvals is not a complete solution for this problem, but it significantly mitigates it, and is a hard requirement for any more complete solution.
