### PR TITLE
Fixing Supervisor method call race

### DIFF
--- a/packages/.pnp.cjs
+++ b/packages/.pnp.cjs
@@ -2913,10 +2913,13 @@ const RAW_RUNTIME_STATE =
           ["@types/react", "npm:19.2.8"],\
           ["@types/react-dom", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:19.2.3"],\
           ["eslint", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:9.39.2"],\
+          ["happy-dom", "npm:20.10.6"],\
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:19.2.3"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
           ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:5.4.21"],\
+          ["vite-tsconfig-paths", "virtual:6471aeeccf6d7d39eaa7ac371d5ea707f776917d655540c779996f3e9742f8b2d01cb8c1b734701600c8896fdc2408b69ce5013a5cd95ac7181e6c3c652baa15#npm:6.1.1"],\
+          ["vitest", "virtual:6471aeeccf6d7d39eaa7ac371d5ea707f776917d655540c779996f3e9742f8b2d01cb8c1b734701600c8896fdc2408b69ce5013a5cd95ac7181e6c3c652baa15#npm:2.1.9"],\
           ["zod", "npm:3.25.76"]\
         ],\
         "linkType": "SOFT"\
@@ -7228,6 +7231,14 @@ const RAW_RUNTIME_STATE =
           ["undici-types", "npm:7.16.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:26.0.0", {\
+        "packageLocation": "../.caches/yarn/@types-node-npm-26.0.0-2a5770ad4a-f36e21634f.zip/node_modules/@types/node/",\
+        "packageDependencies": [\
+          ["@types/node", "npm:26.0.0"],\
+          ["undici-types", "npm:8.3.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@types/prop-types", [\
@@ -7372,6 +7383,25 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.caches/yarn/@types-uuid-npm-10.0.0-9ac1066765-9a1404bf28.zip/node_modules/@types/uuid/",\
         "packageDependencies": [\
           ["@types/uuid", "npm:10.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@types/whatwg-mimetype", [\
+      ["npm:3.0.2", {\
+        "packageLocation": "../.caches/yarn/@types-whatwg-mimetype-npm-3.0.2-cf2bd6921c-dad39d1e4a.zip/node_modules/@types/whatwg-mimetype/",\
+        "packageDependencies": [\
+          ["@types/whatwg-mimetype", "npm:3.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@types/ws", [\
+      ["npm:8.18.1", {\
+        "packageLocation": "../.caches/yarn/@types-ws-npm-8.18.1-61dc106ff0-61aff11291.zip/node_modules/@types/ws/",\
+        "packageDependencies": [\
+          ["@types/node", "npm:25.0.8"],\
+          ["@types/ws", "npm:8.18.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -7759,6 +7789,103 @@ const RAW_RUNTIME_STATE =
         "packagePeers": [\
           "@types/vite",\
           "vite"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@vitest/expect", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/@vitest-expect-npm-2.1.9-4e945bd225-98d1cf0291.zip/node_modules/@vitest/expect/",\
+        "packageDependencies": [\
+          ["@vitest/expect", "npm:2.1.9"],\
+          ["@vitest/spy", "npm:2.1.9"],\
+          ["@vitest/utils", "npm:2.1.9"],\
+          ["chai", "npm:5.3.3"],\
+          ["tinyrainbow", "npm:1.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@vitest/mocker", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/@vitest-mocker-npm-2.1.9-2c6df8716a-f734490d8d.zip/node_modules/@vitest/mocker/",\
+        "packageDependencies": [\
+          ["@vitest/mocker", "npm:2.1.9"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:59ad4fa3e56e064ce0507d8faee4580d6bf7701a56e508bfe6c08d5b2b1a2cb565e094145be3a4d21081f37aa1e9feb19356c154d2df5df1c6837747995d0cc5#npm:2.1.9", {\
+        "packageLocation": "./.yarn/__virtual__/@vitest-mocker-virtual-5cff15fec8/2/.caches/yarn/@vitest-mocker-npm-2.1.9-2c6df8716a-f734490d8d.zip/node_modules/@vitest/mocker/",\
+        "packageDependencies": [\
+          ["@types/msw", null],\
+          ["@types/vite", null],\
+          ["@vitest/mocker", "virtual:59ad4fa3e56e064ce0507d8faee4580d6bf7701a56e508bfe6c08d5b2b1a2cb565e094145be3a4d21081f37aa1e9feb19356c154d2df5df1c6837747995d0cc5#npm:2.1.9"],\
+          ["@vitest/spy", "npm:2.1.9"],\
+          ["estree-walker", "npm:3.0.3"],\
+          ["magic-string", "npm:0.30.21"],\
+          ["msw", null],\
+          ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:5.4.21"]\
+        ],\
+        "packagePeers": [\
+          "@types/msw",\
+          "@types/vite",\
+          "msw",\
+          "vite"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@vitest/pretty-format", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/@vitest-pretty-format-npm-2.1.9-94ea1cc996-155f9ede50.zip/node_modules/@vitest/pretty-format/",\
+        "packageDependencies": [\
+          ["@vitest/pretty-format", "npm:2.1.9"],\
+          ["tinyrainbow", "npm:1.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@vitest/runner", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/@vitest-runner-npm-2.1.9-1d50535316-e81f176bad.zip/node_modules/@vitest/runner/",\
+        "packageDependencies": [\
+          ["@vitest/runner", "npm:2.1.9"],\
+          ["@vitest/utils", "npm:2.1.9"],\
+          ["pathe", "npm:1.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@vitest/snapshot", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/@vitest-snapshot-npm-2.1.9-ad091136c0-394974b3a1.zip/node_modules/@vitest/snapshot/",\
+        "packageDependencies": [\
+          ["@vitest/pretty-format", "npm:2.1.9"],\
+          ["@vitest/snapshot", "npm:2.1.9"],\
+          ["magic-string", "npm:0.30.21"],\
+          ["pathe", "npm:1.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@vitest/spy", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/@vitest-spy-npm-2.1.9-d16af87e46-12a59b5095.zip/node_modules/@vitest/spy/",\
+        "packageDependencies": [\
+          ["@vitest/spy", "npm:2.1.9"],\
+          ["tinyspy", "npm:3.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@vitest/utils", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/@vitest-utils-npm-2.1.9-355aea689e-81a346cd72.zip/node_modules/@vitest/utils/",\
+        "packageDependencies": [\
+          ["@vitest/pretty-format", "npm:2.1.9"],\
+          ["@vitest/utils", "npm:2.1.9"],\
+          ["loupe", "npm:3.2.1"],\
+          ["tinyrainbow", "npm:1.2.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -8297,6 +8424,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["assertion-error", [\
+      ["npm:2.0.1", {\
+        "packageLocation": "../.caches/yarn/assertion-error-npm-2.0.1-8169d136f2-bbbcb117ac.zip/node_modules/assertion-error/",\
+        "packageDependencies": [\
+          ["assertion-error", "npm:2.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["async-function", [\
       ["npm:1.0.0", {\
         "packageLocation": "../.caches/yarn/async-function-npm-1.0.0-a81667ebcd-669a32c2cb.zip/node_modules/async-function/",\
@@ -8573,6 +8709,25 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["buffer-image-size", [\
+      ["npm:0.6.4", {\
+        "packageLocation": "../.caches/yarn/buffer-image-size-npm-0.6.4-a173b80f35-7158205c87.zip/node_modules/buffer-image-size/",\
+        "packageDependencies": [\
+          ["@types/node", "npm:25.0.8"],\
+          ["buffer-image-size", "npm:0.6.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["cac", [\
+      ["npm:6.7.14", {\
+        "packageLocation": "../.caches/yarn/cac-npm-6.7.14-c46284e425-4ee06aaa7b.zip/node_modules/cac/",\
+        "packageDependencies": [\
+          ["cac", "npm:6.7.14"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["cacache", [\
       ["npm:20.0.3", {\
         "packageLocation": "../.caches/yarn/cacache-npm-20.0.3-5f244d5bdd-c7da1ca694.zip/node_modules/cacache/",\
@@ -8696,6 +8851,20 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["chai", [\
+      ["npm:5.3.3", {\
+        "packageLocation": "../.caches/yarn/chai-npm-5.3.3-ebef71cdac-b360fd4d38.zip/node_modules/chai/",\
+        "packageDependencies": [\
+          ["assertion-error", "npm:2.0.1"],\
+          ["chai", "npm:5.3.3"],\
+          ["check-error", "npm:2.1.3"],\
+          ["deep-eql", "npm:5.0.2"],\
+          ["loupe", "npm:3.2.1"],\
+          ["pathval", "npm:2.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["chalk", [\
       ["npm:4.1.2", {\
         "packageLocation": "../.caches/yarn/chalk-npm-4.1.2-ba8b67ab80-4a3fef5cc3.zip/node_modules/chalk/",\
@@ -8720,6 +8889,15 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["chalk", "npm:5.6.2"],\
           ["chalk-template", "npm:1.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["check-error", [\
+      ["npm:2.1.3", {\
+        "packageLocation": "../.caches/yarn/check-error-npm-2.1.3-e17bcf3ed8-878e99038f.zip/node_modules/check-error/",\
+        "packageDependencies": [\
+          ["check-error", "npm:2.1.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -9762,6 +9940,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["deep-eql", [\
+      ["npm:5.0.2", {\
+        "packageLocation": "../.caches/yarn/deep-eql-npm-5.0.2-3bce58289f-7102cf3b7b.zip/node_modules/deep-eql/",\
+        "packageDependencies": [\
+          ["deep-eql", "npm:5.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["deep-is", [\
       ["npm:0.1.4", {\
         "packageLocation": "../.caches/yarn/deep-is-npm-0.1.4-88938b5a67-7f0ee496e0.zip/node_modules/deep-is/",\
@@ -10073,6 +10260,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.caches/yarn/entities-npm-7.0.0-d220393db3-4e7cc40cd0.zip/node_modules/entities/",\
         "packageDependencies": [\
           ["entities", "npm:7.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:7.0.1", {\
+        "packageLocation": "../.caches/yarn/entities-npm-7.0.1-61f8ba3430-b4fb9937bb.zip/node_modules/entities/",\
+        "packageDependencies": [\
+          ["entities", "npm:7.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -10871,6 +11065,14 @@ const RAW_RUNTIME_STATE =
           ["estree-walker", "npm:2.0.2"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:3.0.3", {\
+        "packageLocation": "../.caches/yarn/estree-walker-npm-3.0.3-0372979673-c12e3c2b26.zip/node_modules/estree-walker/",\
+        "packageDependencies": [\
+          ["@types/estree", "npm:1.0.8"],\
+          ["estree-walker", "npm:3.0.3"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["esutils", [\
@@ -10887,6 +11089,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.caches/yarn/eventemitter3-npm-4.0.7-7afcdd74ae-5f6d97cbcb.zip/node_modules/eventemitter3/",\
         "packageDependencies": [\
           ["eventemitter3", "npm:4.0.7"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["expect-type", [\
+      ["npm:1.3.0", {\
+        "packageLocation": "../.caches/yarn/expect-type-npm-1.3.0-95a4384745-8412b3fe4f.zip/node_modules/expect-type/",\
+        "packageDependencies": [\
+          ["expect-type", "npm:1.3.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -11516,6 +11727,22 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.caches/yarn/grapheme-splitter-npm-1.0.4-648f2bf509-108415fb07.zip/node_modules/grapheme-splitter/",\
         "packageDependencies": [\
           ["grapheme-splitter", "npm:1.0.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["happy-dom", [\
+      ["npm:20.10.6", {\
+        "packageLocation": "../.caches/yarn/happy-dom-npm-20.10.6-dc896b83d0-3cf22def88.zip/node_modules/happy-dom/",\
+        "packageDependencies": [\
+          ["@types/node", "npm:26.0.0"],\
+          ["@types/whatwg-mimetype", "npm:3.0.2"],\
+          ["@types/ws", "npm:8.18.1"],\
+          ["buffer-image-size", "npm:0.6.4"],\
+          ["entities", "npm:7.0.1"],\
+          ["happy-dom", "npm:20.10.6"],\
+          ["whatwg-mimetype", "npm:3.0.0"],\
+          ["ws", "virtual:dc896b83d081c6997c9337b24e705c9b36c8ed8f76d14638f4fdffa784b868c2707f73be6e59159c9411ebae5f860fe2c9205af27d00e7d67f9fbfba8170c1ec#npm:8.21.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -12849,6 +13076,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["loupe", [\
+      ["npm:3.2.1", {\
+        "packageLocation": "../.caches/yarn/loupe-npm-3.2.1-a8f491982f-910c872cba.zip/node_modules/loupe/",\
+        "packageDependencies": [\
+          ["loupe", "npm:3.2.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["lower-case", [\
       ["npm:2.0.2", {\
         "packageLocation": "../.caches/yarn/lower-case-npm-2.0.2-151055f1c2-3d925e0903.zip/node_modules/lower-case/",\
@@ -13863,10 +14099,26 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["pathe", [\
+      ["npm:1.1.2", {\
+        "packageLocation": "../.caches/yarn/pathe-npm-1.1.2-b80d94db55-64ee0a4e58.zip/node_modules/pathe/",\
+        "packageDependencies": [\
+          ["pathe", "npm:1.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:2.0.3", {\
         "packageLocation": "../.caches/yarn/pathe-npm-2.0.3-0924246ee0-c118dc5a8b.zip/node_modules/pathe/",\
         "packageDependencies": [\
           ["pathe", "npm:2.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["pathval", [\
+      ["npm:2.0.1", {\
+        "packageLocation": "../.caches/yarn/pathval-npm-2.0.1-7fb9ae82ba-460f470947.zip/node_modules/pathval/",\
+        "packageDependencies": [\
+          ["pathval", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -15894,6 +16146,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["siginfo", [\
+      ["npm:2.0.0", {\
+        "packageLocation": "../.caches/yarn/siginfo-npm-2.0.0-9bbac931f8-3def8f8e51.zip/node_modules/siginfo/",\
+        "packageDependencies": [\
+          ["siginfo", "npm:2.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["signal-exit", [\
       ["npm:4.1.0", {\
         "packageLocation": "../.caches/yarn/signal-exit-npm-4.1.0-61fb957687-41602dce54.zip/node_modules/signal-exit/",\
@@ -16037,6 +16298,24 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["minipass", "npm:7.1.2"],\
           ["ssri", "npm:13.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["stackback", [\
+      ["npm:0.0.2", {\
+        "packageLocation": "../.caches/yarn/stackback-npm-0.0.2-73273dc92e-89a1416668.zip/node_modules/stackback/",\
+        "packageDependencies": [\
+          ["stackback", "npm:0.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["std-env", [\
+      ["npm:3.10.0", {\
+        "packageLocation": "../.caches/yarn/std-env-npm-3.10.0-30d3e2646f-1814927a45.zip/node_modules/std-env/",\
+        "packageDependencies": [\
+          ["std-env", "npm:3.10.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -16641,6 +16920,24 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["tinybench", [\
+      ["npm:2.9.0", {\
+        "packageLocation": "../.caches/yarn/tinybench-npm-2.9.0-2861a048db-c3500b0f60.zip/node_modules/tinybench/",\
+        "packageDependencies": [\
+          ["tinybench", "npm:2.9.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["tinyexec", [\
+      ["npm:0.3.2", {\
+        "packageLocation": "../.caches/yarn/tinyexec-npm-0.3.2-381b1e349c-3efbf791a9.zip/node_modules/tinyexec/",\
+        "packageDependencies": [\
+          ["tinyexec", "npm:0.3.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["tinyglobby", [\
       ["npm:0.2.15", {\
         "packageLocation": "../.caches/yarn/tinyglobby-npm-0.2.15-0e783aadbd-869c31490d.zip/node_modules/tinyglobby/",\
@@ -16657,6 +16954,33 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.caches/yarn/tinylogic-npm-2.0.0-700fcc2fe0-c9417c4b65.zip/node_modules/tinylogic/",\
         "packageDependencies": [\
           ["tinylogic", "npm:2.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["tinypool", [\
+      ["npm:1.1.1", {\
+        "packageLocation": "../.caches/yarn/tinypool-npm-1.1.1-6772421283-bf26727d01.zip/node_modules/tinypool/",\
+        "packageDependencies": [\
+          ["tinypool", "npm:1.1.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["tinyrainbow", [\
+      ["npm:1.2.0", {\
+        "packageLocation": "../.caches/yarn/tinyrainbow-npm-1.2.0-456cccee06-7f78a4b997.zip/node_modules/tinyrainbow/",\
+        "packageDependencies": [\
+          ["tinyrainbow", "npm:1.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["tinyspy", [\
+      ["npm:3.0.2", {\
+        "packageLocation": "../.caches/yarn/tinyspy-npm-3.0.2-4f17593a18-55ffad24e3.zip/node_modules/tinyspy/",\
+        "packageDependencies": [\
+          ["tinyspy", "npm:3.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -16998,6 +17322,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.caches/yarn/undici-types-npm-7.16.0-0e23b08124-3033e2f2b5.zip/node_modules/undici-types/",\
         "packageDependencies": [\
           ["undici-types", "npm:7.16.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.3.0", {\
+        "packageLocation": "../.caches/yarn/undici-types-npm-8.3.0-d34470de3e-c8aa7e2fbe.zip/node_modules/undici-types/",\
+        "packageDependencies": [\
+          ["undici-types", "npm:8.3.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17363,6 +17694,20 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["vite-node", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/vite-node-npm-2.1.9-84dcff71db-0d3589f9f4.zip/node_modules/vite-node/",\
+        "packageDependencies": [\
+          ["cac", "npm:6.7.14"],\
+          ["debug", "virtual:643ed7cc338bcf145a82d8b05b3bef6bcf150ca545df386225596f10ce53cc90b88b3ca83e348ade1ccea5f3f8e76c92d2f0e2ba544da60d40aff9921c56872d#npm:4.4.3"],\
+          ["es-module-lexer", "npm:1.7.0"],\
+          ["pathe", "npm:1.1.2"],\
+          ["vite", "virtual:eec9750b687e80e9b4bad0d59be6d43aec92f76aa3a40311a3f9fee6fabbd3e97ef6266e122a1a47b909d6d9c00666e811802bc985299abb5e24f51be8325726#npm:5.4.21"],\
+          ["vite-node", "npm:2.1.9"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["vite-plugin-dts", [\
       ["npm:4.5.4", {\
         "packageLocation": "../.caches/yarn/vite-plugin-dts-npm-4.5.4-2445647687-5fcb7f3739.zip/node_modules/vite-plugin-dts/",\
@@ -17503,6 +17848,29 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
+      ["npm:6.1.1", {\
+        "packageLocation": "../.caches/yarn/vite-tsconfig-paths-npm-6.1.1-aeb8d4e5a5-5e61080991.zip/node_modules/vite-tsconfig-paths/",\
+        "packageDependencies": [\
+          ["vite-tsconfig-paths", "npm:6.1.1"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:6471aeeccf6d7d39eaa7ac371d5ea707f776917d655540c779996f3e9742f8b2d01cb8c1b734701600c8896fdc2408b69ce5013a5cd95ac7181e6c3c652baa15#npm:6.1.1", {\
+        "packageLocation": "./.yarn/__virtual__/vite-tsconfig-paths-virtual-309b6ff7b9/2/.caches/yarn/vite-tsconfig-paths-npm-6.1.1-aeb8d4e5a5-5e61080991.zip/node_modules/vite-tsconfig-paths/",\
+        "packageDependencies": [\
+          ["@types/vite", null],\
+          ["debug", "virtual:643ed7cc338bcf145a82d8b05b3bef6bcf150ca545df386225596f10ce53cc90b88b3ca83e348ade1ccea5f3f8e76c92d2f0e2ba544da60d40aff9921c56872d#npm:4.4.3"],\
+          ["globrex", "npm:0.1.2"],\
+          ["tsconfck", "virtual:16ae8b92385027acf6952334c35e3950fd4e3e2f9c4daa171523e69ddb524cdfa841994575ade1d58740d22c854d8f3b168c682c4018d8697fd5ec392e1294d6#npm:3.1.6"],\
+          ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:5.4.21"],\
+          ["vite-tsconfig-paths", "virtual:6471aeeccf6d7d39eaa7ac371d5ea707f776917d655540c779996f3e9742f8b2d01cb8c1b734701600c8896fdc2408b69ce5013a5cd95ac7181e6c3c652baa15#npm:6.1.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/vite",\
+          "vite"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:4.3.2", {\
         "packageLocation": "./.yarn/__virtual__/vite-tsconfig-paths-virtual-16ae8b9238/2/.caches/yarn/vite-tsconfig-paths-npm-4.3.2-96d4ddd73d-f390ac1d1c.zip/node_modules/vite-tsconfig-paths/",\
         "packageDependencies": [\
@@ -17542,6 +17910,66 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["vitest", [\
+      ["npm:2.1.9", {\
+        "packageLocation": "../.caches/yarn/vitest-npm-2.1.9-da245b091d-e339e16dcc.zip/node_modules/vitest/",\
+        "packageDependencies": [\
+          ["vitest", "npm:2.1.9"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:6471aeeccf6d7d39eaa7ac371d5ea707f776917d655540c779996f3e9742f8b2d01cb8c1b734701600c8896fdc2408b69ce5013a5cd95ac7181e6c3c652baa15#npm:2.1.9", {\
+        "packageLocation": "./.yarn/__virtual__/vitest-virtual-59ad4fa3e5/2/.caches/yarn/vitest-npm-2.1.9-da245b091d-e339e16dcc.zip/node_modules/vitest/",\
+        "packageDependencies": [\
+          ["@edge-runtime/vm", null],\
+          ["@types/edge-runtime__vm", null],\
+          ["@types/happy-dom", null],\
+          ["@types/jsdom", null],\
+          ["@types/node", "npm:22.19.6"],\
+          ["@types/vitest__browser", null],\
+          ["@types/vitest__ui", null],\
+          ["@vitest/browser", null],\
+          ["@vitest/expect", "npm:2.1.9"],\
+          ["@vitest/mocker", "virtual:59ad4fa3e56e064ce0507d8faee4580d6bf7701a56e508bfe6c08d5b2b1a2cb565e094145be3a4d21081f37aa1e9feb19356c154d2df5df1c6837747995d0cc5#npm:2.1.9"],\
+          ["@vitest/pretty-format", "npm:2.1.9"],\
+          ["@vitest/runner", "npm:2.1.9"],\
+          ["@vitest/snapshot", "npm:2.1.9"],\
+          ["@vitest/spy", "npm:2.1.9"],\
+          ["@vitest/ui", null],\
+          ["@vitest/utils", "npm:2.1.9"],\
+          ["chai", "npm:5.3.3"],\
+          ["debug", "virtual:643ed7cc338bcf145a82d8b05b3bef6bcf150ca545df386225596f10ce53cc90b88b3ca83e348ade1ccea5f3f8e76c92d2f0e2ba544da60d40aff9921c56872d#npm:4.4.3"],\
+          ["expect-type", "npm:1.3.0"],\
+          ["happy-dom", "npm:20.10.6"],\
+          ["jsdom", null],\
+          ["magic-string", "npm:0.30.21"],\
+          ["pathe", "npm:1.1.2"],\
+          ["std-env", "npm:3.10.0"],\
+          ["tinybench", "npm:2.9.0"],\
+          ["tinyexec", "npm:0.3.2"],\
+          ["tinypool", "npm:1.1.1"],\
+          ["tinyrainbow", "npm:1.2.0"],\
+          ["vite", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:5.4.21"],\
+          ["vite-node", "npm:2.1.9"],\
+          ["vitest", "virtual:6471aeeccf6d7d39eaa7ac371d5ea707f776917d655540c779996f3e9742f8b2d01cb8c1b734701600c8896fdc2408b69ce5013a5cd95ac7181e6c3c652baa15#npm:2.1.9"],\
+          ["why-is-node-running", "npm:2.3.0"]\
+        ],\
+        "packagePeers": [\
+          "@edge-runtime/vm",\
+          "@types/edge-runtime__vm",\
+          "@types/happy-dom",\
+          "@types/jsdom",\
+          "@types/node",\
+          "@types/vitest__browser",\
+          "@types/vitest__ui",\
+          "@vitest/browser",\
+          "@vitest/ui",\
+          "happy-dom",\
+          "jsdom"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["vscode-uri", [\
       ["npm:3.1.0", {\
         "packageLocation": "../.caches/yarn/vscode-uri-npm-3.1.0-4985fc49ab-5f6c9c10fd.zip/node_modules/vscode-uri/",\
@@ -17567,6 +17995,15 @@ const RAW_RUNTIME_STATE =
           ["wasm-transpiled", "workspace:local/XAdmin/ui/wasm"]\
         ],\
         "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["whatwg-mimetype", [\
+      ["npm:3.0.0", {\
+        "packageLocation": "../.caches/yarn/whatwg-mimetype-npm-3.0.0-5b617710c1-323895a1cd.zip/node_modules/whatwg-mimetype/",\
+        "packageDependencies": [\
+          ["whatwg-mimetype", "npm:3.0.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["which", [\
@@ -17652,6 +18089,17 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["why-is-node-running", [\
+      ["npm:2.3.0", {\
+        "packageLocation": "../.caches/yarn/why-is-node-running-npm-2.3.0-011cf61a18-1cde0b01b8.zip/node_modules/why-is-node-running/",\
+        "packageDependencies": [\
+          ["siginfo", "npm:2.0.0"],\
+          ["stackback", "npm:0.0.2"],\
+          ["why-is-node-running", "npm:2.3.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["word-wrap", [\
       ["npm:1.2.5", {\
         "packageLocation": "../.caches/yarn/word-wrap-npm-1.2.5-42d00c4b09-e0e4a1ca27.zip/node_modules/word-wrap/",\
@@ -17678,6 +18126,32 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.caches/yarn/wrappy-npm-1.0.2-916de4d4b3-56fece1a40.zip/node_modules/wrappy/",\
         "packageDependencies": [\
           ["wrappy", "npm:1.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["ws", [\
+      ["npm:8.21.0", {\
+        "packageLocation": "../.caches/yarn/ws-npm-8.21.0-7629fe02dd-ef4a243476.zip/node_modules/ws/",\
+        "packageDependencies": [\
+          ["ws", "npm:8.21.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:dc896b83d081c6997c9337b24e705c9b36c8ed8f76d14638f4fdffa784b868c2707f73be6e59159c9411ebae5f860fe2c9205af27d00e7d67f9fbfba8170c1ec#npm:8.21.0", {\
+        "packageLocation": "./.yarn/__virtual__/ws-virtual-47f5d45f92/2/.caches/yarn/ws-npm-8.21.0-7629fe02dd-ef4a243476.zip/node_modules/ws/",\
+        "packageDependencies": [\
+          ["@types/bufferutil", null],\
+          ["@types/utf-8-validate", null],\
+          ["bufferutil", null],\
+          ["utf-8-validate", null],\
+          ["ws", "virtual:dc896b83d081c6997c9337b24e705c9b36c8ed8f76d14638f4fdffa784b868c2707f73be6e59159c9411ebae5f860fe2c9205af27d00e7d67f9fbfba8170c1ec#npm:8.21.0"]\
+        ],\
+        "packagePeers": [\
+          "@types/bufferutil",\
+          "@types/utf-8-validate",\
+          "bufferutil",\
+          "utf-8-validate"\
         ],\
         "linkType": "HARD"\
       }]\

--- a/packages/user/CommonApi/common/packages/common-lib/src/messaging/errors.ts
+++ b/packages/user/CommonApi/common/packages/common-lib/src/messaging/errors.ts
@@ -55,6 +55,7 @@ export class GenericErrorObject {
 export const isGenericError = (error: any): error is Error => {
     return (
         typeof error === "object" &&
+        error !== null &&
         "message" in error &&
         typeof error.message === "string" &&
         "name" in error &&
@@ -71,6 +72,7 @@ export const isGenericErrorObject = (
 ): error is GenericErrorObject => {
     return (
         typeof error === "object" &&
+        error !== null &&
         "message" in error &&
         typeof error.message === "string" &&
         "name" in error &&

--- a/packages/user/Supervisor/ui/package.json
+++ b/packages/user/Supervisor/ui/package.json
@@ -6,7 +6,8 @@
         "dev": "vite",
         "build": "node ../../../if-build-needed.mjs 'tsc -b --noEmit && vite build'",
         "lint": "eslint .",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "test": "vitest run"
     },
     "dependencies": {
         "@bytecodealliance/jco": "1.10.2",
@@ -22,7 +23,10 @@
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
         "eslint": "^9.15.0",
+        "happy-dom": "^20.10.2",
         "typescript": "^5.7.3",
-        "vite": "^5.4.1"
+        "vite": "^5.4.1",
+        "vite-tsconfig-paths": "^6.1.1",
+        "vitest": "2.1.9"
     }
 }

--- a/packages/user/Supervisor/ui/src/serialize.ts
+++ b/packages/user/Supervisor/ui/src/serialize.ts
@@ -3,7 +3,7 @@
 let queue: Promise<unknown> = Promise.resolve();
 
 export function serialize<T>(fn: () => Promise<T>): Promise<T> {
-    const res = queue.then(() => fn());
+    const res = queue.catch(() => {}).then(() => fn());
     queue = res.catch(() => {});
     return res;
 }

--- a/packages/user/Supervisor/ui/src/serialize.ts
+++ b/packages/user/Supervisor/ui/src/serialize.ts
@@ -1,0 +1,9 @@
+// Async serializer pattern:
+// https://advancedweb.hu/how-to-serialize-calls-to-an-async-function/
+let queue: Promise<unknown> = Promise.resolve();
+
+export function serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const res = queue.then(() => fn());
+    queue = res.catch(() => {});
+    return res;
+}

--- a/packages/user/Supervisor/ui/src/serialize.ts
+++ b/packages/user/Supervisor/ui/src/serialize.ts
@@ -1,9 +1,12 @@
 // Async serializer pattern:
 // https://advancedweb.hu/how-to-serialize-calls-to-an-async-function/
-let queue: Promise<unknown> = Promise.resolve();
+let queue: Promise<void> = Promise.resolve();
 
 export function serialize<T>(fn: () => Promise<T>): Promise<T> {
     const res = queue.catch(() => {}).then(() => fn());
-    queue = res.catch(() => {});
+    queue = res.then(
+        () => {},
+        () => {},
+    );
     return res;
 }

--- a/packages/user/Supervisor/ui/src/supervisor-concurrent-entry.test.ts
+++ b/packages/user/Supervisor/ui/src/supervisor-concurrent-entry.test.ts
@@ -1,0 +1,89 @@
+import { isPluginErrorObject } from "@psibase/common-lib/messaging";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CALL_SENTINEL } from "@/test/test-plugin";
+import {
+    createTestSupervisor,
+    mockAppCallArgs,
+    mockAppPluginId,
+    mockParentReplies,
+    TEST_ORIGIN,
+} from "@/test/supervisor-test-harness";
+
+vi.mock("./plugin/plugin-loader", () => ({
+    PluginLoader: class {
+        trackPlugins() {}
+        async processPlugins() {}
+        async awaitReady() {}
+    },
+}));
+
+vi.mock("./utils", () => ({
+    networkNamePromise: Promise.resolve("network"),
+    chainIdPromise: Promise.resolve("chain-id"),
+    networkName: "network",
+    chainId: "chain-id",
+    isEmbedded: false,
+    setQueryToken: vi.fn(),
+    serviceFromOrigin: () => "homepage",
+    parser: () => Promise.resolve({ parse: () => ({}) }),
+    assert: (condition: unknown, errorMessage: string) => {
+        if (!condition) {
+            throw new Error(errorMessage);
+        }
+    },
+    wasmFromUrl: vi.fn(),
+}));
+
+describe("Supervisor concurrent entry", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.location.href = TEST_ORIGIN;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("sequential entries both succeed", async () => {
+        const replies = mockParentReplies();
+        const supervisor = createTestSupervisor();
+        const args = mockAppCallArgs();
+
+        await supervisor.entry(TEST_ORIGIN, "id-1", args);
+        await supervisor.entry(TEST_ORIGIN, "id-2", args);
+
+        expect(replies.get("id-1")).toBe(CALL_SENTINEL);
+        expect(replies.get("id-2")).toBe(CALL_SENTINEL);
+    });
+
+    it("concurrent entries both succeed", async () => {
+        const replies = mockParentReplies();
+        const supervisor = createTestSupervisor();
+        const args = mockAppCallArgs();
+
+        await Promise.all([
+            supervisor.entry(TEST_ORIGIN, "id-a", args),
+            supervisor.entry(TEST_ORIGIN, "id-b", args),
+        ]);
+
+        expect(replies.get("id-a")).toBe(CALL_SENTINEL);
+        expect(replies.get("id-b")).toBe(CALL_SENTINEL);
+        expect(isPluginErrorObject(replies.get("id-a"))).toBe(false);
+        expect(isPluginErrorObject(replies.get("id-b"))).toBe(false);
+    });
+
+    it("concurrent preloadPlugins and entry both succeed", async () => {
+        const replies = mockParentReplies();
+        const supervisor = createTestSupervisor();
+        const args = mockAppCallArgs();
+
+        await Promise.all([
+            supervisor.preloadPlugins(TEST_ORIGIN, [mockAppPluginId()]),
+            supervisor.entry(TEST_ORIGIN, "id-entry", args),
+        ]);
+
+        expect(replies.get("id-entry")).toBe(CALL_SENTINEL);
+        expect(isPluginErrorObject(replies.get("id-entry"))).toBe(false);
+    });
+});

--- a/packages/user/Supervisor/ui/src/supervisor-concurrent-entry.test.ts
+++ b/packages/user/Supervisor/ui/src/supervisor-concurrent-entry.test.ts
@@ -1,14 +1,14 @@
-import { isPluginErrorObject } from "@psibase/common-lib/messaging";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import { CALL_SENTINEL } from "@/test/test-plugin";
 import {
+    TEST_ORIGIN,
     createTestSupervisor,
     mockAppCallArgs,
     mockAppPluginId,
     mockParentReplies,
-    TEST_ORIGIN,
 } from "@/test/supervisor-test-harness";
+import { CALL_SENTINEL } from "@/test/test-plugin";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isPluginErrorObject } from "@psibase/common-lib/messaging";
 
 vi.mock("./plugin/plugin-loader", () => ({
     PluginLoader: class {
@@ -79,10 +79,14 @@ describe("Supervisor concurrent entry", () => {
         const args = mockAppCallArgs();
 
         await Promise.all([
-            supervisor.preloadPlugins(TEST_ORIGIN, [mockAppPluginId()]),
+            supervisor.preloadPlugins(TEST_ORIGIN, "id-preload", [
+                mockAppPluginId(),
+            ]),
             supervisor.entry(TEST_ORIGIN, "id-entry", args),
         ]);
 
+        expect(replies.get("id-preload")).toBe(null);
+        expect(isPluginErrorObject(replies.get("id-preload"))).toBe(false);
         expect(replies.get("id-entry")).toBe(CALL_SENTINEL);
         expect(isPluginErrorObject(replies.get("id-entry"))).toBe(false);
     });

--- a/packages/user/Supervisor/ui/src/supervisor-concurrent-entry.test.ts
+++ b/packages/user/Supervisor/ui/src/supervisor-concurrent-entry.test.ts
@@ -1,14 +1,15 @@
-import { isPluginErrorObject } from "@psibase/common-lib/messaging";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import { CALL_SENTINEL } from "@/test/test-plugin";
+import { serialize } from "@/serialize";
 import {
+    TEST_ORIGIN,
     createTestSupervisor,
     mockAppCallArgs,
     mockAppPluginId,
     mockParentReplies,
-    TEST_ORIGIN,
 } from "@/test/supervisor-test-harness";
+import { CALL_SENTINEL } from "@/test/test-plugin";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isPluginErrorObject } from "@psibase/common-lib/messaging";
 
 vi.mock("./plugin/plugin-loader", () => ({
     PluginLoader: class {
@@ -50,8 +51,8 @@ describe("Supervisor concurrent entry", () => {
         const supervisor = createTestSupervisor();
         const args = mockAppCallArgs();
 
-        await supervisor.entry(TEST_ORIGIN, "id-1", args);
-        await supervisor.entry(TEST_ORIGIN, "id-2", args);
+        await serialize(() => supervisor.entry(TEST_ORIGIN, "id-1", args));
+        await serialize(() => supervisor.entry(TEST_ORIGIN, "id-2", args));
 
         expect(replies.get("id-1")).toBe(CALL_SENTINEL);
         expect(replies.get("id-2")).toBe(CALL_SENTINEL);
@@ -63,8 +64,8 @@ describe("Supervisor concurrent entry", () => {
         const args = mockAppCallArgs();
 
         await Promise.all([
-            supervisor.entry(TEST_ORIGIN, "id-a", args),
-            supervisor.entry(TEST_ORIGIN, "id-b", args),
+            serialize(() => supervisor.entry(TEST_ORIGIN, "id-a", args)),
+            serialize(() => supervisor.entry(TEST_ORIGIN, "id-b", args)),
         ]);
 
         expect(replies.get("id-a")).toBe(CALL_SENTINEL);
@@ -79,8 +80,10 @@ describe("Supervisor concurrent entry", () => {
         const args = mockAppCallArgs();
 
         await Promise.all([
-            supervisor.preloadPlugins(TEST_ORIGIN, [mockAppPluginId()]),
-            supervisor.entry(TEST_ORIGIN, "id-entry", args),
+            serialize(() =>
+                supervisor.preloadPlugins(TEST_ORIGIN, [mockAppPluginId()]),
+            ),
+            serialize(() => supervisor.entry(TEST_ORIGIN, "id-entry", args)),
         ]);
 
         expect(replies.get("id-entry")).toBe(CALL_SENTINEL);

--- a/packages/user/Supervisor/ui/src/supervisor.ts
+++ b/packages/user/Supervisor/ui/src/supervisor.ts
@@ -98,7 +98,18 @@ export class Supervisor implements AppInterface {
         }
     }
 
-    private preloadLock: Promise<void> = Promise.resolve();
+    private sessionLock: Promise<void> = Promise.resolve();
+
+    private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+        const session = this.sessionLock
+            .catch(() => {})
+            .then(() => fn());
+        this.sessionLock = session.then(
+            () => {},
+            () => {},
+        );
+        return session;
+    }
 
     // This step loads the full plugin tree (downloading + parsing + JCO transpiling)
     //
@@ -109,11 +120,7 @@ export class Supervisor implements AppInterface {
     // The caller should dispose of all instantiated plugins after the entry function
     //  finishes.
     private preload(plugins: QualifiedPluginId[]): Promise<void> {
-        const myPreload = this.preloadLock
-            .catch(() => {})
-            .then(() => this.doPreload(plugins));
-        this.preloadLock = myPreload.catch(() => {});
-        return myPreload;
+        return this.doPreload(plugins);
     }
 
     private async doPreload(plugins: QualifiedPluginId[]) {
@@ -349,35 +356,47 @@ export class Supervisor implements AppInterface {
         return ret;
     }
 
+    private cleanupSessionState(): void {
+        this.context = undefined;
+        this.parentOrigination = undefined;
+        this.embedder = undefined;
+    }
+
     // This is an entrypoint that returns the JSON interface for a plugin.
     async getJson(callerOrigin: string, id: string, plugin: QualifiedPluginId) {
-        try {
-            await networkNamePromise;
-            this.setParentOrigination(callerOrigin);
-            await this.preload([plugin]);
-            const json = this.plugins.getPlugin(plugin).plugin.getJson();
-            this.replyToParent(id, json);
-        } catch (e) {
-            this.replyToParent(id, e);
-        } finally {
-            this.plugins.disposeAll();
-        }
+        return this.runExclusive(async () => {
+            try {
+                await networkNamePromise;
+                this.setParentOrigination(callerOrigin);
+                await this.preload([plugin]);
+                const json = this.plugins.getPlugin(plugin).plugin.getJson();
+                this.replyToParent(id, json);
+            } catch (e) {
+                this.replyToParent(id, e);
+            } finally {
+                this.plugins.disposeAll();
+                this.cleanupSessionState();
+            }
+        });
     }
 
     // This is an entrypoint for apps to preload plugins.
     // Intended to be used on pageload to prepare the plugins that an app requires,
     //   which accelerates the responsiveness of the plugins for subsequent calls.
     async preloadPlugins(callerOrigin: string, plugins: QualifiedPluginId[]) {
-        try {
-            await networkNamePromise;
-            this.setParentOrigination(callerOrigin);
-            await this.preload(plugins);
-        } catch (e) {
-            console.error("TODO: Return an error to the caller.");
-            console.error(e);
-        } finally {
-            this.plugins.disposeAll();
-        }
+        return this.runExclusive(async () => {
+            try {
+                await networkNamePromise;
+                this.setParentOrigination(callerOrigin);
+                await this.preload(plugins);
+            } catch (e) {
+                console.error("TODO: Return an error to the caller.");
+                console.error(e);
+            } finally {
+                this.plugins.disposeAll();
+                this.cleanupSessionState();
+            }
+        });
     }
 
     // This is an entrypoint for apps to call into plugins.
@@ -386,65 +405,67 @@ export class Supervisor implements AppInterface {
         id: string,
         args: QualifiedFunctionCallArgs,
     ): Promise<any> {
-        try {
-            await networkNamePromise;
-            this.setParentOrigination(callerOrigin);
+        return this.runExclusive(async () => {
+            try {
+                await networkNamePromise;
+                this.setParentOrigination(callerOrigin);
 
-            // This is the time-intensive step. It includes: downloading, parsing, and transpiling the
-            //   each plugin component. Everything needed to prepare for instantiation and execution.
-            // UIs can use `preloadPlugins` to decouple this task from the actual call to the plugin.
-            await this.preload([
-                {
-                    service: args.service,
-                    plugin: args.plugin,
-                },
-            ]);
+                // This is the time-intensive step. It includes: downloading, parsing, and transpiling the
+                //   each plugin component. Everything needed to prepare for instantiation and execution.
+                // UIs can use `preloadPlugins` to decouple this task from the actual call to the plugin.
+                await this.preload([
+                    {
+                        service: args.service,
+                        plugin: args.plugin,
+                    },
+                ]);
 
-            await this.plugins.instantiateAll();
+                await this.plugins.instantiateAll();
 
-            this.context = this.getCallContext();
+                this.context = this.getCallContext();
 
-            // Starts the tx context.
-            this.supervisorCall(
-                getCallArgs("transact", "plugin", "admin", "start-tx", []),
-            );
+                // Starts the tx context.
+                this.supervisorCall(
+                    getCallArgs("transact", "plugin", "admin", "start-tx", []),
+                );
 
-            // Make a *synchronous* call into the plugin. It can be fully synchronous since everything was
-            //   preloaded.
-            const result = this.call(args);
+                // Make a *synchronous* call into the plugin. It can be fully synchronous since everything was
+                //   preloaded.
+                const result = this.call(args);
 
-            // Closes the current tx context. If actions were added, tx is submitted.
-            const txResult = this.supervisorCall(
-                getCallArgs("transact", "plugin", "admin", "finish-tx", []),
-            );
-            if (txResult !== null && txResult !== undefined) {
-                console.warn(txResult);
-            }
-
-            // Send plugin result to parent window
-            this.replyToParent(id, result);
-
-            this.context = undefined;
-        } catch (e) {
-            const err = getRecoverableError(e);
-            if (err) {
-                let newError;
-                if (err.code === REDIRECT_ERROR_CODE) {
-                    newError = new RedirectErrorObject(
-                        err.producer,
-                        err.message,
-                    );
-                } else {
-                    newError = new PluginErrorObject(err.producer, err.message);
+                // Closes the current tx context. If actions were added, tx is submitted.
+                const txResult = this.supervisorCall(
+                    getCallArgs("transact", "plugin", "admin", "finish-tx", []),
+                );
+                if (txResult !== null && txResult !== undefined) {
+                    console.warn(txResult);
                 }
-                this.replyToParent(id, newError);
-            } else {
-                this.replyToParent(id, e);
-            }
 
-            this.context = undefined;
-        } finally {
-            this.plugins.disposeAll();
-        }
+                // Send plugin result to parent window
+                this.replyToParent(id, result);
+            } catch (e) {
+                const err = getRecoverableError(e);
+                if (err) {
+                    let newError;
+                    if (err.code === REDIRECT_ERROR_CODE) {
+                        newError = new RedirectErrorObject(
+                            err.producer,
+                            err.message,
+                        );
+                    } else {
+                        newError = new PluginErrorObject(
+                            err.producer,
+                            err.message,
+                        );
+                    }
+                    this.replyToParent(id, newError);
+                } else {
+                    this.replyToParent(id, e);
+                }
+            } finally {
+                this.plugins.disposeAll();
+                this.cleanupSessionState();
+            }
+        });
     }
 }

--- a/packages/user/Supervisor/ui/src/supervisor.ts
+++ b/packages/user/Supervisor/ui/src/supervisor.ts
@@ -98,19 +98,6 @@ export class Supervisor implements AppInterface {
         }
     }
 
-    private sessionLock: Promise<void> = Promise.resolve();
-
-    private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
-        const session = this.sessionLock
-            .catch(() => {})
-            .then(() => fn());
-        this.sessionLock = session.then(
-            () => {},
-            () => {},
-        );
-        return session;
-    }
-
     // This step loads the full plugin tree (downloading + parsing + JCO transpiling)
     //
     // This does not instantiate wasms, with the exception of core system plugin wasms,
@@ -364,39 +351,35 @@ export class Supervisor implements AppInterface {
 
     // This is an entrypoint that returns the JSON interface for a plugin.
     async getJson(callerOrigin: string, id: string, plugin: QualifiedPluginId) {
-        return this.runExclusive(async () => {
-            try {
-                await networkNamePromise;
-                this.setParentOrigination(callerOrigin);
-                await this.preload([plugin]);
-                const json = this.plugins.getPlugin(plugin).plugin.getJson();
-                this.replyToParent(id, json);
-            } catch (e) {
-                this.replyToParent(id, e);
-            } finally {
-                this.plugins.disposeAll();
-                this.cleanupSessionState();
-            }
-        });
+        try {
+            await networkNamePromise;
+            this.setParentOrigination(callerOrigin);
+            await this.preload([plugin]);
+            const json = this.plugins.getPlugin(plugin).plugin.getJson();
+            this.replyToParent(id, json);
+        } catch (e) {
+            this.replyToParent(id, e);
+        } finally {
+            this.plugins.disposeAll();
+            this.cleanupSessionState();
+        }
     }
 
     // This is an entrypoint for apps to preload plugins.
     // Intended to be used on pageload to prepare the plugins that an app requires,
     //   which accelerates the responsiveness of the plugins for subsequent calls.
     async preloadPlugins(callerOrigin: string, plugins: QualifiedPluginId[]) {
-        return this.runExclusive(async () => {
-            try {
-                await networkNamePromise;
-                this.setParentOrigination(callerOrigin);
-                await this.preload(plugins);
-            } catch (e) {
-                console.error("TODO: Return an error to the caller.");
-                console.error(e);
-            } finally {
-                this.plugins.disposeAll();
-                this.cleanupSessionState();
-            }
-        });
+        try {
+            await networkNamePromise;
+            this.setParentOrigination(callerOrigin);
+            await this.preload(plugins);
+        } catch (e) {
+            console.error("TODO: Return an error to the caller.");
+            console.error(e);
+        } finally {
+            this.plugins.disposeAll();
+            this.cleanupSessionState();
+        }
     }
 
     // This is an entrypoint for apps to call into plugins.
@@ -405,67 +388,62 @@ export class Supervisor implements AppInterface {
         id: string,
         args: QualifiedFunctionCallArgs,
     ): Promise<any> {
-        return this.runExclusive(async () => {
-            try {
-                await networkNamePromise;
-                this.setParentOrigination(callerOrigin);
+        try {
+            await networkNamePromise;
+            this.setParentOrigination(callerOrigin);
 
-                // This is the time-intensive step. It includes: downloading, parsing, and transpiling the
-                //   each plugin component. Everything needed to prepare for instantiation and execution.
-                // UIs can use `preloadPlugins` to decouple this task from the actual call to the plugin.
-                await this.preload([
-                    {
-                        service: args.service,
-                        plugin: args.plugin,
-                    },
-                ]);
+            // This is the time-intensive step. It includes: downloading, parsing, and transpiling the
+            //   each plugin component. Everything needed to prepare for instantiation and execution.
+            // UIs can use `preloadPlugins` to decouple this task from the actual call to the plugin.
+            await this.preload([
+                {
+                    service: args.service,
+                    plugin: args.plugin,
+                },
+            ]);
 
-                await this.plugins.instantiateAll();
+            await this.plugins.instantiateAll();
 
-                this.context = this.getCallContext();
+            this.context = this.getCallContext();
 
-                // Starts the tx context.
-                this.supervisorCall(
-                    getCallArgs("transact", "plugin", "admin", "start-tx", []),
-                );
+            // Starts the tx context.
+            this.supervisorCall(
+                getCallArgs("transact", "plugin", "admin", "start-tx", []),
+            );
 
-                // Make a *synchronous* call into the plugin. It can be fully synchronous since everything was
-                //   preloaded.
-                const result = this.call(args);
+            // Make a *synchronous* call into the plugin. It can be fully synchronous since everything was
+            //   preloaded.
+            const result = this.call(args);
 
-                // Closes the current tx context. If actions were added, tx is submitted.
-                const txResult = this.supervisorCall(
-                    getCallArgs("transact", "plugin", "admin", "finish-tx", []),
-                );
-                if (txResult !== null && txResult !== undefined) {
-                    console.warn(txResult);
-                }
-
-                // Send plugin result to parent window
-                this.replyToParent(id, result);
-            } catch (e) {
-                const err = getRecoverableError(e);
-                if (err) {
-                    let newError;
-                    if (err.code === REDIRECT_ERROR_CODE) {
-                        newError = new RedirectErrorObject(
-                            err.producer,
-                            err.message,
-                        );
-                    } else {
-                        newError = new PluginErrorObject(
-                            err.producer,
-                            err.message,
-                        );
-                    }
-                    this.replyToParent(id, newError);
-                } else {
-                    this.replyToParent(id, e);
-                }
-            } finally {
-                this.plugins.disposeAll();
-                this.cleanupSessionState();
+            // Closes the current tx context. If actions were added, tx is submitted.
+            const txResult = this.supervisorCall(
+                getCallArgs("transact", "plugin", "admin", "finish-tx", []),
+            );
+            if (txResult !== null && txResult !== undefined) {
+                console.warn(txResult);
             }
-        });
+
+            // Send plugin result to parent window
+            this.replyToParent(id, result);
+        } catch (e) {
+            const err = getRecoverableError(e);
+            if (err) {
+                let newError;
+                if (err.code === REDIRECT_ERROR_CODE) {
+                    newError = new RedirectErrorObject(
+                        err.producer,
+                        err.message,
+                    );
+                } else {
+                    newError = new PluginErrorObject(err.producer, err.message);
+                }
+                this.replyToParent(id, newError);
+            } else {
+                this.replyToParent(id, e);
+            }
+        } finally {
+            this.plugins.disposeAll();
+            this.cleanupSessionState();
+        }
     }
 }

--- a/packages/user/Supervisor/ui/src/test/setup.ts
+++ b/packages/user/Supervisor/ui/src/test/setup.ts
@@ -1,0 +1,10 @@
+import { vi } from "vitest";
+
+vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: { depsFor: null } }),
+        arrayBuffer: async () => new ArrayBuffer(0),
+    })),
+);

--- a/packages/user/Supervisor/ui/src/test/supervisor-test-harness.ts
+++ b/packages/user/Supervisor/ui/src/test/supervisor-test-harness.ts
@@ -1,0 +1,73 @@
+import { QualifiedPluginId } from "@psibase/common-lib";
+import { isFunctionCallResponse } from "@psibase/common-lib/messaging";
+import { vi } from "vitest";
+
+import { Plugins } from "@/plugin/plugins";
+import { Supervisor } from "@/supervisor";
+
+import {
+    createAppPlugin,
+    createTransactPlugin,
+    TestPlugin,
+} from "./test-plugin";
+
+const MOCK_APP: QualifiedPluginId = { service: "mock", plugin: "plugin" };
+const TRANSACT: QualifiedPluginId = { service: "transact", plugin: "plugin" };
+
+export const TEST_ORIGIN = "http://network.psibase.localhost:8080";
+
+function injectPlugin(plugins: Plugins, plugin: TestPlugin): void {
+    const getServiceContext = (
+        plugins as unknown as {
+            getServiceContext: (service: string) => { plugins: TestPlugin[] };
+        }
+    ).getServiceContext.bind(plugins);
+    const ctx = getServiceContext(plugin.id.service);
+    const exists = ctx.plugins.some(
+        (existing) =>
+            existing.id.service === plugin.id.service &&
+            existing.id.plugin === plugin.id.plugin,
+    );
+    if (!exists) {
+        ctx.plugins.push(plugin);
+    }
+}
+
+function seedTestPlugins(plugins: Plugins): void {
+    injectPlugin(plugins, createAppPlugin(MOCK_APP));
+    injectPlugin(plugins, createTransactPlugin(TRANSACT));
+}
+
+export function createTestSupervisor(): Supervisor {
+    const supervisor = new Supervisor();
+    vi.spyOn(supervisor as unknown as { doPreload: () => Promise<void> }, "doPreload").mockImplementation(
+        async function (this: Supervisor) {
+            seedTestPlugins((this as unknown as { plugins: Plugins }).plugins);
+        },
+    );
+    return supervisor;
+}
+
+export function mockParentReplies(): Map<string, unknown> {
+    const replies = new Map<string, unknown>();
+    vi.spyOn(window.parent, "postMessage").mockImplementation((data) => {
+        if (isFunctionCallResponse(data)) {
+            replies.set(data.id, data.result);
+        }
+    });
+    return replies;
+}
+
+export function mockAppCallArgs() {
+    return {
+        service: MOCK_APP.service,
+        plugin: MOCK_APP.plugin,
+        intf: "api",
+        method: "ping",
+        params: [] as unknown[],
+    };
+}
+
+export function mockAppPluginId(): QualifiedPluginId {
+    return { ...MOCK_APP };
+}

--- a/packages/user/Supervisor/ui/src/test/test-plugin.ts
+++ b/packages/user/Supervisor/ui/src/test/test-plugin.ts
@@ -1,0 +1,79 @@
+import { QualifiedPluginId } from "@psibase/common-lib";
+
+import { PluginInvalid } from "@/plugin/errors";
+
+export const CALL_SENTINEL = "mock-entry-ok";
+
+export class TestPlugin {
+    id: QualifiedPluginId;
+
+    private pluginModule: Record<string, unknown> | undefined;
+
+    private readonly compiledPlugin = {
+        instantiate: async () => {
+            await Promise.resolve();
+            return { exports: {} };
+        },
+    };
+
+    constructor(id: QualifiedPluginId, private readonly handlers: TestPluginHandlers) {
+        this.id = id;
+    }
+
+    async instantiate(): Promise<void> {
+        if (this.pluginModule) {
+            return;
+        }
+        await this.compiledPlugin.instantiate();
+        this.pluginModule = {};
+    }
+
+    dispose(): boolean {
+        if (!this.pluginModule) {
+            return false;
+        }
+        this.pluginModule = undefined;
+        return true;
+    }
+
+    call(intf: string | undefined, method: string, _params: unknown[]): unknown {
+        if (!this.pluginModule) {
+            throw new PluginInvalid(this.id);
+        }
+        return this.handlers.call(intf, method);
+    }
+
+    resourceCall(): never {
+        throw new Error("TestPlugin does not implement resourceCall");
+    }
+
+    getJson(): string {
+        return "{}";
+    }
+}
+
+export type TestPluginHandlers = {
+    call: (intf: string | undefined, method: string) => unknown;
+};
+
+export function createAppPlugin(id: QualifiedPluginId): TestPlugin {
+    return new TestPlugin(id, {
+        call: (intf, method) => {
+            if (intf === "api" && method === "ping") {
+                return CALL_SENTINEL;
+            }
+            throw new Error(`Unexpected app call ${intf ?? ""}->${method}`);
+        },
+    });
+}
+
+export function createTransactPlugin(id: QualifiedPluginId): TestPlugin {
+    return new TestPlugin(id, {
+        call: (intf, method) => {
+            if (intf === "admin" && (method === "start-tx" || method === "finish-tx")) {
+                return null;
+            }
+            throw new Error(`Unexpected transact call ${intf ?? ""}->${method}`);
+        },
+    });
+}

--- a/packages/user/Supervisor/ui/src/window-messaging.ts
+++ b/packages/user/Supervisor/ui/src/window-messaging.ts
@@ -1,3 +1,5 @@
+import { serialize } from "./serialize";
+
 export interface CallHandler {
     checkType: (param: any) => boolean;
     dispatch: (param: MessageEvent<any>) => void;
@@ -6,9 +8,16 @@ export interface CallHandler {
 export const addCallHandler = (
     handlers: CallHandler[],
     checkType: (param: any) => boolean,
-    dispatch: (param: MessageEvent<any>) => void,
+    dispatch: (param: MessageEvent<any>) => Promise<void> | void,
 ) => {
-    handlers.push({ checkType, dispatch });
+    handlers.push({
+        checkType,
+        dispatch: (param) => {
+            void serialize(async () => {
+                await dispatch(param);
+            });
+        },
+    });
 };
 
 export const registerCallHandlers = (

--- a/packages/user/Supervisor/ui/vitest.config.mts
+++ b/packages/user/Supervisor/ui/vitest.config.mts
@@ -1,0 +1,21 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+    plugins: [tsconfigPaths()],
+    resolve: {
+        alias: {
+            "@": path.resolve(import.meta.dirname, "src"),
+            "@psibase/common-lib": path.resolve(
+                import.meta.dirname,
+                "../../CommonApi/common/packages/common-lib/src",
+            ),
+        },
+    },
+    test: {
+        environment: "happy-dom",
+        include: ["src/**/*.test.ts"],
+        setupFiles: ["src/test/setup.ts"],
+    },
+});

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -2049,10 +2049,13 @@ __metadata:
     "@types/react": "npm:^19.1.0"
     "@types/react-dom": "npm:^19.1.0"
     eslint: "npm:^9.15.0"
+    happy-dom: "npm:^20.10.2"
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     typescript: "npm:^5.7.3"
     vite: "npm:^5.4.1"
+    vite-tsconfig-paths: "npm:^6.1.1"
+    vitest: "npm:2.1.9"
     zod: "npm:^3.24.2"
   languageName: unknown
   linkType: soft
@@ -5173,6 +5176,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=20.0.0":
+  version: 26.0.0
+  resolution: "@types/node@npm:26.0.0"
+  dependencies:
+    undici-types: "npm:~8.3.0"
+  checksum: 10c0/f36e21634fd8e8ded162ca486508bd8bb229d398a8d5541f6d8c1255968d4464e53327a77f403b216ef98e3b6f6956882eef83e4857d4bc2be9569dd55d37aae
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^18.7.15":
   version: 18.19.130
   resolution: "@types/node@npm:18.19.130"
@@ -5301,6 +5313,22 @@ __metadata:
   version: 10.0.0
   resolution: "@types/uuid@npm:10.0.0"
   checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
+  languageName: node
+  linkType: hard
+
+"@types/whatwg-mimetype@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/whatwg-mimetype@npm:3.0.2"
+  checksum: 10c0/dad39d1e4abe760a0a963c84bbdbd26b1df0eb68aff83bdf6ecbb50ad781ead777f6906d19a87007790b750f7500a12e5624d31fc6a1529d14bd19b5c3a316d1
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -5462,6 +5490,87 @@ __metadata:
   peerDependencies:
     vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
   checksum: 10c0/692f23960972879485d647713663ec299c478222c96567d60285acf7c7dc5c178e71abfe9d2eefddef1eeb01514dacbc2ed68aad84628debf9c7116134734253
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/expect@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": "npm:2.1.9"
+    "@vitest/utils": "npm:2.1.9"
+    chai: "npm:^5.1.2"
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/98d1cf02917316bebef9e4720723e38298a1c12b3c8f3a81f259bb822de4288edf594e69ff64f0b88afbda6d04d7a4f0c2f720f3fec16b4c45f5e2669f09fdbb
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/mocker@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": "npm:2.1.9"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.12"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^5.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/f734490d8d1206a7f44dfdfca459282f5921d73efa72935bb1dc45307578defd38a4131b14853316373ec364cbe910dbc74594ed4137e0da35aa4d9bb716f190
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:2.1.9, @vitest/pretty-format@npm:^2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/pretty-format@npm:2.1.9"
+  dependencies:
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/155f9ede5090eabed2a73361094bb35ed4ec6769ae3546d2a2af139166569aec41bb80e031c25ff2da22b71dd4ed51e5468e66a05e6aeda5f14b32e30bc18f00
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/runner@npm:2.1.9"
+  dependencies:
+    "@vitest/utils": "npm:2.1.9"
+    pathe: "npm:^1.1.2"
+  checksum: 10c0/e81f176badb12a815cbbd9bd97e19f7437a0b64e8934d680024b0f768d8670d59cad698ef0e3dada5241b6731d77a7bb3cd2c7cb29f751fd4dd35eb11c42963a
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/snapshot@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:2.1.9"
+    magic-string: "npm:^0.30.12"
+    pathe: "npm:^1.1.2"
+  checksum: 10c0/394974b3a1fe96186a3c87f933b2f7f1f7b7cc42f9c781d80271dbb4c987809bf035fecd7398b8a3a2d54169e3ecb49655e38a0131d0e7fea5ce88960613b526
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/spy@npm:2.1.9"
+  dependencies:
+    tinyspy: "npm:^3.0.2"
+  checksum: 10c0/12a59b5095e20188b819a1d797e0a513d991b4e6a57db679927c43b362a3eff52d823b34e855a6dd9e73c9fa138dcc5ef52210841a93db5cbf047957a60ca83c
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/utils@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:2.1.9"
+    loupe: "npm:^3.1.2"
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/81a346cd72b47941f55411f5df4cc230e5f740d1e97e0d3f771b27f007266fc1f28d0438582f6409ea571bc0030ed37f684c64c58d1947d6298d770c21026fdf
   languageName: node
   linkType: hard
 
@@ -5927,6 +6036,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
 "async-function@npm:^1.0.0":
   version: 1.0.0
   resolution: "async-function@npm:1.0.0"
@@ -6168,6 +6284,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-image-size@npm:^0.6.4":
+  version: 0.6.4
+  resolution: "buffer-image-size@npm:0.6.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/7158205c8726caa521d3ae6ef7bc341eff211ff86f7278d122e45062e1720afef2f7ad8e845edc96c04f499b292c4ec8a74df9836a25074881260ba00b863448
+  languageName: node
+  linkType: hard
+
 "buffer@npm:^5.2.1":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
@@ -6175,6 +6300,13 @@ __metadata:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.1.13"
   checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
+  languageName: node
+  linkType: hard
+
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
   languageName: node
   linkType: hard
 
@@ -6286,6 +6418,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^5.1.2":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10c0/b360fd4d38861622e5010c2f709736988b05c7f31042305fa3f4e9911f6adb80ccfb4e302068bf8ed10e835c2e2520cba0f5edc13d878b886987e5aa62483f53
+  languageName: node
+  linkType: hard
+
 "chalk-template@npm:^1":
   version: 1.1.2
   resolution: "chalk-template@npm:1.1.2"
@@ -6309,6 +6454,13 @@ __metadata:
   version: 5.6.2
   resolution: "chalk@npm:5.6.2"
   checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: 10c0/878e99038fb6476316b74668cd6a498c7e66df3efe48158fa40db80a06ba4258742ac3ee2229c4a2a98c5e73f5dff84eb3e50ceb6b65bbd8f831eafc8338607d
   languageName: node
   linkType: hard
 
@@ -7194,6 +7346,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -7465,6 +7624,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "entities@npm:7.0.1"
+  checksum: 10c0/b4fb9937bb47ecb00aaaceb9db9cdd1cc0b0fb649c0e843d05cf5dbbd2e9d2df8f98721d8b1b286445689c72af7b54a7242fc2d63ef7c9739037a8c73363e7ca
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -7564,7 +7730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.6.0, es-module-lexer@npm:^1.7.0":
+"es-module-lexer@npm:^1.5.4, es-module-lexer@npm:^1.6.0, es-module-lexer@npm:^1.7.0":
   version: 1.7.0
   resolution: "es-module-lexer@npm:1.7.0"
   checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
@@ -8078,6 +8244,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2, esutils@npm:^2.0.3":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -8089,6 +8264,13 @@ __metadata:
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -8616,6 +8798,21 @@ __metadata:
   version: 1.0.4
   resolution: "grapheme-splitter@npm:1.0.4"
   checksum: 10c0/108415fb07ac913f17040dc336607772fcea68c7f495ef91887edddb0b0f5ff7bc1d1ab181b125ecb2f0505669ef12c9a178a3bbd2dd8e042d8c5f1d7c90331a
+  languageName: node
+  linkType: hard
+
+"happy-dom@npm:^20.10.2":
+  version: 20.10.6
+  resolution: "happy-dom@npm:20.10.6"
+  dependencies:
+    "@types/node": "npm:>=20.0.0"
+    "@types/whatwg-mimetype": "npm:^3.0.2"
+    "@types/ws": "npm:^8.18.1"
+    buffer-image-size: "npm:^0.6.4"
+    entities: "npm:^7.0.1"
+    whatwg-mimetype: "npm:^3.0.0"
+    ws: "npm:^8.21.0"
+  checksum: 10c0/3cf22def886b0876b00bb04b9fbaab6c05c041fbcf0869978b6fba9eddccc45a5fc6dab14e369502be9019da43eda44ad1bee3019029ef71bb0c7db3351f4a42
   languageName: node
   linkType: hard
 
@@ -9801,6 +9998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^3.1.0, loupe@npm:^3.1.2":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 10c0/910c872cba291309664c2d094368d31a68907b6f5913e989d301b5c25f30e97d76d77f23ab3bf3b46d0f601ff0b6af8810c10c31b91d2c6b2f132809ca2cc705
+  languageName: node
+  linkType: hard
+
 "lower-case@npm:^2.0.2":
   version: 2.0.2
   resolution: "lower-case@npm:2.0.2"
@@ -10695,10 +10899,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "pathe@npm:1.1.2"
+  checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
+  languageName: node
+  linkType: hard
+
 "pathe@npm:^2.0.1, pathe@npm:^2.0.3":
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 10c0/460f4709479fbf2c45903a65655fc8f0a5f6d808f989173aeef5fdea4ff4f303dc13f7870303999add60ec49d4c14733895c0a869392e9866f1091fa64fd7581
   languageName: node
   linkType: hard
 
@@ -12178,6 +12396,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
@@ -12288,6 +12513,20 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/405f3a531cd98b013cecb355d63555dca42fd12c7bc6671738aaa9a82882ff41cdf0ef9a2b734ca4f9a760338f114c29d01d9238a65db3ccac27929bd6e6d4b2
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.8.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
   languageName: node
   linkType: hard
 
@@ -12796,6 +13035,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
@@ -12810,6 +13063,27 @@ __metadata:
   version: 2.0.0
   resolution: "tinylogic@npm:2.0.0"
   checksum: 10c0/c9417c4b65dfc469c71c9eba4d43d44813ab8baceb80ba2c0e6c286de2e93e9c4b8522e4b0a7b91cb4a85353368ee93838a862262ce54bac431b884e694d1c89
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "tinyrainbow@npm:1.2.0"
+  checksum: 10c0/7f78a4b997e5ba0f5ecb75e7ed786f30bab9063716e7dff24dd84013fb338802e43d176cb21ed12480561f5649a82184cf31efb296601a29d38145b1cdb4c192
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "tinyspy@npm:3.0.2"
+  checksum: 10c0/55ffad24e346622b59292e097c2ee30a63919d5acb7ceca87fc0d1c223090089890587b426e20054733f97a58f20af2c349fb7cc193697203868ab7ba00bcea0
   languageName: node
   linkType: hard
 
@@ -13108,6 +13382,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10c0/c8aa7e2fbebfce519654dafadc0ece59be888d2ccaf180fb4495da875e7b536d2456345c384069c7e6f3e9c9ab7435f074957da306f142343eee86ff8048855a
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^5.0.0":
   version: 5.0.0
   resolution: "unique-filename@npm:5.0.0"
@@ -13257,6 +13538,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:2.1.9":
+  version: 2.1.9
+  resolution: "vite-node@npm:2.1.9"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.3.7"
+    es-module-lexer: "npm:^1.5.4"
+    pathe: "npm:^1.1.2"
+    vite: "npm:^5.0.0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10c0/0d3589f9f4e9cff696b5b49681fdb75d1638c75053728be52b4013f70792f38cb0120a9c15e3a4b22bdd6b795ad7c2da13bcaf47242d439f0906049e73bdd756
+  languageName: node
+  linkType: hard
+
 "vite-plugin-dts@npm:^4.5.0":
   version: 4.5.4
   resolution: "vite-plugin-dts@npm:4.5.4"
@@ -13344,7 +13640,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.4.1, vite@npm:^5.4.11":
+"vite-tsconfig-paths@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "vite-tsconfig-paths@npm:6.1.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+    globrex: "npm:^0.1.2"
+    tsconfck: "npm:^3.0.3"
+  peerDependencies:
+    vite: "*"
+  checksum: 10c0/5e61080991418fefa08c5b98995cdcada4931ae01ac97ef9e2ee941051f61b76890a6e7ba48bed3b2a229ec06fef33a06621bba4ce457b3f4233ad31dc0c1d1b
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0, vite@npm:^5.4.1, vite@npm:^5.4.11":
   version: 5.4.21
   resolution: "vite@npm:5.4.21"
   dependencies:
@@ -13399,6 +13708,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vitest@npm:2.1.9":
+  version: 2.1.9
+  resolution: "vitest@npm:2.1.9"
+  dependencies:
+    "@vitest/expect": "npm:2.1.9"
+    "@vitest/mocker": "npm:2.1.9"
+    "@vitest/pretty-format": "npm:^2.1.9"
+    "@vitest/runner": "npm:2.1.9"
+    "@vitest/snapshot": "npm:2.1.9"
+    "@vitest/spy": "npm:2.1.9"
+    "@vitest/utils": "npm:2.1.9"
+    chai: "npm:^5.1.2"
+    debug: "npm:^4.3.7"
+    expect-type: "npm:^1.1.0"
+    magic-string: "npm:^0.30.12"
+    pathe: "npm:^1.1.2"
+    std-env: "npm:^3.8.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.1"
+    tinypool: "npm:^1.0.1"
+    tinyrainbow: "npm:^1.2.0"
+    vite: "npm:^5.0.0"
+    vite-node: "npm:2.1.9"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/node": ^18.0.0 || >=20.0.0
+    "@vitest/browser": 2.1.9
+    "@vitest/ui": 2.1.9
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/e339e16dccacf4589ff43cb1f38c7b4d14427956ae8ef48702af6820a9842347c2b6c77356aeddb040329759ca508a3cb2b104ddf78103ea5bc98ab8f2c3a54e
+  languageName: node
+  linkType: hard
+
 "vscode-uri@npm:^3.0.8":
   version: 3.1.0
   resolution: "vscode-uri@npm:3.1.0"
@@ -13418,6 +13777,13 @@ __metadata:
   resolution: "wasm-transpiled@workspace:local/XAdmin/ui/wasm"
   languageName: unknown
   linkType: soft
+
+"whatwg-mimetype@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "whatwg-mimetype@npm:3.0.0"
+  checksum: 10c0/323895a1cda29a5fb0b9ca82831d2c316309fede0365047c4c323073e3239067a304a09a1f4b123b9532641ab604203f33a1403b5ca6a62ef405bcd7a204080f
+  languageName: node
+  linkType: hard
 
 "which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
   version: 1.1.1
@@ -13502,6 +13868,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
+  languageName: node
+  linkType: hard
+
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
@@ -13524,6 +13902,21 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.21.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Problem (https://github.com/gofractally/psibase/issues/1864)
Method calls to the Supervisor client could race. The big issue was that each method call ends with `disposeAll()` (wasms). If 2 method calls were made in rapid succession, the first call's disposeAll() could rug pull the wams the 2nd method call planned to use. More technically, for `Promise.all[supervisor.preloadPlugins(...), supervisor.entry(...))` the 2nd method call would `await this.preload(...)`, as soon as 1st method call resolved the preload promise, 2nd method call would continue, but the 1st method call wasn't quite done. In its `finally { ... }`, it would call `disposeAll()` potentially at quite the inopportune time for the 2nd method call.

I've included tests that repro the issue (and currently pass with the fix), but if you want to see the issue, I've added logging, which slows things just enough to show the issue. branch: `mm/exposing-supervisor-entry-race`

The Fix
While perhaps not the most elegant, is the simplest effective fix that also mirrors how this was being done already with the old `this.preloadLock` which has effectively had its scope expanded to the full scope of each method call isntead of its former, smaller scope.

Now all Supervisor method calls are guaranteed to complete before the next Supervisor method call is entertained, ensuring there's no `disposeAll()` stomping of other Supervisor method calls.