### PR TITLE
Restrict table read access

### DIFF
--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -7,6 +7,7 @@
 #include <psibase/nativeTables.hpp>
 #include <psibase/trace.hpp>
 #include <psio/to_hex.hpp>
+#include <services/system/Accounts.hpp>
 #include <services/system/PrivateKeyInfo.hpp>
 #include <services/system/Spki.hpp>
 #include <services/system/VirtualServer.hpp>
@@ -38,6 +39,11 @@ namespace psibase
       if (action.sender == SystemService::Transact::service &&
           action.service == SystemService::VirtualServer::service)
          return false;
+      if (action.sender == SystemService::Transact::service &&
+          action.service == SystemService::Accounts::service && action.method == "getAuthOf"_m)
+      {
+         return false;
+      }
       if (action.service == "events"_a && action.method == "sync"_m)
          return false;
       if (action.sender == AccountNumber{})

--- a/packages/system/Db/src/Db.cpp
+++ b/packages/system/Db/src/Db.cpp
@@ -30,9 +30,11 @@ namespace
       message += to_string(db);
       abortMessage(message);
    }
-   void prefixError(AccountNumber sender, std::span<const char> prefix)
+   void prefixError(AccountNumber sender, std::span<const char> prefix, std::string_view verb)
    {
-      std::string message = sender.str() + " cannot write to another service's prefix";
+      std::string message = sender.str() + " cannot ";
+      message += verb;
+      message += " another service's prefix";
       if (prefix.size() >= sizeof(std::uint64_t))
       {
          std::uint64_t value;
@@ -64,7 +66,18 @@ UniqueKvHandle Db::open(DbId db, psio::view<const std::vector<char>> prefixView,
          auto expected = psio::convert_to_key(sender);
          if (!std::ranges::starts_with(prefix, expected))
          {
-            prefixError(sender, prefix);
+            prefixError(sender, prefix, "write to");
+         }
+      }
+      else
+      {
+         auto expected = psio::convert_to_key(sender);
+         // Subaccounts of the same primary account, all have
+         // shared read access
+         expected.pop_back();
+         if (!std::ranges::starts_with(prefix, expected))
+         {
+            prefixError(sender, prefix, "read from");
          }
       }
    }

--- a/packages/system/Transact/include/services/system/Transact.hpp
+++ b/packages/system/Transact/include/services/system/Transact.hpp
@@ -459,6 +459,10 @@ namespace SystemService
       /// TODO: remove
       psibase::BlockTime headBlockTime() const;
 
+      /// Returns the tapos `refBlockIndex` and `refBlockSuffix`
+      /// for the head block.
+      std::pair<uint8_t, uint32_t> headTapos();
+
       struct Events
       {
          struct History
@@ -492,6 +496,7 @@ namespace SystemService
                 method(currentBlock),
                 method(headBlock),
                 method(headBlockTime),
+                method(headTapos)
                 //
    )
 

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -1536,10 +1536,7 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest&  reques
                              trx.proofs[i]);
          }
          // check auth
-         auto accountsTables = Accounts::Tables(Accounts::service);
-         auto accountTable   = accountsTables.open<AccountTable>();
-         auto accountIndex   = accountTable.getIndex<0>();
-         auto account        = accountIndex.get(sender);
+         auto account = to<Accounts>().getAccount(sender);
          if (!account)
             return make404("Account not found");
          Actor<AuthInterface> auth(RTransact::service, account->authService);
