### PR TITLE
Make startBlock a transaction

### DIFF
--- a/libraries/psibase/native/include/psibase/ForkDb.hpp
+++ b/libraries/psibase/native/include/psibase/ForkDb.hpp
@@ -1196,7 +1196,6 @@ namespace psibase
                auto claim = validateBlockSignature(prev, state->info, blockPtr->signature());
                ctx.start(Block(blockPtr->block()));
                validateTransactionSignatures(ctx, ctx.current, prev->revision);
-               ctx.callStartBlock();
                ctx.execAllInBlock();
                auto [newRevision, id] = ctx.writeRevision(FixedProver(blockPtr->signature()), claim,
                                                           state->getProdsAuthRevision());
@@ -2030,7 +2029,7 @@ namespace psibase
 
          // TODO: This can run concurrently
          BlockContext     bc{*systemContext, systemContext->sharedDatabase.getHead(),
-                         systemContext->sharedDatabase.createWriter(), true};
+                             systemContext->sharedDatabase.createWriter(), true};
          TransactionTrace trace;
          try
          {

--- a/libraries/psibase/native/src/BlockContext.cpp
+++ b/libraries/psibase/native/src/BlockContext.cpp
@@ -142,32 +142,23 @@ namespace psibase
       if (current.header.blockNum == 2)
          return;
 
-      checkActive();
-      active = false;
-
-      Action action{
-          .sender  = {},
-          .service = transactionServiceNum,
-          .method  = MethodNumber("startBlock"),
-          .rawData = psio::to_frac(std::tuple()),
-      };
-      SignedTransaction  trx;
-      TransactionTrace   trace;
-      TransactionContext tc{*this, trx, trace, DbMode::transaction()};
-      auto&              atrace = trace.actionTraces.emplace_back();
+      SignedTransaction trx{.transaction{Transaction{
+          .tapos   = {.expiration = std::chrono::ceil<Seconds>(current.header.time + Seconds(1))},
+          .actions = {{
+              .sender  = {},
+              .service = transactionServiceNum,
+              .method  = MethodNumber("startBlock"),
+              .rawData = psio::to_frac(std::tuple()),
+          }},
+      }}};
+      TransactionTrace  trace;
 
       // Failure here aborts the block since Transact relies on startBlock
       // functioning correctly. Fixing this type of failure requires forking
       // the chain, just like fixing bugs which block transactions within
       // Transact's processTransaction may require forking the chain.
       //
-      // TODO: log failure
-      tc.execNonTrxAction(0, action, atrace);
-      BOOST_LOG_SCOPED_LOGGER_TAG(trxLogger, "Trace", trace);
-      PSIBASE_LOG(trxLogger, debug) << "startBlock succeeded";
-      // printf("%s\n", prettyTrace(atrace).c_str());
-
-      active = true;
+      pushTransaction(std::move(trx), trace, std::nullopt, false, true);
    }
 
    void BlockContext::callOnBlock()

--- a/libraries/psibase/tester/src/tester.cpp
+++ b/libraries/psibase/tester/src/tester.cpp
@@ -281,6 +281,19 @@ namespace
       expect(tester::runAction(self.nativeHandle(), RunMode::rpc, true, xhttp.startSession()));
    }
 
+   psibase::SignedTransaction makeStartBlock(psibase::TimePointUSec expiration)
+   {
+      return {.transaction{{
+          .tapos   = {.expiration = std::chrono::ceil<psibase::Seconds>(expiration)},
+          .actions = {{
+              .sender  = {},
+              .service = psibase::transactionServiceNum,
+              .method  = psibase::MethodNumber("startBlock"),
+              .rawData = psio::to_frac(std::tuple()),
+          }},
+      }}};
+   }
+
 }  // namespace
 
 psibase::TestChain::TestChain(uint32_t chain_id, bool clone, bool pub, bool init, bool writable)
@@ -404,11 +417,16 @@ void psibase::TestChain::startBlock(BlockTime tp)
    {
       tester::raw::startBlock(id, (tp - Seconds(1)).time_since_epoch().count(), producer.value,
                               term, commitNum);
+      tester::pushTransaction(id, makeStartBlock(tp));
       finishBlock();
       commitNum = status->head.value().header.blockNum;
    }
    tester::raw::startBlock(id, tp.time_since_epoch().count(), producer.value, term, commitNum);
