### PR TITLE
Try to fix WatchdogTests

### DIFF
--- a/libraries/psibase/native/tests/WatchdogTests.cpp
+++ b/libraries/psibase/native/tests/WatchdogTests.cpp
@@ -33,13 +33,13 @@ TEST_CASE("CpuClock should be associated with the current thread")
    std::chrono::nanoseconds t0_elapsed;
    auto                     start = CpuClock::now();
    std::thread              t0{[&]
-                  {
+                               {
                      auto start = CpuClock::now();
-                     std::this_thread::sleep_for(std::chrono::milliseconds(25));
+                     std::this_thread::sleep_for(std::chrono::milliseconds(50));
                      auto end   = CpuClock::now();
                      t0_elapsed = end - start;
                      done       = true;
-                  }};
+                               }};
    while (!done)
    {
    }


### PR DESCRIPTION
The test that sometimes fails now ("CpuClock should be associated with the current thread") relies on the main thread getting enough CPU time, which can fail if the system is under too high a load. Increase the duration of the test to compensate.