@@ -1553,9 +1550,9 @@ std::optional<HttpReply> RTransact::serveSys(const psibase::HttpRequest&  reques
          // Construct token
          auto exp = std::chrono::time_point_cast<std::chrono::seconds>(
              std::chrono::system_clock::now() + std::chrono::days(30));
-         auto                token = encodeJWT(getJWTKey(), LoginTokenData{.sub = sender,
-                                                                           .aud = std::string(rootHost(request)),
-                                                                           .exp = exp.time_since_epoch().count()});
+         auto token = encodeJWT(getJWTKey(), LoginTokenData{.sub = sender,
+                                                            .aud = std::string(rootHost(request)),
+                                                            .exp = exp.time_since_epoch().count()});
          HttpReply           reply{.contentType = "application/json",
                                    .headers     = allowCors(request, AccountNumber{"supervisor"})};
          psio::vector_stream stream{reply.body};

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -314,14 +314,9 @@ namespace SystemService
 
       if (transactStatus && transactStatus->enforceAuth)
       {
-         auto accountsTables = Accounts::Tables(Accounts::service, KvMode::read);
-         auto accountTable   = accountsTables.open<AccountTable>();
-         auto accountIndex   = accountTable.getIndex<0>();
-         auto account        = accountIndex.get(action.sender);
-         if (!account)
-            abortMessage("unknown sender \"" + action.sender.str() + "\"");
+         auto authService = to<Accounts>().getAuthOf(action.sender);
 
-         if (requester != account->authService && requester != action.sender.base())
+         if (requester != authService && requester != action.sender.base())
          {
             uint32_t flags = 0;
             if (requester == action.sender)
@@ -363,19 +358,19 @@ namespace SystemService
 
                if (!flags_str.empty())
                {
-                  psibase::writeConsole("Checking auth service " + account->authService.str() +
+                  psibase::writeConsole("Checking auth service " + authService.str() +
                                         " with flags: \n" + flags_str + "\n");
                }
             }
 
-            Actor<AuthInterface> auth(Transact::service, account->authService);
+            Actor<AuthInterface> auth(Transact::service, authService);
             if (!auth.checkAuthSys(flags, requester, action.sender,
                                    ServiceMethod{action.service, action.method}, allowedActions,
                                    std::vector<Claim>{}))
             {
                abortMessage("Not authorized");
             }
-         }  // if (requester != account->authService)
+         }  // if (requester != authService)
       }  // if(enforceAuth)
 
       for (auto& a : allowedActions)
@@ -419,6 +414,11 @@ namespace SystemService
       if (stat.head)
          return stat.head->header.time;
       return {};
+   }
+
+   std::pair<uint8_t, uint32_t> Transact::headTapos()
+   {
+      return SystemService::headTapos();
    }
 
    namespace
