### PR TITLE
Making Supervisor.preLoadPlugins() more honest

### DIFF
--- a/packages/user/CommonApi/common/packages/common-lib/src/messaging/preload-plugins-request.ts
+++ b/packages/user/CommonApi/common/packages/common-lib/src/messaging/preload-plugins-request.ts
@@ -4,6 +4,7 @@ const PRE_LOAD_PLUGINS_REQUEST = "PRE_LOAD_PLUGINS_REQUEST" as const;
 
 export interface PreLoadPluginsRequest {
     type: typeof PRE_LOAD_PLUGINS_REQUEST;
+    id: string;
     payload: {
         plugins: QualifiedPluginId[];
     };
@@ -18,6 +19,7 @@ export const buildPreLoadPluginsRequest = (
     plugins: QualifiedPluginId[],
 ): PreLoadPluginsRequest => ({
     type: PRE_LOAD_PLUGINS_REQUEST,
+    id: window.crypto.randomUUID?.() ?? Math.random().toString(),
     payload: {
         plugins,
     },

--- a/packages/user/CommonApi/common/packages/common-lib/src/supervisor.ts
+++ b/packages/user/CommonApi/common/packages/common-lib/src/supervisor.ts
@@ -258,22 +258,23 @@ export class Supervisor {
         });
     }
 
-    public async preLoadPlugins(plugins: PluginId[]) {
-        await this.onLoaded();
+    public preLoadPlugins(plugins: PluginId[]) {
         // Fully qualify any plugins with default values
         const fqPlugins: QualifiedPluginId[] = plugins.map((plugin) => ({
             ...plugin,
             plugin: plugin.plugin || "plugin",
         }));
 
-        const message = buildPreLoadPluginsRequest(fqPlugins);
-
-        const iframe = this.getSupervisorIframe();
-        if (!iframe.contentWindow)
-            throw new Error(
-                `Failed to get content window from supervisor iframe`,
-            );
-        iframe.contentWindow.postMessage(message, this.supervisorSrc);
+        const request = buildPreLoadPluginsRequest(fqPlugins);
+        const autoRedirectConfig: AutoRedirectConfig = {
+            enabled: false,
+            returnPath: "/",
+        };
+        return this.sendRequest(
+            `Preload plugins: ${fqPlugins.map((p) => `${p.service}:${p.plugin}`).join(", ")}`,
+            autoRedirectConfig,
+            request,
+        );
     }
 }
 

--- a/packages/user/Supervisor/ui/src/app-interface.ts
+++ b/packages/user/Supervisor/ui/src/app-interface.ts
@@ -9,18 +9,19 @@ import {
 export interface AppInterface {
     preloadPlugins: (
         callerOrigin: string,
+        id: string,
         plugins: QualifiedPluginId[],
-    ) => void;
+    ) => Promise<void>;
 
     entry: (
         callerOrigin: string,
         id: UUID,
         args: QualifiedFunctionCallArgs,
-    ) => void;
+    ) => Promise<void>;
 
     getJson: (
         callerOrigin: string,
         id: string,
         plugin: QualifiedPluginId,
-    ) => void;
+    ) => Promise<void>;
 }

--- a/packages/user/Supervisor/ui/src/main.ts
+++ b/packages/user/Supervisor/ui/src/main.ts
@@ -63,7 +63,11 @@ addCallHandler(callHandlers, isFunctionCallRequest, (msg) =>
     supervisor.entry(msg.origin, msg.data.id, normalizeCallArgs(msg.data.args)),
 );
 addCallHandler(callHandlers, isPreLoadPluginsRequest, (msg) =>
-    supervisor.preloadPlugins(msg.origin, msg.data.payload.plugins),
+    supervisor.preloadPlugins(
+        msg.origin,
+        msg.data.id,
+        msg.data.payload.plugins,
+    ),
 );
 addCallHandler(callHandlers, isGetJsonRequest, (msg) =>
     supervisor.getJson(msg.origin, msg.data.id, msg.data.payload.plugin),

--- a/packages/user/Supervisor/ui/src/supervisor.ts
+++ b/packages/user/Supervisor/ui/src/supervisor.ts
@@ -367,16 +367,21 @@ export class Supervisor implements AppInterface {
     // This is an entrypoint for apps to preload plugins.
     // Intended to be used on pageload to prepare the plugins that an app requires,
     //   which accelerates the responsiveness of the plugins for subsequent calls.
-    async preloadPlugins(callerOrigin: string, plugins: QualifiedPluginId[]) {
+    async preloadPlugins(
+        callerOrigin: string,
+        id: string,
+        plugins: QualifiedPluginId[],
+    ) {
+        let result: unknown = null;
         try {
             await networkNamePromise;
             this.setParentOrigination(callerOrigin);
             await this.preload(plugins);
         } catch (e) {
-            console.error("TODO: Return an error to the caller.");
-            console.error(e);
+            result = e;
         } finally {
             this.plugins.disposeAll();
+            this.replyToParent(id, result);
         }
     }
 


### PR DESCRIPTION
`preLoadPlugins()` is declared async, but if a client awaits it, the client will see the promise resolved before preLoadPlugins() has run it's `finally { ... }`, so awaiting it doesn't do what a client would reasonably expect it to do.
This fix uses the existing code flow that `getJson()` and `entry()` already use to make the await honest.