### PR TITLE
Improve dirty tracking

### DIFF
--- a/packages/shared-ui/components/form/internal/field-errors.tsx
+++ b/packages/shared-ui/components/form/internal/field-errors.tsx
@@ -7,7 +7,7 @@ type FieldErrorsProps = {
 };
 
 export const FieldErrors = ({ meta }: FieldErrorsProps) => {
-    if (!meta?.errors.length) return null;
+    if (!meta?.isTouched) return null;
 
     return meta.errors.map(parseError).map((error, index) => (
         <p key={index} className="text-destructive text-sm">

--- a/packages/shared-ui/components/form/internal/field-errors.tsx
+++ b/packages/shared-ui/components/form/internal/field-errors.tsx
@@ -7,7 +7,7 @@ type FieldErrorsProps = {
 };
 
 export const FieldErrors = ({ meta }: FieldErrorsProps) => {
-    if (!meta?.isTouched) return null;
+    if (!meta?.errors.length) return null;
 
     return meta.errors.map(parseError).map((error, index) => (
         <p key={index} className="text-destructive text-sm">

--- a/packages/user/Config/ui/src/lib/name-market-form.ts
+++ b/packages/user/Config/ui/src/lib/name-market-form.ts
@@ -173,15 +173,6 @@ export function marketRowsEqual(
     );
 }
 
-export function getDirtyMarkets(
-    values: NameMarketsFormValues,
-    defaults: NameMarketsFormValues,
-): NameMarketFormRow[] {
-    return values.markets.filter(
-        (row, index) => !marketRowsEqual(row, defaults.markets[index]!),
-    );
-}
-
 export function validateDirtyMarkets(
     values: NameMarketsFormValues,
     defaults: NameMarketsFormValues,
@@ -190,9 +181,6 @@ export function validateDirtyMarkets(
     const fieldErrors: Record<string, string> = {};
 
     values.markets.forEach((row, index) => {
-        if (marketRowsEqual(row, defaults.markets[index]!)) {
-            return;
-        }
 
         const result = zDirtyMarketRow(systemToken).safeParse(row);
         if (result.success) {

--- a/packages/user/Config/ui/src/lib/name-market-form.ts
+++ b/packages/user/Config/ui/src/lib/name-market-form.ts
@@ -137,9 +137,9 @@ export function buildNameMarketsFormValues(
         const windowForm = configured
             ? secondsToWindowForm(row!.windowSeconds)
             : {
-                  amount: "",
-                  unit: NAME_MARKET_DEFAULT_PARAMS.windowUnit,
-              };
+                amount: "",
+                unit: NAME_MARKET_DEFAULT_PARAMS.windowUnit,
+            };
         markets.push({
             length,
             configured,
@@ -157,30 +157,17 @@ export function buildNameMarketsFormValues(
     return { markets };
 }
 
-export function marketRowsEqual(
-    a: NameMarketFormRow,
-    b: NameMarketFormRow,
-): boolean {
-    return (
-        a.enabled === b.enabled &&
-        a.initialPrice === b.initialPrice &&
-        a.floorPrice === b.floorPrice &&
-        a.windowAmount === b.windowAmount &&
-        a.windowUnit === b.windowUnit &&
-        a.target === b.target &&
-        a.increasePct === b.increasePct &&
-        a.decreasePct === b.decreasePct
-    );
-}
-
 export function validateDirtyMarkets(
     values: NameMarketsFormValues,
-    defaults: NameMarketsFormValues,
     systemToken: SystemTokenInfo,
+    isRowDirty: (index: number) => boolean,
 ): { fields: Record<string, string> } | undefined {
     const fieldErrors: Record<string, string> = {};
 
     values.markets.forEach((row, index) => {
+        if (!isRowDirty(index)) {
+            return;
+        }
 
         const result = zDirtyMarketRow(systemToken).safeParse(row);
         if (result.success) {

--- a/packages/user/Config/ui/src/pages/account-marketplace/components/name-market-row-panel.tsx
+++ b/packages/user/Config/ui/src/pages/account-marketplace/components/name-market-row-panel.tsx
@@ -1,7 +1,4 @@
-import type {
-    NameMarketFormRow,
-    NameMarketsFormValues,
-} from "@/lib/name-market-form";
+import type { NameMarketsFormValues } from "@/lib/name-market-form";
 import type { AnyFieldMeta } from "@tanstack/react-form";
 import type { ReactNode } from "react";
 
@@ -48,7 +45,7 @@ type MarketFormApi = {
                 value: string;
                 meta: {
                     errors: unknown[];
-                    isTouched: boolean;
+                    isDefaultValue: boolean;
                 };
             };
             handleChange: (value: string) => void;
@@ -64,7 +61,6 @@ type MarketFormApi = {
 export type NameMarketRowPanelProps = {
     form: MarketFormApi;
     index: number;
-    baseline: NameMarketFormRow;
     actionsDisabled: boolean;
 };
 
@@ -78,7 +74,6 @@ function CompactField({
     placeholder,
     inputMode,
     meta,
-    isDirty,
 }: {
     id: string;
     label: string;
@@ -88,14 +83,23 @@ function CompactField({
     disabled?: boolean;
     placeholder?: string;
     inputMode?: "numeric" | "text";
-    meta: { errors: unknown[]; isTouched: boolean };
-    isDirty?: boolean;
+    meta: {
+        errors: unknown[];
+        isDefaultValue: boolean;
+    };
 }) {
-    const isError = meta.errors.length > 0 && meta.isTouched;
+    const isDirty = !meta.isDefaultValue;
+    const isError = meta.errors.length > 0;
 
     return (
         <div className="grid min-w-0 gap-1">
-            <Label htmlFor={id} className={FIELD_LABEL_CLASS}>
+            <Label
+                htmlFor={id}
+                className={cn(
+                    FIELD_LABEL_CLASS,
+                    isError && "text-destructive",
+                )}
+            >
                 {label}
             </Label>
             <Input
@@ -110,8 +114,8 @@ function CompactField({
                 className={cn(
                     "h-8 scroll-mt-28 font-mono text-sm",
                     isDirty &&
-                        !isError &&
-                        "border-amber-300 ring-2 ring-amber-400/50 dark:border-amber-700 dark:ring-amber-500/40",
+                    !isError &&
+                    "border-amber-300 ring-2 ring-amber-400/50 dark:border-amber-700 dark:ring-amber-500/40",
                 )}
                 aria-invalid={isError}
             />
@@ -138,10 +142,12 @@ function WindowLengthField({
     onUnitChange: (value: DurationUnit) => void;
     onAmountBlur: () => void;
     disabled?: boolean;
-    meta: { errors: unknown[]; isTouched: boolean };
+    meta: {
+        errors: unknown[];
+    };
     isDirty?: boolean;
 }) {
-    const isError = meta.errors.length > 0 && meta.isTouched;
+    const isError = meta.errors.length > 0;
     const dirtyRingClass =
         isDirty && !isError
             ? "border-amber-300 ring-2 ring-amber-400/50 dark:border-amber-700 dark:ring-amber-500/40"
@@ -204,7 +210,6 @@ function WindowLengthField({
 export function NameMarketRowPanel({
     form,
     index,
-    baseline,
     actionsDisabled,
 }: NameMarketRowPanelProps) {
     const baseName = `markets[${index}]` as const;
@@ -232,9 +237,6 @@ export function NameMarketRowPanel({
                                         : MARKET_FIELD_PLACEHOLDERS.initialPrice
                                 }
                                 meta={field.state.meta}
-                                isDirty={
-                                    field.state.value !== baseline.initialPrice
-                                }
                             />
                         )}
                     </form.Field>
@@ -252,9 +254,6 @@ export function NameMarketRowPanel({
                                     MARKET_FIELD_PLACEHOLDERS.floorPrice
                                 }
                                 meta={field.state.meta}
-                                isDirty={
-                                    field.state.value !== baseline.floorPrice
-                                }
                             />
                         )}
                     </form.Field>
@@ -278,10 +277,10 @@ export function NameMarketRowPanel({
                                         disabled={actionsDisabled}
                                         meta={amountField.state.meta}
                                         isDirty={
-                                            amountField.state.value !==
-                                                baseline.windowAmount ||
-                                            unitField.state.value !==
-                                                baseline.windowUnit
+                                            !amountField.state.meta
+                                                .isDefaultValue ||
+                                            !unitField.state.meta
+                                                .isDefaultValue
                                         }
                                     />
                                 )}
@@ -301,7 +300,6 @@ export function NameMarketRowPanel({
                                 inputMode="numeric"
                                 placeholder={MARKET_FIELD_PLACEHOLDERS.target}
                                 meta={field.state.meta}
-                                isDirty={field.state.value !== baseline.target}
                             />
                         )}
                     </form.Field>
@@ -320,9 +318,6 @@ export function NameMarketRowPanel({
                                     MARKET_FIELD_PLACEHOLDERS.increasePct
                                 }
                                 meta={field.state.meta}
-                                isDirty={
-                                    field.state.value !== baseline.increasePct
-                                }
                             />
                         )}
                     </form.Field>
@@ -341,9 +336,6 @@ export function NameMarketRowPanel({
                                     MARKET_FIELD_PLACEHOLDERS.decreasePct
                                 }
                                 meta={field.state.meta}
-                                isDirty={
-                                    field.state.value !== baseline.decreasePct
-                                }
                             />
                         )}
                     </form.Field>

--- a/packages/user/Config/ui/src/pages/account-marketplace/components/name-market-row-panel.tsx
+++ b/packages/user/Config/ui/src/pages/account-marketplace/components/name-market-row-panel.tsx
@@ -95,10 +95,7 @@ function CompactField({
         <div className="grid min-w-0 gap-1">
             <Label
                 htmlFor={id}
-                className={cn(
-                    FIELD_LABEL_CLASS,
-                    isError && "text-destructive",
-                )}
+                className={FIELD_LABEL_CLASS}
             >
                 {label}
             </Label>

--- a/packages/user/Config/ui/src/pages/account-marketplace/index.tsx
+++ b/packages/user/Config/ui/src/pages/account-marketplace/index.tsx
@@ -8,7 +8,6 @@ import {
     type NameMarketFormRow,
     type NameMarketsFormValues,
     buildNameMarketsFormValues,
-    getDirtyMarkets,
     validateDirtyMarkets,
 } from "@/lib/name-market-form";
 import { scrollToFirstMarketFieldError } from "@/lib/name-market-validation-ui";
@@ -128,9 +127,10 @@ export const NameMarketConfig = () => {
                 return;
             }
 
-            const defaults = formApi.options
-                .defaultValues as NameMarketsFormValues;
-            const dirtyRows = getDirtyMarkets(value, defaults);
+            const { fieldMeta } = formApi.state;
+            const dirtyRows = value.markets.filter((_, index) =>
+                isMarketRowDirty(fieldMeta, index),
+            );
             if (dirtyRows.length === 0) {
                 return;
             }

--- a/packages/user/Config/ui/src/pages/account-marketplace/index.tsx
+++ b/packages/user/Config/ui/src/pages/account-marketplace/index.tsx
@@ -9,7 +9,6 @@ import {
     type NameMarketsFormValues,
     buildNameMarketsFormValues,
     getDirtyMarkets,
-    marketRowsEqual,
     validateDirtyMarkets,
 } from "@/lib/name-market-form";
 import { scrollToFirstMarketFieldError } from "@/lib/name-market-validation-ui";
@@ -56,6 +55,16 @@ const MARKET_EDITABLE_FIELDS: Array<keyof NameMarketFormRow> = [
     "increasePct",
     "decreasePct",
 ];
+
+function isMarketRowDirty(
+    fieldMeta: Record<string, { isDefaultValue?: boolean } | undefined>,
+    index: number,
+): boolean {
+    return MARKET_EDITABLE_FIELDS.some((field) => {
+        const meta = fieldMeta[`markets[${index}].${field}`];
+        return meta != null && meta.isDefaultValue === false;
+    });
+}
 
 export const NameMarketConfig = () => {
     const { data: systemToken, isLoading: systemTokenLoading } =
@@ -107,17 +116,6 @@ export const NameMarketConfig = () => {
 
                 if (validation?.fields) {
                     window.requestAnimationFrame(() => {
-                        for (const fieldPath of Object.keys(
-                            validation.fields,
-                        )) {
-                            form.setFieldMeta(
-                                fieldPath as `markets[${number}].initialPrice`,
-                                (prev) => ({
-                                    ...prev,
-                                    isTouched: true,
-                                }),
-                            );
-                        }
                         scrollToFirstMarketFieldError(validation.fields);
                     });
                 }
@@ -143,27 +141,17 @@ export const NameMarketConfig = () => {
         },
     });
 
-    const isDirty = useStore(form.store, (state) => state.isDirty);
+    const isDirty = useStore(form.store, (state) => !state.isDefaultValue);
 
     const resetMarketRow = useCallback(
         (index: number) => {
-            const baseline = defaultValues.markets[index];
-            if (!baseline) {
-                return;
-            }
-
             for (const field of MARKET_EDITABLE_FIELDS) {
-                const fieldName =
-                    `markets[${index}].${field}` as `markets[${number}].${typeof field}`;
-                form.setFieldValue(fieldName, baseline[field]);
-                form.setFieldMeta(fieldName, (prev) => ({
-                    ...prev,
-                    isTouched: false,
-                    errors: [],
-                }));
+                form.resetField(
+                    `markets[${index}].${field}` as `markets[${number}].${typeof field}`,
+                );
             }
         },
-        [defaultValues.markets, form],
+        [form],
     );
 
     const isMarketsLoading = systemTokenLoading || isLoading;
@@ -249,151 +237,149 @@ export const NameMarketConfig = () => {
                     }}
                     className="pb-20"
                 >
-                    <div className="space-y-4">
-                        {defaultValues.markets.map((market, index) => (
-                            <Card
-                                key={market.length}
-                                className={cn(
-                                    "gap-0 py-0 shadow-sm",
-                                    !market.configured && "border-dashed",
-                                )}
-                            >
-                                <form.Subscribe
-                                    selector={(state) => {
-                                        const current =
-                                            state.values.markets[index];
-                                        const baseline =
-                                            defaultValues.markets[index];
-                                        return {
-                                            enabled: current?.enabled,
-                                            isRowDirty:
-                                                current !== undefined &&
-                                                baseline !== undefined &&
-                                                !marketRowsEqual(
-                                                    current,
-                                                    baseline,
+                    <form.Subscribe selector={(state) => state.values.markets}>
+                        {(markets) => (
+                            <div className="space-y-4">
+                                {markets.map((market, index) => (
+                                    <Card
+                                        key={market.length}
+                                        className={cn(
+                                            "gap-0 py-0 shadow-sm",
+                                            !market.configured &&
+                                                "border-dashed",
+                                        )}
+                                    >
+                                        <form.Subscribe
+                                            selector={(state) => ({
+                                                enabled:
+                                                    state.values.markets[index]
+                                                        ?.enabled,
+                                                isRowDirty: isMarketRowDirty(
+                                                    state.fieldMeta,
+                                                    index,
                                                 ),
-                                        };
-                                    }}
-                                >
-                                    {({ enabled, isRowDirty }) => (
-                                        <>
-                                            <CardHeader
-                                                className={cn(
-                                                    "flex items-center gap-4 px-4 py-3",
-                                                    enabled &&
-                                                        "[.border-b]:pb-3 border-b",
-                                                )}
-                                            >
-                                                <div className="flex flex-1 flex-wrap items-center justify-between gap-2">
-                                                    <div className="flex flex-wrap items-center gap-2">
-                                                        <CardTitle className="font-mono text-sm font-medium">
-                                                            Length{" "}
-                                                            {market.length}
-                                                        </CardTitle>
-                                                        {market.configured &&
-                                                        enabled &&
-                                                        systemToken ? (
-                                                            <LivePrice
-                                                                price={livePriceByLength.get(
-                                                                    market.length,
-                                                                )}
-                                                                systemToken={
-                                                                    systemToken
-                                                                }
-                                                                className="text-muted-foreground px-1 py-0.5 text-xs"
-                                                            />
-                                                        ) : null}
-                                                    </div>
-                                                    <div
+                                            })}
+                                        >
+                                            {({ enabled, isRowDirty }) => (
+                                                <>
+                                                    <CardHeader
                                                         className={cn(
-                                                            "flex items-center gap-1.5",
-                                                            !isRowDirty &&
-                                                                "invisible",
+                                                            "flex items-center gap-4 px-4 py-3",
+                                                            enabled &&
+                                                                "[.border-b]:pb-3 border-b",
                                                         )}
-                                                        aria-hidden={
-                                                            !isRowDirty
-                                                        }
                                                     >
-                                                        <Badge
-                                                            variant="outline"
-                                                            className="border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
-                                                        >
-                                                            Unsaved changes
-                                                        </Badge>
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="icon-sm"
-                                                            disabled={
-                                                                rowActionsDisabled ||
-                                                                isSaving
-                                                            }
-                                                            aria-label="Reset changes"
-                                                            onClick={() =>
-                                                                resetMarketRow(
-                                                                    index,
-                                                                )
-                                                            }
-                                                        >
-                                                            <Undo2 />
-                                                        </Button>
-                                                    </div>
-                                                </div>
-                                                <div className="flex items-center gap-2">
-                                                    <Label
-                                                        htmlFor={`pm-enabled-${index}`}
-                                                        className="text-muted-foreground text-xs font-normal"
-                                                    >
-                                                        Enabled
-                                                    </Label>
-                                                    <form.Field
-                                                        name={`markets[${index}].enabled`}
-                                                    >
-                                                        {(field) => (
-                                                            <Switch
-                                                                id={`pm-enabled-${index}`}
-                                                                checked={
-                                                                    field.state
-                                                                        .value
+                                                        <div className="flex flex-1 flex-wrap items-center justify-between gap-2">
+                                                            <div className="flex flex-wrap items-center gap-2">
+                                                                <CardTitle className="font-mono text-sm font-medium">
+                                                                    Length{" "}
+                                                                    {
+                                                                        market.length
+                                                                    }
+                                                                </CardTitle>
+                                                                {market.configured &&
+                                                                enabled &&
+                                                                systemToken ? (
+                                                                    <LivePrice
+                                                                        price={livePriceByLength.get(
+                                                                            market.length,
+                                                                        )}
+                                                                        systemToken={
+                                                                            systemToken
+                                                                        }
+                                                                        className="text-muted-foreground px-1 py-0.5 text-xs"
+                                                                    />
+                                                                ) : null}
+                                                            </div>
+                                                            <div
+                                                                className={cn(
+                                                                    "flex items-center gap-1.5",
+                                                                    !isRowDirty &&
+                                                                        "invisible",
+                                                                )}
+                                                                aria-hidden={
+                                                                    !isRowDirty
                                                                 }
-                                                                disabled={
+                                                            >
+                                                                <Badge
+                                                                    variant="outline"
+                                                                    className="border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
+                                                                >
+                                                                    Unsaved
+                                                                    changes
+                                                                </Badge>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon-sm"
+                                                                    disabled={
+                                                                        rowActionsDisabled ||
+                                                                        isSaving
+                                                                    }
+                                                                    aria-label="Reset changes"
+                                                                    onClick={() =>
+                                                                        resetMarketRow(
+                                                                            index,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    <Undo2 />
+                                                                </Button>
+                                                            </div>
+                                                        </div>
+                                                        <div className="flex items-center gap-2">
+                                                            <Label
+                                                                htmlFor={`pm-enabled-${index}`}
+                                                                className="text-muted-foreground text-xs font-normal"
+                                                            >
+                                                                Enabled
+                                                            </Label>
+                                                            <form.Field
+                                                                name={`markets[${index}].enabled`}
+                                                            >
+                                                                {(field) => (
+                                                                    <Switch
+                                                                        id={`pm-enabled-${index}`}
+                                                                        checked={
+                                                                            field
+                                                                                .state
+                                                                                .value
+                                                                        }
+                                                                        disabled={
+                                                                            rowActionsDisabled ||
+                                                                            isSaving
+                                                                        }
+                                                                        aria-label={`Purchases for length-${market.length} names`}
+                                                                        onCheckedChange={
+                                                                            field.handleChange
+                                                                        }
+                                                                    />
+                                                                )}
+                                                            </form.Field>
+                                                        </div>
+                                                    </CardHeader>
+                                                    {enabled ? (
+                                                        <CardContent className="px-4 py-3">
+                                                            <NameMarketRowPanel
+                                                                form={
+                                                                    form as NameMarketRowPanelProps["form"]
+                                                                }
+                                                                index={index}
+                                                                actionsDisabled={
                                                                     rowActionsDisabled ||
                                                                     isSaving
                                                                 }
-                                                                aria-label={`Purchases for length-${market.length} names`}
-                                                                onCheckedChange={
-                                                                    field.handleChange
-                                                                }
                                                             />
-                                                        )}
-                                                    </form.Field>
-                                                </div>
-                                            </CardHeader>
-                                            {enabled ? (
-                                                <CardContent className="px-4 py-3">
-                                                    <NameMarketRowPanel
-                                                        form={
-                                                            form as NameMarketRowPanelProps["form"]
-                                                        }
-                                                        index={index}
-                                                        baseline={
-                                                            defaultValues
-                                                                .markets[index]!
-                                                        }
-                                                        actionsDisabled={
-                                                            rowActionsDisabled ||
-                                                            isSaving
-                                                        }
-                                                    />
-                                                </CardContent>
-                                            ) : null}
-                                        </>
-                                    )}
-                                </form.Subscribe>
-                            </Card>
-                        ))}
-                    </div>
+                                                        </CardContent>
+                                                    ) : null}
+                                                </>
+                                            )}
+                                        </form.Subscribe>
+                                    </Card>
+                                ))}
+                            </div>
+                        )}
+                    </form.Subscribe>
 
                     <div
                         className={cn(

--- a/packages/user/Config/ui/src/pages/account-marketplace/index.tsx
+++ b/packages/user/Config/ui/src/pages/account-marketplace/index.tsx
@@ -6,7 +6,6 @@ import { useConfiguredNameMarkets } from "@/hooks/name-markets/use-configured-ma
 import { useSaveNameMarkets } from "@/hooks/name-markets/use-save-name-markets";
 import {
     type NameMarketFormRow,
-    type NameMarketsFormValues,
     buildNameMarketsFormValues,
     validateDirtyMarkets,
 } from "@/lib/name-market-form";

--- a/packages/user/Config/ui/src/pages/account-marketplace/index.tsx
+++ b/packages/user/Config/ui/src/pages/account-marketplace/index.tsx
@@ -55,10 +55,10 @@ const MARKET_EDITABLE_FIELDS: Array<keyof NameMarketFormRow> = [
     "decreasePct",
 ];
 
-function isMarketRowDirty(
+const isMarketRowDirty = (
     fieldMeta: Record<string, { isDefaultValue?: boolean } | undefined>,
     index: number,
-): boolean {
+): boolean => {
     return MARKET_EDITABLE_FIELDS.some((field) => {
         const meta = fieldMeta[`markets[${index}].${field}`];
         return meta != null && meta.isDefaultValue === false;
@@ -105,12 +105,11 @@ export const NameMarketConfig = () => {
                     return undefined;
                 }
 
-                const defaults = formApi.options
-                    .defaultValues as NameMarketsFormValues;
+                const { fieldMeta } = formApi.state;
                 const validation = validateDirtyMarkets(
                     value,
-                    defaults,
                     systemToken,
+                    (index) => isMarketRowDirty(fieldMeta, index),
                 );
 
                 if (validation?.fields) {
@@ -246,7 +245,7 @@ export const NameMarketConfig = () => {
                                         className={cn(
                                             "gap-0 py-0 shadow-sm",
                                             !market.configured &&
-                                                "border-dashed",
+                                            "border-dashed",
                                         )}
                                     >
                                         <form.Subscribe
@@ -266,7 +265,7 @@ export const NameMarketConfig = () => {
                                                         className={cn(
                                                             "flex items-center gap-4 px-4 py-3",
                                                             enabled &&
-                                                                "[.border-b]:pb-3 border-b",
+                                                            "[.border-b]:pb-3 border-b",
                                                         )}
                                                     >
                                                         <div className="flex flex-1 flex-wrap items-center justify-between gap-2">
@@ -278,8 +277,8 @@ export const NameMarketConfig = () => {
                                                                     }
                                                                 </CardTitle>
                                                                 {market.configured &&
-                                                                enabled &&
-                                                                systemToken ? (
+                                                                    enabled &&
+                                                                    systemToken ? (
                                                                     <LivePrice
                                                                         price={livePriceByLength.get(
                                                                             market.length,
@@ -295,7 +294,7 @@ export const NameMarketConfig = () => {
                                                                 className={cn(
                                                                     "flex items-center gap-1.5",
                                                                     !isRowDirty &&
-                                                                        "invisible",
+                                                                    "invisible",
                                                                 )}
                                                                 aria-hidden={
                                                                     !isRowDirty


### PR DESCRIPTION
From what I can tell we can depend on `meta.isDefaultValue` for tracking dirty state rather than doing our own equality checks like this
```
    return (
        a.enabled === b.enabled &&
        a.initialPrice === b.initialPrice &&
        a.floorPrice === b.floorPrice &&
        a.windowAmount === b.windowAmount &&
        a.windowUnit === b.windowUnit &&
        a.target === b.target &&
        a.increasePct === b.increasePct &&
        a.decreasePct === b.decreasePct
    );

 vs

MARKET_EDITABLE_FIELDS.some((field) => {
    const meta = fieldMeta[`markets[${index}].${field}`];
    return meta != null && meta.isDefaultValue === false;
});
```

defaultValues is built by `buildNameMarketsFormValues` so we can iterate on `state.values.markets` directly rather than doing our own equality checks manually between defaultValues and form state. 