### PR TITLE
track and print correct panic locations on unit test errors

### DIFF
--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -1069,14 +1069,17 @@ pub struct ChainEmptyResult {
 }
 
 impl ChainEmptyResult {
+    #[track_caller]
     pub fn get(&self) -> Result<(), anyhow::Error> {
         if let Some(e) = &self.trace.error {
-            Err(anyhow!("{}", e))
+            let loc = std::panic::Location::caller();
+            Err(anyhow!("{} (at {}:{})", e, loc.file(), loc.line()))
         } else {
             Ok(())
         }
     }
 
+    #[track_caller]
     pub fn match_error(self, msg: &str) -> Result<TransactionTrace, anyhow::Error> {
         self.trace.match_error(msg)
     }
@@ -1088,6 +1091,7 @@ pub struct ChainResult<T: fracpack::UnpackOwned> {
 }
 
 impl<T: fracpack::UnpackOwned> ChainResult<T> {
+    #[track_caller]
     pub fn get(&self) -> Result<T, anyhow::Error> {
         self.get_with_debug(false)
     }
@@ -1107,9 +1111,11 @@ impl<T: fracpack::UnpackOwned> ChainResult<T> {
             || act.sender == AccountNumber::default())
     }
 
+    #[track_caller]
     pub fn get_with_debug(&self, debug: bool) -> Result<T, anyhow::Error> {
         if let Some(e) = &self.trace.error {
-            return Err(anyhow!("{}", e));
+            let loc = std::panic::Location::caller();
+            return Err(anyhow!("{} (at {}:{})", e, loc.file(), loc.line()));
         }
         if let Some(transact) = self.trace.action_traces.last() {
             let at = transact
@@ -1140,9 +1146,15 @@ impl<T: fracpack::UnpackOwned> ChainResult<T> {
                 return Ok(unpacked_ret);
             }
         }
-        Err(anyhow!("Can't find action in trace"))
+        let loc = std::panic::Location::caller();
+        Err(anyhow!(
+            "Can't find action in trace (at {}:{})",
+            loc.file(),
+            loc.line()
+        ))
     }
 
+    #[track_caller]
     pub fn match_error(self, msg: &str) -> Result<TransactionTrace, anyhow::Error> {
         self.trace.match_error(msg)
     }

--- a/rust/psibase/src/trace.rs
+++ b/rust/psibase/src/trace.rs
@@ -77,29 +77,37 @@ pub struct TransactionTrace {
 }
 
 impl TransactionTrace {
+    #[track_caller]
     pub fn ok(self) -> Result<TransactionTrace, anyhow::Error> {
         if let Some(e) = self.error {
-            Err(anyhow::anyhow!("{}", e))
+            let loc = std::panic::Location::caller();
+            Err(anyhow::anyhow!("{} (at {}:{})", e, loc.file(), loc.line()))
         } else {
             Ok(self)
         }
     }
 
+    #[track_caller]
     pub fn match_error(self, msg: &str) -> Result<TransactionTrace, anyhow::Error> {
+        let loc = std::panic::Location::caller();
         if let Some(e) = &self.error {
             if e.contains(msg) {
                 Ok(self)
             } else {
                 Err(anyhow::anyhow!(
-                    "Transaction was expected to fail with \"{}\", but failed with \"{}\"",
+                    "Transaction was expected to fail with \"{}\", but failed with \"{}\" (at {}:{})",
                     msg,
-                    e
+                    e,
+                    loc.file(),
+                    loc.line()
                 ))
             }
         } else {
             Err(anyhow::anyhow!(
-                "Transaction was expected to fail with \"{}\", but succeeded",
+                "Transaction was expected to fail with \"{}\", but succeeded (at {}:{})",
                 msg,
+                loc.file(),
+                loc.line()
             ))
         }
     }


### PR DESCRIPTION
Failures from `.get()?` / `.match_error(...)?` don’t panic at the call site in our rust tests. They become an `Err`, bubble out of the test body, and only then panic inside the macro-generated wrapper. So Rust’s normal panic location always points at that wrapper, which is not helpful at all. 

This allows the panic to track the caller location which tells you the line in your test that's actually failing.