@@ -523,18 +523,12 @@ namespace SystemService
                      bool                      first,
                      bool                      readOnly)
       {
-         auto accountsTables = Accounts::Tables(Accounts::service);
-         auto accountTable   = accountsTables.open<AccountTable>();
-         auto accountIndex   = accountTable.getIndex<0>();
-
-         auto account = accountIndex.get(act.sender().unpack());
-         if (!account)
-            abortMessage("unknown sender \"" + act.sender().unpack().str() + "\"");
+         auto authService = to<Accounts>().getAuthOf(act.sender().unpack());
 
          if constexpr (enable_print)
             std::printf("call checkAuthSys on %s for sender account %s\n",
-                        account->authService.str().c_str(), act.sender().unpack().str().c_str());
-         Actor<AuthInterface> auth(Transact::service, account->authService);
+                        authService.str().c_str(), act.sender().unpack().str().c_str());
+         Actor<AuthInterface> auth(Transact::service, authService);
          uint32_t             flags = AuthInterface::topActionReq;
          if (first && !readOnly)
          {

--- a/packages/user/CommonApi/src/CommonApi.cpp
+++ b/packages/user/CommonApi/src/CommonApi.cpp
@@ -112,9 +112,9 @@ namespace SystemService
             return to_json(to<HttpServer>().rootHost(request.host));
          if (request.target == "/common/tapos/head")
          {
-            auto [index, suffix] = headTapos();
+            auto [index, suffix] = to<Transact>().headTapos();
             auto json            = "{\"refBlockIndex\":" + std::to_string(index) +
-                        ",\"refBlockSuffix\":" + std::to_string(suffix) + "}";
+                                   ",\"refBlockSuffix\":" + std::to_string(suffix) + "}";
             return HttpReply{
                 .contentType = "application/json",
                 .body        = {json.begin(), json.end()},

--- a/packages/user/Events/src/SchemaCache.cpp
+++ b/packages/user/Events/src/SchemaCache.cpp
@@ -8,7 +8,7 @@ using namespace psio::schema_types;
 
 namespace UserService
 {
-   SchemaCache::SchemaCache(InstalledSchemaTable table) : table(std::move(table)) {}
+   SchemaCache::SchemaCache() {}
    const CompiledType* SchemaCache::getSchemaType(DbId          db,
                                                   AccountNumber service,
                                                   MethodNumber  event)
@@ -16,9 +16,9 @@ namespace UserService
       auto pos = cache.find(service);
       if (pos == cache.end())
       {
-         if (auto schema = table.getIndex<0>().get(service))
+         if (auto schema = to<Packages>().getSchema(service))
          {
-            pos = cache.try_emplace(service, std::move(schema->schema)).first;
+            pos = cache.try_emplace(service, std::move(*schema)).first;
          }
          else
          {
@@ -38,7 +38,7 @@ namespace UserService
 
    SchemaCache& SchemaCache::instance()
    {
-      static SchemaCache result{Packages{}.open<InstalledSchemaTable>()};
+      static SchemaCache result{};
       return result;
    }
 }  // namespace UserService

--- a/packages/user/Events/src/SchemaCache.hpp
+++ b/packages/user/Events/src/SchemaCache.hpp
@@ -7,7 +7,7 @@ namespace UserService
 {
    struct SchemaCache
    {
-      explicit SchemaCache(InstalledSchemaTable table);
+      SchemaCache();
       const psio::schema_types::CompiledType* getSchemaType(psibase::DbId          db,
                                                             psibase::AccountNumber service,
                                                             psibase::MethodNumber  event);
@@ -20,7 +20,6 @@ namespace UserService
          psio::schema_types::CompiledSchema cschema;
       };
       static SchemaCache&                          instance();
-      InstalledSchemaTable                         table;
       std::map<psibase::AccountNumber, CacheEntry> cache;
    };
 }  // namespace UserService

--- a/packages/user/Packages/include/services/user/Packages.hpp
+++ b/packages/user/Packages/include/services/user/Packages.hpp
@@ -30,7 +30,15 @@ namespace UserService
       std::vector<psibase::AccountNumber> services;
       std::vector<PackageExport>          exports;
    };
-   PSIO_REFLECT(PackageMeta, name, version, scope, description, depends, accounts, services, exports)
+   PSIO_REFLECT(PackageMeta,
+                name,
+                version,
+                scope,
+                description,
+                depends,
+                accounts,
+                services,
+                exports)
 
    struct PublishedPackage
    {
@@ -97,7 +105,15 @@ namespace UserService
 
       using ByName = psibase::CompositeKey<&InstalledPackage::name, &InstalledPackage::owner>;
    };
-   PSIO_REFLECT(InstalledPackage, name, version, description, depends, accounts, services, exports, owner)
+   PSIO_REFLECT(InstalledPackage,
+                name,
+                version,
+                description,
+                depends,
+                accounts,
+                services,
+                exports,
+                owner)
 
    struct PackageDataFile
    {
@@ -161,6 +177,7 @@ namespace UserService
       // This should be the last action run when installing a package
       void postinstall(PackageMeta package, std::vector<char> manifest);
       void setSchema(psibase::ServiceSchema schema);
+      auto getSchema(psibase::AccountNumber service) -> std::optional<psibase::ServiceSchema>;
 
       void publish(PackageMeta package, psibase::Checksum256 sha256, std::string file);
 
@@ -177,6 +194,7 @@ namespace UserService
    PSIO_REFLECT(Packages,
                 method(postinstall, package, manifest),
                 method(setSchema, account, schema),
+                method(getSchema),
                 method(publish, package, sha256, file),
                 method(setSources, sources),
                 method(checkOrder, id, index),

--- a/packages/user/Packages/src/Packages.cpp
+++ b/packages/user/Packages/src/Packages.cpp
@@ -12,23 +12,6 @@ namespace UserService
 {
    namespace
    {
-      AccountNumber getAuthServ(AccountNumber account)
-      {
-         auto db = Accounts::Tables(Accounts::service);
-         if (auto row = db.open<AccountTable>().getIndex<0>().get(account))
-            return row->authService;
-         else
-            abortMessage("Unknown account " + account.str());
-      }
-      AccountNumber getOwner(AccountNumber account)
-      {
-         auto db = AuthDelegate::Tables(AuthDelegate::service);
-         if (auto row = db.open<AuthDelegateTable>().getIndex<0>().get(account))
-            return row->owner;
-         else
-            abortMessage("Cannot find owner for " + account.str());
-      }
-
       using namespace psio::schema_types;
 
       const AnyType* getFieldType(const Object& ty, std::uint32_t index)
@@ -91,7 +74,7 @@ namespace UserService
       auto sender = getSender();
       for (AccountNumber account : package.accounts)
       {
-         if (auto auth = getAuthServ(account); auth != AuthDelegate::service)
+         if (auto auth = to<Accounts>().getAuthOf(account); auth != AuthDelegate::service)
          {
             // - A single account doesn't need to use delegation
             // - Accounts that have special auth defined in this package are okay
@@ -102,7 +85,7 @@ namespace UserService
          }
          else
          {
-            if (getOwner(account) != sender)
+            if (to<AuthDelegate>().getOwner(account) != sender)
                abortMessage("Account " + account.str() + " in " + package.name +
                             " is not owned by " + sender.str());
          }
@@ -209,6 +192,15 @@ namespace UserService
          }
       }
       schemas.put({service, std::move(schema)});
+   }
+
+   std::optional<ServiceSchema> Packages::getSchema(AccountNumber service)
+   {
+      auto schemas = open<InstalledSchemaTable>(KvMode::read);
+      if (auto row = schemas.get(service))
+         return std::move(row->schema);
+      else
+         return std::nullopt;
    }
 
    void Packages::publish(PackageMeta package, Checksum256 sha256, std::string file)

--- a/programs/psinode/tests/test_subjective.py
+++ b/programs/psinode/tests/test_subjective.py
@@ -16,6 +16,8 @@ def is_user_action(action):
         return False
     if action['sender'] == 'transact' and action['service'] == 'vserver':
         return False
+    if action['sender'] == 'transact' and action['service'] == 'accounts' and action['method'] == 'getauthof':
+        return False
     if action['service'] == 'events' and action['method'] == 'sync':
         return False
     if action['sender'] == '':

--- a/rust/psibase/src/services/packages.rs
+++ b/rust/psibase/src/services/packages.rs
@@ -88,6 +88,11 @@ mod service {
     }
 
     #[action]
+    fn getSchema(service: AccountNumber) -> Option<Schema> {
+        unimplemented!()
+    }
+
+    #[action]
     fn setSources(sources: Vec<PackageSource>) {
         unimplemented!()
     }

--- a/rust/psibase/src/services/transact.rs
+++ b/rust/psibase/src/services/transact.rs
@@ -395,6 +395,13 @@ mod service {
         unimplemented!()
     }
 
+    /// Returns the tapos `refBlockIndex` and `refBlockSuffix`
+    /// for the head block.
+    #[action]
+    fn headTapos() -> (u8, u32) {
+        unimplemented!();
+    }
+
     /// Emitted at the start of each block
     #[event(history)]
     fn blockStart(blockNum: crate::BlockNum, blockTime: crate::BlockTime) {

--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -982,11 +982,14 @@ impl<T: fracpack::UnpackOwned> ChainResult<T> {
     fn is_user_action(act: &Action) -> bool {
         use crate::{
             self as psibase, method,
-            services::{cpu_limit, db, events, transact, virtual_server},
+            services::{accounts, cpu_limit, db, events, transact, virtual_server},
         };
         !(act.service == db::SERVICE && act.method == method!("open")
             || act.service == cpu_limit::SERVICE
             || act.sender == transact::SERVICE && act.service == virtual_server::SERVICE
+            || act.sender == transact::SERVICE
+                && act.service == accounts::SERVICE
+                && act.method == method!("getAuthOf")
             || act.service == events::SERVICE && act.method == method!("sync")
             || act.sender == AccountNumber::default())
     }


### PR DESCRIPTION
All subaccounts and the primary account are allowed to read each other's tables directly. Other services must go through the action interface.