### PR TITLE
Add minimial transact service for testing consensus

### DIFF
--- a/libraries/net/test/main.cpp
+++ b/libraries/net/test/main.cpp
@@ -14,7 +14,7 @@ struct ConsoleLog
    std::string filter = "Severity > critical";
    std::string format =
        "[{TimeStamp}] [{Severity}] [{Host}]: {Message}{?: {TransactionId}}{?: {BlockId}: "
-       "{BlockHeader}}";
+       "{BlockHeader}}{Indent:4:{TraceConsole}}";
 };
 PSIO_REFLECT(ConsoleLog, type, filter, format);
 

--- a/libraries/net/test/test_util.cpp
+++ b/libraries/net/test/test_util.cpp
@@ -80,40 +80,10 @@ auto makeBoot(const ConsensusData& producers, bool ec) -> std::vector<SignedTran
 {
    std::vector<SignedTransaction> result;
    std::vector<GenesisService>    services = {{
-                                                  .service = Transact::service,
-                                                  .flags   = Transact::serviceFlags,
-                                                  .code    = readWholeFile("Transact.wasm"),
-                                           },
-                                              {
-                                                  .service = RTransact::service,
-                                                  .flags   = 0,
-                                                  .code    = readWholeFile("RTransact.wasm"),
-                                           },
-                                              {
-                                                  .service = CpuLimit::service,
-                                                  .flags   = CpuLimit::serviceFlags,
-                                                  .code    = readWholeFile("MockCpuLimit.wasm"),
-                                           },
-                                              {
-                                                  .service = Accounts::service,
-                                                  .flags   = 0,
-                                                  .code    = readWholeFile("Accounts.wasm"),
-                                           },
-                                              {
-                                                  .service = Producers::service,
-                                                  .flags   = Producers::serviceFlags,
-                                                  .code    = readWholeFile("Producers.wasm"),
-                                           },
-                                              {
-                                                  .service = AuthAny::service,
-                                                  .flags   = 0,
-                                                  .code    = readWholeFile("AuthAny.wasm"),
-                                           },
-                                              {
-                                                  .service = Db::service,
-                                                  .flags   = Db::flags,
-                                                  .code    = readWholeFile("Db.wasm"),
-                                           }};
+       .service = Transact::service,
+       .flags   = Transact::serviceFlags,
+       .code    = readWholeFile("MockTransact.wasm"),
+   }};
    if (ec)
    {
       services.push_back({
@@ -122,7 +92,6 @@ auto makeBoot(const ConsensusData& producers, bool ec) -> std::vector<SignedTran
           .code    = readWholeFile("VerifySig.wasm"),
       });
    }
-   // Transact + Producers + AuthAny + Accounts
    result.push_back({Transaction{
        //
        .actions = {
@@ -131,23 +100,11 @@ auto makeBoot(const ConsensusData& producers, bool ec) -> std::vector<SignedTran
                   .service = AccountNumber{"psibase"},  // ignored
                   .method  = MethodNumber{"boot"},
                   .rawData = psio::convert_to_frac(GenesisActionData{.services = services})}}}});
+   result.push_back(
+       {Transaction{.tapos   = {.expiration = TimePointSec{Seconds(2)}},
+                    .actions = {transactor<Producers>(Producers::service, Producers::service)
+                                    .setConsensus(producers)}}});
 
-   result.push_back({Transaction{
-       .tapos   = {.expiration = TimePointSec{Seconds(2)}},
-       .actions = {
-           Action{.sender  = Transact::service,
-                  .service = Transact::service,
-                  .method  = MethodNumber{"startBoot"},
-                  .rawData = psio::to_frac(std::tuple(std::vector<Checksum256>()))},
-           Action{.sender  = Accounts::service,
-                  .service = Accounts::service,
-                  .method  = MethodNumber{"init"},
-                  .rawData = psio::to_frac(std::tuple())},
-           transactor<Producers>(Producers::service, Producers::service).setConsensus(producers),
-           Action{.sender  = Transact::service,
-                  .service = Transact::service,
-                  .method  = MethodNumber{"finishBoot"},
-                  .rawData = psio::to_frac(std::tuple())}}}});
    return result;
 }
 

