### PR TITLE
use /usr/bin/env to find bash in scripts

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 WORKSPACE_ROOT=$1
 BUILDER_IMAGE=$2
 UBUNTU_BUILD_VER=$3

--- a/.github/scripts/make_publisher.sh
+++ b/.github/scripts/make_publisher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: make_publisher.sh <ACCOUNT> <CHAIN_URL>
 #

--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/.github/scripts/submodule-regression-check.sh
+++ b/.github/scripts/submodule-regression-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 declare -A PR_MAP
 declare -A BASE_MAP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1274,7 +1274,7 @@ function(write_package_index target dir)
     add_custom_command(
         OUTPUT ${dir}/index.json
         DEPENDS ${deps}
-        COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/make_package_index.sh ${CMAKE_COMMAND} ${dir} ${ARGN} >${dir}/index.json
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/make_package_index.sh ${CMAKE_COMMAND} ${dir} ${ARGN} >${dir}/index.json
     )
     add_custom_target(${target} ALL DEPENDS ${dir}/index.json)
 endfunction()

--- a/libraries/psibase/sdk/psidk-cmake-args
+++ b/libraries/psibase/sdk/psidk-cmake-args
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SDK=$(realpath -e `dirname "$0"`/..)
 
 echo -DCMAKE_TOOLCHAIN_FILE=$SDK/share/psibase/cmake/toolchain.cmake

--- a/make_package_index.sh
+++ b/make_package_index.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CMAKE_COMMAND="$1"
 DIR="$2"

--- a/rust/scripts/publish.sh
+++ b/rust/scripts/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run with 
 #   `./scripts/publish.sh`

--- a/rust/scripts/set-version.sh
+++ b/rust/scripts/set-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run with 
 #   `./scripts/set-version.sh x.y.z`


### PR DESCRIPTION
This change uses the /usr/bin/env utility to find the location of bash in scripts.
Right now, the scripts are assuming the location of bash which might not be true on some systems such as NixOS and others.

For more information, please see https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability , https://stackoverflow.com/a/10383546 