-   status    = kvGet<psibase::StatusRow>(psibase::StatusRow::db, psibase::statusKey());
+   status = kvGet<psibase::StatusRow>(psibase::StatusRow::db, psibase::statusKey());
+   if (status && status->head)
+   {
+      tester::pushTransaction(id, makeStartBlock(tp + Seconds(1)));
+   }
    producing = true;
 }
 
@@ -762,9 +780,9 @@ std::string psibase::TestChain::login(AccountNumber user, AccountNumber service)
 {
    transactor<LoginInterface> loginTransactor{user, service};
    Tapos             tapos{.expiration = std::chrono::time_point_cast<std::chrono::seconds>(
-                                 std::chrono::system_clock::now()) +
-                             std::chrono::seconds(10),
-                           .flags = Tapos::do_not_broadcast_flag};
+                                             std::chrono::system_clock::now()) +
+                                         std::chrono::seconds(10),
+                           .flags      = Tapos::do_not_broadcast_flag};
    Transaction       trx{.tapos = tapos, .actions = {loginTransactor.loginSys("psibase.io")}};
    SignedTransaction strx{trx};
    auto reply = post<SystemService::LoginReply>(SystemService::Transact::service, "/login",

--- a/packages/psibase_tests/src/MockTransact.cpp
+++ b/packages/psibase_tests/src/MockTransact.cpp
@@ -12,7 +12,6 @@ namespace TestService
    struct MockTransact : psibase::Service
    {
       static constexpr auto service = SystemService::Transact::service;
-      void                  startBlock();
       /// Called by native code on objective writes to the database
       void kvNotify(psibase::AccountNumber service,
                     psibase::DbId          db,
@@ -21,17 +20,13 @@ namespace TestService
                     std::uint32_t          newValueLen);
       void setConsensus(psibase::ConsensusData consensus);
    };
-   PSIO_REFLECT(MockTransact,
-                method(startBlock),
-                method(kvNotify, service, db, keyLen, oldValueLen, newValueLen))
+   PSIO_REFLECT(MockTransact, method(kvNotify, service, db, keyLen, oldValueLen, newValueLen))
 
 }  // namespace TestService
 
 using namespace TestService;
 using namespace SystemService;
 using namespace psibase;