--- a/packages/psibase_tests/CMakeLists.txt
+++ b/packages/psibase_tests/CMakeLists.txt
@@ -27,6 +27,7 @@ function(add suffix)
     service(SetWasmConfig "${suffix}" src/SetWasmConfig.cpp)
     service(XSudo "${suffix}" src/XSudo.cpp)
     service(AsRpc "${suffix}" src/AsRpc.cpp)
+    service(MockTransact "${suffix}" src/MockTransact.cpp)
 
     set(TEST_GENERATE_SCHEMA 1)
     service(MockCpuLimit "${suffix}" src/MockCpuLimit.cpp)

--- a/packages/psibase_tests/src/MockTransact.cpp
+++ b/packages/psibase_tests/src/MockTransact.cpp
@@ -1,0 +1,77 @@
+#include <psibase/dispatch.hpp>
+#include <psibase/nativeTables.hpp>
+#include <psibase/serviceEntry.hpp>
+#include <services/system/Producers.hpp>
+#include <services/system/Transact.hpp>
+
+namespace TestService
+{
+
+   // A bare bones implementation of transact that
+   // is used to test the consensus algorithm.
+   struct MockTransact : psibase::Service
+   {
+      static constexpr auto service = SystemService::Transact::service;
+      void                  startBlock();
+      /// Called by native code on objective writes to the database
+      void kvNotify(psibase::AccountNumber service,
+                    psibase::DbId          db,
+                    std::uint32_t          keyLen,
+                    std::uint32_t          oldValueLen,
+                    std::uint32_t          newValueLen);
+      void setConsensus(psibase::ConsensusData consensus);
+   };
+   PSIO_REFLECT(MockTransact,
+                method(startBlock),
+                method(kvNotify, service, db, keyLen, oldValueLen, newValueLen))
+
+}  // namespace TestService
+
+using namespace TestService;
+using namespace SystemService;
+using namespace psibase;
+
+void MockTransact::startBlock() {}
+
+void MockTransact::kvNotify(psibase::AccountNumber service,
+                            psibase::DbId          db,
+                            std::uint32_t          keyLen,
+                            std::uint32_t          oldValueLen,
+                            std::uint32_t          newValueLen)
+{
+}
+
+void MockTransact::setConsensus(ConsensusData consensus)
+{
+   auto table  = Native::tablesDirect().open<StatusTable>();
+   auto status = table.get({});
+   check(status.has_value(), "Missing status row");
+   check(!status->consensus.next || status->consensus.next->blockNum == status->current.blockNum,
+         "Consensus update pending");
+   status->consensus.next = {{std::move(consensus), status->consensus.current.services,
+                              status->consensus.current.wasmConfig},
+                             status->current.blockNum};
+   table.put(*status);
+}
+
+extern "C" [[clang::export_name("processTransaction")]] void processTransaction()
+{
+   auto top_act                = getCurrentActionView();
+   auto args                   = psio::view<const ProcessTransactionArgs>(top_act->rawData());
+   psibase::internal::receiver = Transact::service;
+
+   for (auto act : args.transaction()->actions())
+   {
+      check(act.service() == Producers::service, "wrong service");
+      check(act.method() == MethodNumber{"setConsensus"}, "wrong method");
+      auto [consensus] = psio::from_frac<std::tuple<ConsensusData>>(act.rawData());
+      MockTransact{}.setConsensus(std::move(consensus));
+   }
+}
+
+extern "C" [[clang::export_name("nextTransaction")]] void nextTransaction()
+{
+   setRetval(std::optional<std::uint32_t>());
+}
+
+PSIBASE_DISPATCH(MockTransact)


### PR DESCRIPTION
The consensus tests used to break regularly when core system services were updated. This change should prevent that by not using any of the standard system services. Also improves performance of the tests by trimming it down to the absolute minimum (we have to boot a *lot* of chains).