### PR TITLE
Handle flags in local packages

### DIFF
--- a/packages/local/XAdmin/src/XAdmin.cpp
+++ b/packages/local/XAdmin/src/XAdmin.cpp
@@ -647,6 +647,13 @@ namespace LocalService
                                 .headers     = std::move(challenges)};
          }
       };
+
+      struct ServiceFlags
+      {
+         std::string isPrivileged  = "0";
+         std::string isReplacement = "0";
+         PSIO_REFLECT(ServiceFlags, isPrivileged, isReplacement)
+      };
    }  // namespace
 
    void XAdmin::startSession()
@@ -904,6 +911,16 @@ namespace LocalService
             auto native          = Native::subjective(KvMode::readWrite);
             auto codeByHashTable = native.open<CodeByHashTable>();
             auto codeTable       = native.open<CodeTable>();
+            auto parsedFlags     = req.query<ServiceFlags>();
+            auto flags           = std::uint64_t{0};
+            if (parsedFlags.isPrivileged == "1")
+            {
+               flags |= CodeRow::isPrivileged;
+            }
+            if (parsedFlags.isReplacement == "1")
+            {
+               flags |= CodeRow::isReplacement;
+            }
             PSIBASE_SUBJECTIVE_TX
             {
                auto account = codeTable.get(service);
@@ -917,7 +934,7 @@ namespace LocalService
                constexpr std::uint8_t vmVersion = 0;
 
                if (vmType == account->vmType && vmVersion == account->vmVersion &&
-                   codeHash == account->codeHash)
+                   codeHash == account->codeHash && flags == account->flags)
                   return HttpReply{};
 
                // decrement old reference count
@@ -928,7 +945,7 @@ namespace LocalService
                }
 
                account->codeHash  = codeHash;
-               account->flags     = CodeRow::isPrivileged;
+               account->flags     = flags;
                account->vmType    = vmType;
                account->vmVersion = vmVersion;
                codeTable.put(*account);

--- a/packages/local/XAdmin/ui/src/lib/chain-endpoints/install-files.ts
+++ b/packages/local/XAdmin/ui/src/lib/chain-endpoints/install-files.ts
@@ -3,6 +3,21 @@ import { lookup } from "mrmime";
 
 import { siblingUrl } from "@psibase/common-lib";
 
+function parseFlags(flags: string[] | undefined): string {
+    if (flags === undefined || flags.length == 0) {
+        return "";
+    } else {
+        return (
+            "?" +
+            flags
+                .map((name) => {
+                    return `${name}=1`;
+                })
+                .join("&")
+        );
+    }
+}
+
 /**
  * Install a single service from the package
  */
@@ -20,7 +35,12 @@ export async function installService(
     }
 
     const wasmData = await wasmFile.async("arraybuffer");
-    const response = await fetch(`/services/${serviceName}`, {
+
+    const info = JSON.parse(await jsonMetaFile.async("text"));
+
+    const flags = parseFlags(info.flags);
+
+    const response = await fetch(`/services/${serviceName}${flags}`, {
         method: "PUT",
         headers: {
             "Content-Type": "application/wasm",
@@ -35,7 +55,6 @@ export async function installService(
         );
     }
 
-    const info = JSON.parse(await jsonMetaFile.async("text"));
     if (info.server) {
         const response = await fetch(
             siblingUrl(null, "x-http", "/register_server"),

--- a/packages/psibase_tests/test/test.cpp
+++ b/packages/psibase_tests/test/test.cpp
@@ -58,7 +58,7 @@ TEST_CASE("import/export handles")
    t.http(HttpRequest{
        .host        = "x-admin.psibase.io",
        .method      = "PUT",
-       .target      = "/services/" + TestExport::service.str(),
+       .target      = "/services/" + TestExport::service.str() + "?isPrivileged=1",
        .contentType = "application/wasm",
        .body        = readWholeFile("TestExport.wasm"),
    });

--- a/programs/psinode/tests/services.py
+++ b/programs/psinode/tests/services.py
@@ -104,16 +104,30 @@ class XAdmin(Service):
     def install(self, file):
         from zipfile import ZipFile
         with ZipFile(file) as package:
+            services = {}
+            class Filenames:
+                def __init__(self):
+                    self.json = None
+                    self.wasm = None
             for filename in package.namelist():
                 if filename.startswith('service/') and filename.endswith('.json'):
                     service = filename.removeprefix('service/').removesuffix('.json')
-                    with package.open(filename) as f:
+                    services.setdefault(service, Filenames()).json = filename
+                if filename.startswith('service/') and filename.endswith('.wasm'):
+                    service = filename.removeprefix('service/').removesuffix('.wasm')
+                    services.setdefault(service, Filenames()).wasm = filename
+            for (service, filenames) in services.items():
+                flags = ''
+                if filenames.json is not None:
+                    with package.open(filenames.json) as f:
                         info = json.load(f)
                     server = info.get('server')
                     if server is not None:
                         XHttp(self.api).register_server(service, server)
-                if filename.startswith('service/') and filename.endswith('.wasm'):
-                    service = filename.removeprefix('service/').removesuffix('.wasm')
-                    with package.open(filename) as f:
-                        with self.put('/services/' + service, data=f, headers={'Content-Type': 'application/wasm'}) as reply:
+                    flagsList = info.get('flags', [])
+                    if len(flagsList) != 0:
+                        flags = '?' + '&'.join(f + '=1' for f in flagsList)
+                if filenames.wasm is not None:
+                    with package.open(filenames.wasm) as f:
+                        with self.put('/services/' + service + flags, data=f, headers={'Content-Type': 'application/wasm'}) as reply:
                             reply.raise_for_status()

--- a/rust/psibase/src/package.rs
+++ b/rust/psibase/src/package.rs
@@ -367,6 +367,25 @@ fn translate_flags(flags: &[String]) -> Result<u64, Error> {
     Ok(result)
 }
 
+fn translate_local_flags(flags: &[String]) -> Result<String, Error> {
+    let mut result = String::new();
+    for flag in flags {
+        match flag.as_str() {
+            "isPrivileged" => {}
+            "isReplacement" => {}
+            _ => Err(Error::InvalidFlags)?,
+        };
+        if result.is_empty() {
+            result += "?";
+        } else {
+            result += "&";
+        }
+        result += flag;
+        result += "=1";
+    }
+    Ok(result)
+}
+
 fn read<T: Read>(reader: &mut T) -> Result<Vec<u8>, anyhow::Error> {
     let mut result = vec![];
     reader.read_to_end(&mut result)?;
@@ -948,11 +967,11 @@ impl<R: Read + Seek> PackagedService<R> {
             }
             crate::as_text(
                 client
-                    .put(
-                        x_admin::SERVICE
-                            .url(base_url)?
-                            .join(&format!("/services/{}", account))?,
-                    )
+                    .put(x_admin::SERVICE.url(base_url)?.join(&format!(
+                        "/services/{}{}",
+                        account,
+                        translate_local_flags(&info.flags)?
+                    ))?)
                     .body(read(&mut self.archive.by_index(*index)?)?)
                     .header("Content-Type", "application/wasm"),
             )


### PR DESCRIPTION
Previously, `PUT` to `/services/*` couldn't control the code flags, so it just hard-coded `isPrivileged`. This change allows deploying non-privileged local services, and also allows setting the `isReplacement` flag.