-
-void MockTransact::startBlock() {}
 
 void MockTransact::kvNotify(psibase::AccountNumber service,
                             psibase::DbId          db,
@@ -62,6 +57,8 @@ extern "C" [[clang::export_name("processTransaction")]] void processTransaction(
 
    for (auto act : args.transaction()->actions())
    {
+      if (isStartBlock(act))
+         continue;
       check(act.service() == Producers::service, "wrong service");
       check(act.method() == MethodNumber{"setConsensus"}, "wrong method");
       auto [consensus] = psio::from_frac<std::tuple<ConsensusData>>(act.rawData());

--- a/packages/psibase_tests/test/test_notify.cpp
+++ b/packages/psibase_tests/test/test_notify.cpp
@@ -79,6 +79,9 @@ TEST_CASE("notify onTransaction")
    static constexpr auto notify2 = AccountNumber{"notify2"};
    t.addService(NotifyService::service, "NotifyService.wasm");
    t.addService(notify2, "NotifyService.wasm");
+   // startBlock causes an extra transaction that will
+   // throw our counts off.
+   t.setAutoBlockStart(false);
    for (auto service : {NotifyService::service, notify2})
    {
       t.from(Transact::service)
@@ -100,7 +103,7 @@ TEST_CASE("notify onTransaction")
       CHECK(row->count == 1);
    }
    fail.put({});
-   REQUIRE(t.from(Nop::service).to<Nop>().nop().succeeded());
+   REQUIRE(t.from(Nop::service).to<Nop>().withId(0).succeeded());
    {
       auto row = table1.get({});
       REQUIRE(row.has_value());
@@ -112,7 +115,7 @@ TEST_CASE("notify onTransaction")
       CHECK(row->count == 2);
    }
    fail.remove({});
-   REQUIRE(t.from(Nop::service).to<Nop>().nop().succeeded());
+   REQUIRE(t.from(Nop::service).to<Nop>().withId(1).succeeded());
    {
       auto row = table1.get({});
       REQUIRE(row.has_value());

--- a/packages/system/Transact/include/services/system/Transact.hpp
+++ b/packages/system/Transact/include/services/system/Transact.hpp
@@ -215,8 +215,9 @@ namespace SystemService
    struct BlockSummary
    {
       std::array<uint32_t, 256> blockSuffixes;
+      std::uint32_t             blockNum;
    };
-   PSIO_REFLECT(BlockSummary, blockSuffixes)
+   PSIO_REFLECT(BlockSummary, blockSuffixes, blockNum)
    using BlockSummaryTable = psibase::Table<BlockSummary, psibase::SingletonKey{}>;
    PSIO_REFLECT_TYPENAME(BlockSummaryTable)
 
@@ -572,6 +573,10 @@ namespace SystemService
          if (!(stat->head->header.blockNum & 0x1fff))
             update((stat->head->header.blockNum >> 13) | 0x80);
       }
+      if (stat)
+      {
+         summary->blockNum = stat->current.blockNum;
+      }
       return *summary;
    }  // getBlockSummary()
 
@@ -588,5 +593,15 @@ namespace SystemService
       }
       else
          return {0, 0};  // Usable for transactions in the genesis block
+   }
+
+   inline bool isStartBlock(psio::view<const psibase::Action> act)
+   {
+      return act.sender() == psibase::AccountNumber{} && act.service() == Transact::service &&
+             act.method() == psibase::MethodNumber{"startBlock"};
+   }
+   inline bool isStartBlock(psio::view<const psibase::Transaction> tx)
+   {
+      return tx.actions().size() == 1 && isStartBlock(tx.actions()[0]);
    }
 }  // namespace SystemService

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -423,7 +423,10 @@ namespace SystemService
 
    namespace
    {
-      bool checkTapos(const Checksum256& id, const Tapos& tapos, bool speculative)
+      bool checkTapos(const Checksum256& id,
+                      const Tapos&       tapos,
+                      bool               speculative,
+                      bool               isStartBlock)
       {
          auto statusTable =
              Transact{}.open<TransactStatusTable>(speculative ? KvMode::read : KvMode::readWrite);
@@ -437,7 +440,6 @@ namespace SystemService
          check(stat.current.time < tapos.expiration, "transaction has expired");
          check(tapos.expiration < stat.current.time + maxTrxLifetime,
                "transaction was submitted too early");
-
          auto transactStatus = statusIdx.get(std::tuple{});
 
          std::optional<BlockSummary> summary;
@@ -446,6 +448,31 @@ namespace SystemService
          else
             summary = summaryIdx.get(std::tuple<>{});
 
+         if (isStartBlock)
+         {
+            if (summary)
+            {
+               check(summary->blockNum + 1 >= getStatus().current.blockNum,
+                     "startBlock was not run in the previous block");
+               check(summary->blockNum + 1 == getStatus().current.blockNum,
+                     "startBlock has already been run");
+            }
+            check(!tapos.refBlockIndex && !tapos.refBlockSuffix,
+                  "tapos must be zero for startBlock");
+            return false;
+         }
+         else
+         {
+            if (!summary)
+            {
+               check(!getStatus().head, "startBlock has not been run");
+            }
+            else
+            {
+               check(summary->blockNum == getStatus().current.blockNum,
+                     "startBlock has not been run");
+            }
+         }
          if (transactStatus && transactStatus->bootTransactions)
          {
             auto& bootTransactions = *transactStatus->bootTransactions;
@@ -536,7 +563,7 @@ namespace SystemService
    {
       check(trx.actions().size() > 0, "transaction has no actions");
       auto _           = recurse();
-      bool enforceAuth = checkTapos(id, trx.tapos(), true);
+      bool enforceAuth = checkTapos(id, trx.tapos(), true, false);
       if (enforceAuth)
          checkAuth(trx.actions().front(), trx.claims(), true, true);
       return enforceAuth;
@@ -575,7 +602,7 @@ namespace SystemService
       check(!includedIdx.get(std::tuple{tapos.expiration, id}), "duplicate transaction");
       includedTable.put({tapos.expiration, id});
 
-      bool enforceAuth = checkTapos(id, tapos, speculative);
+      bool enforceAuth = checkTapos(id, tapos, speculative, isStartBlock(trx));
 
       Actor<CpuLimit> cpuLimit(Transact::service, CpuLimit::service, CallFlags::runModeRpc);
       Actor<Accounts> accounts(Transact::service, Accounts::service);

--- a/packages/user/Nop/include/services/user/Nop.hpp
+++ b/packages/user/Nop/include/services/user/Nop.hpp
@@ -5,7 +5,9 @@ namespace UserService
    struct Nop : psibase::Service
    {
       static constexpr auto service = psibase::AccountNumber{"nop"};
-      void                  nop();
+
+      void nop();
+      void withId(std::uint32_t id);
    };
-   PSIO_REFLECT(Nop, method(nop))
+   PSIO_REFLECT(Nop, method(nop), method(withId, id))
 }  // namespace UserService

--- a/programs/psitest/main.cpp
+++ b/programs/psitest/main.cpp
@@ -289,7 +289,7 @@ struct test_chain
       sys    = std::make_unique<psibase::SystemContext>(
           psibase::SystemContext{this->db,
                                  state.shared_wasm_cache,
-                                    {},
+                                 {},
                                  state.watchdogManager,
                                  std::make_shared<psibase::Sockets>(this->db)});
       state.shared_memory_cache.init(*sys);
@@ -371,7 +371,6 @@ struct test_chain
           std::make_unique<psibase::BlockContext>(*sys, revisionAtBlockStart, writer, true);
 
       blockContext->start(time, producer, term, commitNum);
-      blockContext->callStartBlock();
    }
 
    void start_if_needed()

--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -400,6 +400,28 @@ impl Chain {
         self.start_block_at(current_time + micro_seconds);
     }
 
+    fn push_start_block(&self, expiration: TimePointUSec) {
+        let trx = Transaction {
+            tapos: Tapos {
+                expiration: expiration.ceil_seconds(),
+                refBlockSuffix: 0,
+                flags: 0,
+                refBlockIndex: 0,
+            },
+            actions: vec![
+                services::transact::Wrapper::pack_from(AccountNumber::new(0)).startBlock(),
+            ],
+            claims: vec![],
+        };
+        let strx = SignedTransaction {
+            transaction: trx.packed().into(),
+            proofs: vec![],
+            subjectiveData: None,
+        }
+        .packed();
+        unsafe { tester_raw::pushTransaction(self.chain_handle, strx.as_ptr(), strx.len()) };
+    }
+
     /// Start a new block
     ///
     /// Starts a new block at `time`. If `time.seconds` is 0,
@@ -442,6 +464,7 @@ impl Chain {
                         commit_num,
                     )
                 }
+                self.push_start_block(time);
                 commit_num += 1;
             }
         }
@@ -454,6 +477,7 @@ impl Chain {
                 commit_num,
             )
         }
+        self.push_start_block(time + Seconds::new(1));
         *status = self
             .kv_get::<StatusRow, _>(StatusRow::DB, &status_key())
             .unwrap();

--- a/rust/psibase/src/time.rs
+++ b/rust/psibase/src/time.rs
@@ -135,6 +135,11 @@ impl TimePointUSec {
             seconds: self.microseconds / 1000000,
         }
     }
+    pub fn ceil_seconds(&self) -> TimePointSec {
+        TimePointSec {
+            seconds: (self.microseconds + 999999) / 1000000,
+        }
+    }
 }
 
 impl From<i64> for TimePointUSec {


### PR DESCRIPTION
This resolves an issue where a long sequence of empty blocks would create a large number of events that were not indexed until the next transaction, causing OOM in the event indexer when a transaction is finally submitted. Subjective mode calls required to index events are only allowed in transactions.

- transact will report an error if startBlock is not run
- transact verifies that startBlock is only run once per block
- When applying a block, startBlock doesn't need to be called separately anymore, because it's in the list of transactions
- Native is still responsible for adding the call to startBlock, when building a block. However, because startBlock is no longer a separate step on replay, this is no longer a matter of consensus and RTransact can eventually take over full management of startBlock.
- In the tester, call startBlock from wasm instead of native