### PR TITLE
accrue mid-tx billing transfers until settlement at end-of-tx

### DIFF
--- a/packages/system/Transact/include/services/system/Transact.hpp
+++ b/packages/system/Transact/include/services/system/Transact.hpp
@@ -442,6 +442,11 @@ namespace SystemService
       /// Asserts that all writes promised by `skipBilling` were consumed.
       void endSkipBilling();
 
+      /// Attribute subsequent disk writes to the system account until `numBytes`
+      /// bytes have been written or the transaction ends. `numBytes = 0` clears
+      /// the override. Callable only by the VirtualServer service.
+      void systemWrite(uint64_t numBytes);
+
       /// Get the currently executing transaction
       psio::view<const psibase::Transaction> getTransaction() const;
 
@@ -494,6 +499,7 @@ namespace SystemService
                 method(resMonitoring, enable),
                 method(skipBilling, numWrites),
                 method(endSkipBilling),
+                method(systemWrite, numBytes),
                 method(getTransaction),
                 method(isTransaction),
                 method(currentBlock),

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -32,19 +32,56 @@ namespace SystemService
          return config && config->enabled;
       }
 
-      // When set, kv writes are attributed to the system account (`{}`) instead of `trxSender`
-      bool systemWrite = false;
+      // While enabled, kv writes are attributed to the system account (`{}`) instead of
+      // `trxSender`, up to a budget of `systemWriteBudget` net bytes written.
+      bool     systemWriteEnabled = false;
+      uint64_t systemWriteBudget  = 0;
 
       // RAII guard that marks the enclosing scope as performing authorized system
-      // writes. Restores the previous value on destruction so nesting is safe.
+      // writes. All writes are attributed to the system account until the guard is
+      // destroyed.
       struct SystemWriteGuard
       {
-         bool prev;
-         SystemWriteGuard() : prev(systemWrite) { systemWrite = true; }
-         ~SystemWriteGuard() { systemWrite = prev; }
+         SystemWriteGuard()
+         {
+            check(!systemWriteEnabled, "system write already active");
+            systemWriteEnabled = true;
+            // Use the guard when the limit is specified by the scope of the guard,
+            // rather than a byte limit.
+            systemWriteBudget = static_cast<uint64_t>(-1);
+         }
+         ~SystemWriteGuard()
+         {
+            systemWriteEnabled = false;
+            systemWriteBudget  = 0;
+         }
          SystemWriteGuard(const SystemWriteGuard&)            = delete;
          SystemWriteGuard& operator=(const SystemWriteGuard&) = delete;
       };
+
+      // Returns true if a write of net size `delta` should be attributed to the
+      // system account
+      bool chargeSystemWrite(int64_t delta)
+      {
+         if (!systemWriteEnabled)
+            return false;
+         if (delta > 0)
+         {
+            auto d = static_cast<uint64_t>(delta);
+            if (d > systemWriteBudget)
+            {
+               systemWriteBudget  = 0;
+               systemWriteEnabled = false;
+               // If the budget is exceeded, attribute the whole write to
+               // the normal sender.
+               return false;
+            }
+            systemWriteBudget -= d;
+            if (systemWriteBudget == 0)
+               systemWriteEnabled = false;
+         }
+         return true;
+      }
    }  // namespace
 
    void Transact::startBoot(psio::view<const std::vector<Checksum256>> bootTransactions)
@@ -619,7 +656,6 @@ namespace SystemService
    void Transact::skipBilling(uint32_t numWrites)
    {
       checkPrivilegedSender();
-      systemWrite = true;
       to<VirtualServer>().skip_billing(numWrites);
    }
 
@@ -627,7 +663,16 @@ namespace SystemService
    {
       checkPrivilegedSender();
       to<VirtualServer>().end_skip_billing();
-      systemWrite = false;
+   }
+
+   void Transact::systemWrite(uint64_t numBytes)
+   {
+      check(getSender() == VirtualServer::service, "Wrong sender");
+      if (numBytes > 0)
+         check(!systemWriteEnabled, "system write already active");
+
+      systemWriteEnabled = numBytes != 0;
+      systemWriteBudget  = numBytes;
    }
 
    static void processTransactionImpl(
@@ -769,7 +814,7 @@ namespace SystemService
          {
             AccountNumber user;
 
-            if (systemWrite)
+            if (chargeSystemWrite(delta))
             {
                user = AccountNumber{};
             }

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -32,10 +32,9 @@ namespace SystemService
          return config && config->enabled;
       }
 
-      // While enabled, kv writes are attributed to the system account (`{}`) instead of
+      // While nonzero, kv writes are attributed to the system account (`{}`) instead of
       // `trxSender`, up to a budget of `systemWriteBudget` net bytes written.
-      bool     systemWriteEnabled = false;
-      uint64_t systemWriteBudget  = 0;
+      uint64_t systemWriteBudget = 0;
 
       // RAII guard that marks the enclosing scope as performing authorized system
       // writes. All writes are attributed to the system account until the guard is
@@ -44,16 +43,14 @@ namespace SystemService
       {
          SystemWriteGuard()
          {
-            check(!systemWriteEnabled, "system write already active");
-            systemWriteEnabled = true;
+            check(systemWriteBudget == 0, "system write already active");
             // Use the guard when the limit is specified by the scope of the guard,
             // rather than a byte limit.
             systemWriteBudget = static_cast<uint64_t>(-1);
          }
          ~SystemWriteGuard()
          {
-            systemWriteEnabled = false;
-            systemWriteBudget  = 0;
+            systemWriteBudget = 0;
          }
          SystemWriteGuard(const SystemWriteGuard&)            = delete;
          SystemWriteGuard& operator=(const SystemWriteGuard&) = delete;
@@ -63,22 +60,19 @@ namespace SystemService
       // system account
       bool chargeSystemWrite(int64_t delta)
       {
-         if (!systemWriteEnabled)
+         if (systemWriteBudget == 0)
             return false;
          if (delta > 0)
          {
             auto d = static_cast<uint64_t>(delta);
             if (d > systemWriteBudget)
             {
-               systemWriteBudget  = 0;
-               systemWriteEnabled = false;
+               systemWriteBudget = 0;
                // If the budget is exceeded, attribute the whole write to
                // the normal sender.
                return false;
             }
             systemWriteBudget -= d;
-            if (systemWriteBudget == 0)
-               systemWriteEnabled = false;
          }
          return true;
       }
@@ -669,10 +663,9 @@ namespace SystemService
    {
       check(getSender() == VirtualServer::service, "Wrong sender");
       if (numBytes > 0)
-         check(!systemWriteEnabled, "system write already active");
+         check(systemWriteBudget == 0, "system write already active");
 
-      systemWriteEnabled = numBytes != 0;
-      systemWriteBudget  = numBytes;
+      systemWriteBudget = numBytes;
    }
 
    static void processTransactionImpl(

--- a/packages/system/VirtualServer/service/src/billing.rs
+++ b/packages/system/VirtualServer/service/src/billing.rs
@@ -1,0 +1,98 @@
+use crate::resource_type::ResourceType;
+use crate::tables::tables::{BillingConfig, CapacityPricing, CapacityPricingTable, UserSettings};
+use crate::tx_cache::{accrual, balance_cache};
+use psibase::services::tokens::{Decimal, Quantity, Wrapper as Tokens};
+use psibase::{abort_message, get_service, AccountNumber, Table};
+use std::collections::HashMap;
+
+/// Pays fees out to the configured `fee_receiver`.
+pub fn credit_fee_receiver(amount: u64) {
+    if amount > 0 {
+        let c = BillingConfig::get_assert();
+        Tokens::call().credit(c.sys, c.fee_receiver, amount.into(), "".into());
+    }
+}
+
+/// End-of-tx settlement:
+/// * one per-payer settlement
+/// * one per-relay settlement
+/// * one fee-receiver credit
+pub fn reconcile() {
+    let payer_accruals = balance_cache::drain_balances();
+    let capacity_accruals = accrual::capacity_limited::drain();
+    let rate_accruals = accrual::rate_limited::drain();
+
+    let Some(config) = BillingConfig::get().filter(|c| c.enabled) else {
+        return;
+    };
+    let sys = config.sys;
+    let key = |account: &AccountNumber, sub: &Option<String>| {
+        UserSettings::to_sub_account_key(*account, sub.clone())
+    };
+
+    // 1. Charge payers first so the service balance funds the relay/fee payouts below.
+    for ((account, sub), net) in &payer_accruals {
+        if *net < 0 {
+            Tokens::call().fromSub(sys, key(account, sub), Quantity::new((-net) as u64));
+        }
+    }
+
+    // 2. Rate-limited resources: entire fee goes to the fee receiver.
+    let mut to_fee_receiver: u64 = rate_accruals.iter().map(|(_, r)| r.fee).sum();
+
+    // 3. Capacity-limited resources
+    let accrued: HashMap<ResourceType, (i128, u64)> = capacity_accruals
+        .into_iter()
+        .map(|(r, c)| (r, (c.relay_delta, c.fee)))
+        .collect();
+    let table = CapacityPricingTable::read();
+    for pricing in &table.get_index_pk() {
+        let resource = pricing.resource();
+        let (relay_delta, fee) = accrued.get(&resource).copied().unwrap_or((0, 0));
+        CapacityPricing::settle_relay(resource, relay_delta);
+
+        // Settle drift with relay's own generated fee, leftovers go to the fee receiver
+        to_fee_receiver += CapacityPricing::settle_drift(resource, fee);
+    }
+
+    // 4. Process payer resource refunds
+    for ((account, sub), net) in &payer_accruals {
+        if *net > 0 {
+            Tokens::call().toSub(sys, key(account, sub), Quantity::new(*net as u64));
+        }
+    }
+
+    // 5. Credit the fee receiver
+    credit_fee_receiver(to_fee_receiver);
+}
+
+/// Used when enabling billing to capitalize any relay shortfall
+/// The specified payer is simply paying for it out of pocket
+/// Todo: consider constructing a new curve when billing is enabled for the first time to
+///       avoid requiring some particular payer to subsidize everyone else's prior writes.
+pub fn settle_relay_balance(resource: ResourceType, payer: AccountNumber) {
+    let net = CapacityPricing::get_assert(resource).relay_net();
+    if net == 0 {
+        return;
+    }
+    let config = BillingConfig::get_assert();
+    let sys = config.sys;
+    if net > 0 {
+        let amt = Quantity::new(net as u64);
+        let shared = Tokens::call().getSharedBal(sys, payer, get_service());
+        if shared < amt {
+            let precision = BillingConfig::get_sys_token().precision;
+            let paid = Decimal::new(shared, precision);
+            let required = Decimal::new(amt, precision);
+            abort_message(&format!(
+                "Account {payer} has paid {paid} tokens, but enabling billing requires {required} tokens"
+            ));
+        }
+        Tokens::call().debit(sys, payer, amt, "".into());
+        CapacityPricing::settle_relay(resource, net);
+        Tokens::call().reject(sys, payer, "Change".into());
+    } else {
+        CapacityPricing::settle_relay(resource, net);
+        credit_fee_receiver((-net) as u64);
+    }
+}

--- a/packages/system/VirtualServer/service/src/billing.rs
+++ b/packages/system/VirtualServer/service/src/billing.rs
@@ -2,14 +2,24 @@ use crate::resource_type::ResourceType;
 use crate::tables::tables::{BillingConfig, CapacityPricing, CapacityPricingTable, UserSettings};
 use crate::tx_cache::{accrual, balance_cache};
 use psibase::services::tokens::{Decimal, Quantity, Wrapper as Tokens};
+use psibase::services::transact::Wrapper as Transact;
 use psibase::{abort_message, get_service, AccountNumber, Table};
 use std::collections::HashMap;
+
+/// Upper bound on the bytes written when crediting the fee receiver during
+/// settlement.
+/// Possible writes:
+/// * A new primary balance record on the fee receiver account
+/// * A new SharedBalance record between vserver and the fee receiver
+const FEE_RECEIVER_CREDIT_MAX_BYTES: u64 = 169;
 
 /// Pays fees out to the configured `fee_receiver`.
 pub fn credit_fee_receiver(amount: u64) {
     if amount > 0 {
+        Transact::call().systemWrite(FEE_RECEIVER_CREDIT_MAX_BYTES);
         let c = BillingConfig::get_assert();
         Tokens::call().credit(c.sys, c.fee_receiver, amount.into(), "".into());
+        Transact::call().systemWrite(0);
     }
 }
 

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -110,6 +110,7 @@ mod tx_cache {
     pub mod balance_cache {
         use crate::tables::tables::UserSettings;
         use crate::tx_cache::{drain_cache, with_cache};
+        use psibase::services::tokens::Quantity;
         use psibase::{abort_message, AccountNumber};
         use std::cell::RefCell;
         use std::collections::HashMap;
@@ -171,6 +172,14 @@ mod tx_cache {
         /// Returns whether the payer already has a pending accrual in this tx.
         pub fn has_pending(account: AccountNumber, sub: Option<String>) -> bool {
             with(|m| m.contains_key(&(account, sub)))
+        }
+
+        /// The current resource balance for the specified account
+        pub fn get_available(account: AccountNumber, sub: Option<String>) -> Quantity {
+            match with(|m| m.get(&(account, sub.clone())).map(|b| b.available)) {
+                Some(available) => Quantity::new(available.max(0) as u64),
+                None => UserSettings::get_resource_balance(account, sub),
+            }
         }
 
         /// Handles mid-tx resource purchase/deletion.
@@ -663,13 +672,13 @@ mod service {
     /// Gets the amount of resources available for the caller
     #[action]
     fn res_balance() -> Quantity {
-        UserSettings::get_resource_balance(get_sender(), None)
+        balance_cache::get_available(get_sender(), None)
     }
 
     /// Gets the amount of resources available for the caller's specified sub-account
     #[action]
     fn res_balance_sub(sub_account: String) -> Quantity {
-        UserSettings::get_resource_balance(get_sender(), Some(sub_account.clone()))
+        balance_cache::get_available(get_sender(), Some(sub_account))
     }
 
     /// Reserves system tokens for future resource consumption by the sender
@@ -1088,7 +1097,7 @@ mod service {
         }
 
         let cpu_pricing = RateLimitPricing::get_assert(Cpu);
-        let res_balance = UserSettings::get_resource_balance(account, sub_account).value;
+        let res_balance = balance_cache::get_available(account, sub_account).value;
 
         let price_per_unit = cpu_pricing.price();
         let ns_per_unit = cpu_pricing.billable_unit;

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -266,10 +266,10 @@ mod tx_cache {
                 sub: Option<String>,
                 cost: u64,
             ) {
-                crate::tx_cache::check_lock(&LOCKED);
                 if is_system_user(user) || cost == 0 {
                     return;
                 }
+                crate::tx_cache::check_lock(&LOCKED);
                 balance_cache::charge(user, sub, cost);
                 with(resource, |a| a.relay_delta += cost as i128);
             }
@@ -281,11 +281,11 @@ mod tx_cache {
                 user_refund: u64,
                 fee: u64,
             ) {
-                crate::tx_cache::check_lock(&LOCKED);
                 let gross = user_refund + fee;
                 if is_system_user(user) || gross == 0 {
                     return;
                 }
+                crate::tx_cache::check_lock(&LOCKED);
                 with(resource, |a| {
                     a.relay_delta -= gross as i128;
                     a.fee += fee;

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -14,15 +14,23 @@ mod tx_cache {
     use std::collections::HashMap;
     use std::thread::LocalKey;
 
-    pub fn check_lock(lock: &'static LocalKey<Cell<bool>>) {
-        if lock.with(Cell::get) {
-            abort_message("resource billing attempted during end-of-tx settlement");
-        }
+    /// Mutably access a billing cache
+    fn with_cache<T: 'static, R>(
+        cache: &'static LocalKey<RefCell<Option<T>>>,
+        f: impl FnOnce(&mut T) -> R,
+    ) -> R {
+        cache.with_borrow_mut(|m| {
+            f(m.as_mut()
+                .expect("resource billing attempted during end-of-tx settlement"))
+        })
     }
 
-    pub fn lock_billing(lock: &'static LocalKey<Cell<bool>>) {
-        check_lock(lock);
-        lock.with(|l| l.set(true));
+    /// Drain a billing cache, subsequent access panics.
+    fn drain_cache<T: 'static>(cache: &'static LocalKey<RefCell<Option<T>>>) -> T {
+        cache.with_borrow_mut(|m| {
+            m.take()
+                .expect("resource billing attempted during end-of-tx settlement")
+        })
     }
 
     thread_local! {
@@ -101,8 +109,9 @@ mod tx_cache {
     /// balances once at the end of the transaction.
     pub mod balance_cache {
         use crate::tables::tables::UserSettings;
+        use crate::tx_cache::{drain_cache, with_cache};
         use psibase::{abort_message, AccountNumber};
-        use std::cell::{Cell, RefCell};
+        use std::cell::RefCell;
         use std::collections::HashMap;
 
         type Payer = (AccountNumber, Option<String>);
@@ -129,17 +138,16 @@ mod tx_cache {
         }
 
         thread_local! {
-            static BALANCES: RefCell<HashMap<Payer, Balance>> = RefCell::new(HashMap::new());
-            static LOCKED: Cell<bool> = const { Cell::new(false) };
+            static BALANCES: RefCell<Option<HashMap<Payer, Balance>>> =
+                RefCell::new(Some(HashMap::new()));
         }
 
         fn with<R>(f: impl FnOnce(&mut HashMap<Payer, Balance>) -> R) -> R {
-            BALANCES.with_borrow_mut(f)
+            with_cache(&BALANCES, f)
         }
 
         /// Applies `delta` to the payer's balance, aborts on overdraft.
         fn adjust(account: AccountNumber, sub: Option<String>, delta: i128) {
-            crate::tx_cache::check_lock(&LOCKED);
             with(|m| {
                 let bal = m
                     .entry((account, sub.clone()))
@@ -164,7 +172,6 @@ mod tx_cache {
         /// Shifts available+initial together so the delta is unchanged but the new balance is spendable.
         /// No-op if the account hasn't yet been touched for billing.
         pub fn update_balance(account: AccountNumber, sub: Option<String>, delta: i128) {
-            crate::tx_cache::check_lock(&LOCKED);
             with(|m| {
                 if let Some(bal) = m.get_mut(&(account, sub)) {
                     bal.available += delta;
@@ -174,13 +181,10 @@ mod tx_cache {
         }
 
         pub fn drain_balances() -> Vec<(Payer, i128)> {
-            crate::tx_cache::lock_billing(&LOCKED);
-            with(|m| {
-                std::mem::take(m)
-                    .into_iter()
-                    .map(|(payer, b)| (payer, b.delta()))
-                    .collect()
-            })
+            drain_cache(&BALANCES)
+                .into_iter()
+                .map(|(payer, b)| (payer, b.delta()))
+                .collect()
         }
     }
 
@@ -194,9 +198,9 @@ mod tx_cache {
         pub mod rate_limited {
             use super::is_system_user;
             use crate::resource_type::ResourceType;
-            use crate::tx_cache::balance_cache;
+            use crate::tx_cache::{balance_cache, drain_cache, with_cache};
             use psibase::AccountNumber;
-            use std::cell::{Cell, RefCell};
+            use std::cell::RefCell;
             use std::collections::HashMap;
 
             #[derive(Default)]
@@ -205,8 +209,8 @@ mod tx_cache {
             }
 
             thread_local! {
-                static STATE: RefCell<HashMap<ResourceType, Accrual>> = RefCell::new(HashMap::new());
-                static LOCKED: Cell<bool> = const { Cell::new(false) };
+                static STATE: RefCell<Option<HashMap<ResourceType, Accrual>>> =
+                    RefCell::new(Some(HashMap::new()));
             }
 
             pub fn consume(
@@ -215,7 +219,6 @@ mod tx_cache {
                 sub: Option<String>,
                 cost: u64,
             ) {
-                crate::tx_cache::check_lock(&LOCKED);
                 if cost == 0 {
                     return;
                 }
@@ -223,12 +226,11 @@ mod tx_cache {
                     psibase::abort_message("System user consumes rate-limited resources!");
                 }
                 balance_cache::charge(user, sub, cost);
-                STATE.with_borrow_mut(|m| m.entry(resource).or_default().fee += cost);
+                with_cache(&STATE, |m| m.entry(resource).or_default().fee += cost);
             }
 
             pub fn drain() -> Vec<(ResourceType, Accrual)> {
-                crate::tx_cache::lock_billing(&LOCKED);
-                STATE.with_borrow_mut(|m| std::mem::take(m).into_iter().collect())
+                drain_cache(&STATE).into_iter().collect()
             }
         }
 
@@ -240,9 +242,9 @@ mod tx_cache {
         pub mod capacity_limited {
             use super::is_system_user;
             use crate::resource_type::ResourceType;
-            use crate::tx_cache::balance_cache;
+            use crate::tx_cache::{balance_cache, drain_cache, with_cache};
             use psibase::AccountNumber;
-            use std::cell::{Cell, RefCell};
+            use std::cell::RefCell;
             use std::collections::HashMap;
 
             #[derive(Default)]
@@ -252,12 +254,12 @@ mod tx_cache {
             }
 
             thread_local! {
-                static STATE: RefCell<HashMap<ResourceType, Accrual>> = RefCell::new(HashMap::new());
-                static LOCKED: Cell<bool> = const { Cell::new(false) };
+                static STATE: RefCell<Option<HashMap<ResourceType, Accrual>>> =
+                    RefCell::new(Some(HashMap::new()));
             }
 
             fn with<R>(resource: ResourceType, f: impl FnOnce(&mut Accrual) -> R) -> R {
-                STATE.with_borrow_mut(|m| f(m.entry(resource).or_default()))
+                with_cache(&STATE, |m| f(m.entry(resource).or_default()))
             }
 
             pub fn consume(
@@ -269,7 +271,6 @@ mod tx_cache {
                 if is_system_user(user) || cost == 0 {
                     return;
                 }
-                crate::tx_cache::check_lock(&LOCKED);
                 balance_cache::charge(user, sub, cost);
                 with(resource, |a| a.relay_delta += cost as i128);
             }
@@ -285,7 +286,6 @@ mod tx_cache {
                 if is_system_user(user) || gross == 0 {
                     return;
                 }
-                crate::tx_cache::check_lock(&LOCKED);
                 with(resource, |a| {
                     a.relay_delta -= gross as i128;
                     a.fee += fee;
@@ -296,8 +296,7 @@ mod tx_cache {
             }
 
             pub fn drain() -> Vec<(ResourceType, Accrual)> {
-                crate::tx_cache::lock_billing(&LOCKED);
-                STATE.with_borrow_mut(|m| std::mem::take(m).into_iter().collect())
+                drain_cache(&STATE).into_iter().collect()
             }
         }
     }

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -168,6 +168,11 @@ mod tx_cache {
             adjust(account, sub, amount as i128);
         }
 
+        /// Returns whether the payer already has a pending accrual in this tx.
+        pub fn has_pending(account: AccountNumber, sub: Option<String>) -> bool {
+            with(|m| m.contains_key(&(account, sub)))
+        }
+
         /// Handles mid-tx resource purchase/deletion.
         /// Shifts available+initial together so the delta is unchanged but the new balance is spendable.
         /// No-op if the account hasn't yet been touched for billing.
@@ -633,6 +638,13 @@ mod service {
         let sys = config.sys;
 
         let sender = get_sender();
+
+        // Cannot delete a sub-account that has pending billing
+        check(
+            !balance_cache::has_pending(sender, Some(sub_account.clone())),
+            "cannot delete a sub-account that has pending billing this transaction",
+        );
+
         let Some(balance) =
             UserSettings::get_resource_balance_opt(sender, Some(sub_account.clone()))
         else {

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -5,12 +5,25 @@ pub mod rpc;
 pub mod tables;
 pub use crate::tables::DEFAULT_AUTO_FILL_THRESHOLD_PERCENT;
 
+mod billing;
 mod math_utils;
 
 mod tx_cache {
     use psibase::{abort_message, AccountNumber};
     use std::cell::{Cell, RefCell};
     use std::collections::HashMap;
+    use std::thread::LocalKey;
+
+    pub fn check_lock(lock: &'static LocalKey<Cell<bool>>) {
+        if lock.with(Cell::get) {
+            abort_message("resource billing attempted during end-of-tx settlement");
+        }
+    }
+
+    pub fn lock_billing(lock: &'static LocalKey<Cell<bool>>) {
+        check_lock(lock);
+        lock.with(|l| l.set(true));
+    }
 
     thread_local! {
         static BILLABLE_ACCOUNT: Cell<Option<AccountNumber>> = const { Cell::new(None) };
@@ -81,6 +94,212 @@ mod tx_cache {
                 .map(|m| m.into_iter().map(|(k, (a, c))| (k, a, c)).collect())
                 .unwrap_or_default()
         })
+    }
+
+    /// Cache of account resource balances.
+    /// We track updates to user resources in the cache so we can do a settlement of the actual token
+    /// balances once at the end of the transaction.
+    pub mod balance_cache {
+        use crate::tables::tables::UserSettings;
+        use psibase::{abort_message, AccountNumber};
+        use std::cell::{Cell, RefCell};
+        use std::collections::HashMap;
+
+        type Payer = (AccountNumber, Option<String>);
+
+        #[derive(Clone, Copy)]
+        struct Balance {
+            available: i128,
+            initial: i128,
+        }
+
+        impl Balance {
+            fn from_live((account, sub): &Payer) -> Self {
+                let value = UserSettings::get_resource_balance(*account, sub.clone()).value as i128;
+                Balance {
+                    available: value,
+                    initial: value,
+                }
+            }
+
+            // The amount to settle
+            fn delta(self) -> i128 {
+                self.available - self.initial
+            }
+        }
+
+        thread_local! {
+            static BALANCES: RefCell<HashMap<Payer, Balance>> = RefCell::new(HashMap::new());
+            static LOCKED: Cell<bool> = const { Cell::new(false) };
+        }
+
+        fn with<R>(f: impl FnOnce(&mut HashMap<Payer, Balance>) -> R) -> R {
+            BALANCES.with_borrow_mut(f)
+        }
+
+        /// Applies `delta` to the payer's balance, aborts on overdraft.
+        fn adjust(account: AccountNumber, sub: Option<String>, delta: i128) {
+            crate::tx_cache::check_lock(&LOCKED);
+            with(|m| {
+                let bal = m
+                    .entry((account, sub.clone()))
+                    .or_insert_with_key(Balance::from_live);
+                bal.available += delta;
+                if bal.available < 0 {
+                    let who = UserSettings::to_sub_account_key(account, sub);
+                    abort_message(&format!("{} has insufficient resource balance", who));
+                }
+            });
+        }
+
+        pub fn charge(account: AccountNumber, sub: Option<String>, cost: u64) {
+            adjust(account, sub, -(cost as i128));
+        }
+
+        pub fn refund(account: AccountNumber, sub: Option<String>, amount: u64) {
+            adjust(account, sub, amount as i128);
+        }
+
+        /// Handles mid-tx resource purchase/deletion.
+        /// Shifts available+initial together so the delta is unchanged but the new balance is spendable.
+        /// No-op if the account hasn't yet been touched for billing.
+        pub fn update_balance(account: AccountNumber, sub: Option<String>, delta: i128) {
+            crate::tx_cache::check_lock(&LOCKED);
+            with(|m| {
+                if let Some(bal) = m.get_mut(&(account, sub)) {
+                    bal.available += delta;
+                    bal.initial += delta;
+                }
+            });
+        }
+
+        pub fn drain_balances() -> Vec<(Payer, i128)> {
+            crate::tx_cache::lock_billing(&LOCKED);
+            with(|m| {
+                std::mem::take(m)
+                    .into_iter()
+                    .map(|(payer, b)| (payer, b.delta()))
+                    .collect()
+            })
+        }
+    }
+
+    /// Per-tx billing accrual, settled at end of tx
+    pub mod accrual {
+        fn is_system_user(user: psibase::AccountNumber) -> bool {
+            user == psibase::AccountNumber::new(0)
+        }
+
+        /// Rate-limited resources: consumption cost is directly credited to the fee receiver.
+        pub mod rate_limited {
+            use super::is_system_user;
+            use crate::resource_type::ResourceType;
+            use crate::tx_cache::balance_cache;
+            use psibase::AccountNumber;
+            use std::cell::{Cell, RefCell};
+            use std::collections::HashMap;
+
+            #[derive(Default)]
+            pub struct Accrual {
+                pub fee: u64,
+            }
+
+            thread_local! {
+                static STATE: RefCell<HashMap<ResourceType, Accrual>> = RefCell::new(HashMap::new());
+                static LOCKED: Cell<bool> = const { Cell::new(false) };
+            }
+
+            pub fn consume(
+                resource: ResourceType,
+                user: AccountNumber,
+                sub: Option<String>,
+                cost: u64,
+            ) {
+                crate::tx_cache::check_lock(&LOCKED);
+                if cost == 0 {
+                    return;
+                }
+                if is_system_user(user) {
+                    psibase::abort_message("System user consumes rate-limited resources!");
+                }
+                balance_cache::charge(user, sub, cost);
+                STATE.with_borrow_mut(|m| m.entry(resource).or_default().fee += cost);
+            }
+
+            pub fn drain() -> Vec<(ResourceType, Accrual)> {
+                crate::tx_cache::lock_billing(&LOCKED);
+                STATE.with_borrow_mut(|m| std::mem::take(m).into_iter().collect())
+            }
+        }
+
+        /// Capacity-limited resources: consumption cost is sent as a reserve into a relay. When freed, relay refund is split between
+        /// the user and the fee receiver.
+        ///
+        /// In rare cases (system writes or writes when billing is disabled), the relay may become under-collateralized. In such cases,
+        /// tokens that would be sent to the fee receiver are instead used to recollateralize the relay.
+        pub mod capacity_limited {
+            use super::is_system_user;
+            use crate::resource_type::ResourceType;
+            use crate::tx_cache::balance_cache;
+            use psibase::AccountNumber;
+            use std::cell::{Cell, RefCell};
+            use std::collections::HashMap;
+
+            #[derive(Default)]
+            pub struct Accrual {
+                pub relay_delta: i128,
+                pub fee: u64,
+            }
+
+            thread_local! {
+                static STATE: RefCell<HashMap<ResourceType, Accrual>> = RefCell::new(HashMap::new());
+                static LOCKED: Cell<bool> = const { Cell::new(false) };
+            }
+
+            fn with<R>(resource: ResourceType, f: impl FnOnce(&mut Accrual) -> R) -> R {
+                STATE.with_borrow_mut(|m| f(m.entry(resource).or_default()))
+            }
+
+            pub fn consume(
+                resource: ResourceType,
+                user: AccountNumber,
+                sub: Option<String>,
+                cost: u64,
+            ) {
+                crate::tx_cache::check_lock(&LOCKED);
+                if is_system_user(user) || cost == 0 {
+                    return;
+                }
+                balance_cache::charge(user, sub, cost);
+                with(resource, |a| a.relay_delta += cost as i128);
+            }
+
+            pub fn free(
+                resource: ResourceType,
+                user: AccountNumber,
+                sub: Option<String>,
+                user_refund: u64,
+                fee: u64,
+            ) {
+                crate::tx_cache::check_lock(&LOCKED);
+                let gross = user_refund + fee;
+                if is_system_user(user) || gross == 0 {
+                    return;
+                }
+                with(resource, |a| {
+                    a.relay_delta -= gross as i128;
+                    a.fee += fee;
+                });
+                if user_refund > 0 {
+                    balance_cache::refund(user, sub, user_refund);
+                }
+            }
+
+            pub fn drain() -> Vec<(ResourceType, Accrual)> {
+                crate::tx_cache::lock_billing(&LOCKED);
+                STATE.with_borrow_mut(|m| std::mem::take(m).into_iter().collect())
+            }
+        }
     }
 }
 
@@ -158,8 +377,11 @@ mod tx_cache {
 /// service to manage server specs, network variables, and billing parameters, as needed.
 #[psibase::service(name = "vserver", recursive = "true", tables = "tables::tables")]
 mod service {
+    use crate::billing;
     use crate::tables::tables::{UserSettings, *};
     use crate::tx_cache;
+    use crate::tx_cache::accrual;
+    use crate::tx_cache::balance_cache;
     use psibase::services::events;
     use psibase::services::{
         accounts::Wrapper as Accounts,
@@ -334,7 +556,7 @@ mod service {
 
         if enabled {
             let payer = check_some(payer, "payer is required when enabling billing");
-            CapacityPricing::get_assert(Disk).settle_relay_balance(payer);
+            billing::settle_relay_balance(Disk, payer);
         }
 
         BillingConfig::enable(enabled);
@@ -364,6 +586,7 @@ mod service {
 
         Tokens::call().debit(sys, buyer, amount, "".into());
         Tokens::call().toSub(sys, for_user.to_string(), amount);
+        balance_cache::update_balance(for_user, None, amount.value as i128);
 
         if buyer != for_user {
             // No need for a subsidy event if user == buyer because it's not a subsidy and the purchase
@@ -395,9 +618,10 @@ mod service {
         Tokens::call().debit(sys, buyer, amount, "".into());
         Tokens::call().toSub(
             sys,
-            UserSettings::to_sub_account_key(buyer, Some(sub_account)),
+            UserSettings::to_sub_account_key(buyer, Some(sub_account.clone())),
             amount,
         );
+        balance_cache::update_balance(buyer, Some(sub_account), amount.value as i128);
     }
 
     /// Deletes the resource subaccount, returning the resources back to the caller's primary
@@ -417,9 +641,11 @@ mod service {
         };
 
         if balance.value != 0u64 {
-            let sub_account = UserSettings::to_sub_account_key(sender, Some(sub_account));
-            Tokens::call().fromSub(sys, sub_account, balance);
+            let sub_key = UserSettings::to_sub_account_key(sender, Some(sub_account.clone()));
+            Tokens::call().fromSub(sys, sub_key, balance);
             Tokens::call().toSub(sys, sender.to_string(), balance);
+            balance_cache::update_balance(sender, Some(sub_account), -(balance.value as i128));
+            balance_cache::update_balance(sender, None, balance.value as i128);
         }
     }
 
@@ -670,12 +896,10 @@ mod service {
         );
 
         let amount_bits = check_some(amount_bytes.checked_mul(8), "network usage overflow");
-        let cost = RateLimitPricing::get_assert(Net).consume(
-            amount_bits,
-            user,
-            tx_cache::get_sub(user),
-            is_billing_enabled(),
-        );
+        let sub = tx_cache::get_sub(user);
+        let raw_cost = RateLimitPricing::get_assert(Net).consume(amount_bits);
+        let cost = if is_billing_enabled() { raw_cost } else { 0 };
+        accrual::rate_limited::consume(Net, user, sub, cost);
 
         let amount = to_i64(amount_bytes, "Consumed network bandwidth");
         let cost = to_i64(cost, "Consumed network bandwidth cost");
@@ -696,12 +920,10 @@ mod service {
             "[useCpuSys] Unauthorized",
         );
 
-        let cost = RateLimitPricing::get_assert(Cpu).consume(
-            amount_ns,
-            user,
-            tx_cache::get_sub(user),
-            is_billing_enabled(),
-        );
+        let sub = tx_cache::get_sub(user);
+        let raw_cost = RateLimitPricing::get_assert(Cpu).consume(amount_ns);
+        let cost = if is_billing_enabled() { raw_cost } else { 0 };
+        accrual::rate_limited::consume(Cpu, user, sub, cost);
 
         let amount = to_i64(amount_ns, "Consumed CPU");
         let cost = to_i64(cost, "Consumed CPU cost");
@@ -720,6 +942,8 @@ mod service {
                 .history()
                 .consumed(disk_user, Disk.as_id(), disk_amount, disk_cost);
         }
+
+        billing::reconcile();
     }
 
     /// Suppress billing/tracking for the next `num_writes` `useDiskSys` calls.
@@ -773,19 +997,29 @@ mod service {
             return;
         }
 
+        let billing = is_billing_enabled();
         let sub = tx_cache::get_sub(user);
 
         let cost = match db_id {
             DbId::Service | DbId::Native => {
                 if amount_bytes > 0 {
-                    let c =
-                        CapacityPricing::get_assert(Disk).consume(amount_bytes as u64, user, sub);
-                    to_i64(c, "Disk consume cost")
+                    let c = CapacityPricing::get_assert(Disk).consume(amount_bytes as u64);
+                    if billing {
+                        accrual::capacity_limited::consume(Disk, user, sub, c);
+                        to_i64(c, "Disk consume cost")
+                    } else {
+                        0
+                    }
                 } else {
                     // amount_bytes < 0
-                    let user_refund =
-                        CapacityPricing::get_assert(Disk).free((-amount_bytes) as u64, user, sub);
-                    -(to_i64(user_refund, "Disk refund"))
+                    let (user_refund, fee) =
+                        CapacityPricing::get_assert(Disk).free((-amount_bytes) as u64);
+                    if billing {
+                        accrual::capacity_limited::free(Disk, user, sub, user_refund, fee);
+                        -(to_i64(user_refund, "Disk refund"))
+                    } else {
+                        0
+                    }
                 }
             }
             DbId::HistoryEvent | DbId::UiEvent | DbId::MerkleEvent | DbId::WriteOnly => return, // TODO: Event billing (rate-limit-style)

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -707,6 +707,12 @@ mod service {
         );
 
         let sender = get_sender();
+
+        check(
+            UserSettings::get_resource_balance_opt(sender, Some(sub_account.clone())).is_some(),
+            "Billable sub-account does not exist",
+        );
+
         tx_cache::set_sub(sender, sub_account.clone());
 
         if sender == billable_account {

--- a/packages/system/VirtualServer/service/src/resource_type.rs
+++ b/packages/system/VirtualServer/service/src/resource_type.rs
@@ -1,6 +1,6 @@
 use psibase::abort_message;
 
-#[derive(async_graphql::Enum, Copy, Clone, Eq, PartialEq)]
+#[derive(async_graphql::Enum, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ResourceType {
     Cpu,
     Net,

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -64,10 +64,6 @@ fn relay_sub(resource: ResourceType) -> String {
     )
 }
 
-fn is_billing_active() -> bool {
-    BillingConfig::get().map(|c| c.enabled).unwrap_or(false)
-}
-
 pub(crate) struct Curve {
     pub(crate) x0: u64,
     pub(crate) y0: u64,
@@ -190,10 +186,6 @@ impl CurvePosition {
     }
 }
 
-fn is_system(user: AccountNumber) -> bool {
-    user == AccountNumber::new(0)
-}
-
 /// Ensures a valid curve parameterization
 pub(crate) fn validate_curve_params(
     max_reserve: u64,
@@ -240,7 +232,7 @@ pub(crate) fn check_curve_params(max_reserve: u64, max_capacity: u64, curve_d: u
 }
 
 impl CapacityPricing {
-    fn resource(&self) -> ResourceType {
+    pub(crate) fn resource(&self) -> ResourceType {
         ResourceType::from_id(self.resource_id)
     }
 
@@ -362,16 +354,9 @@ impl CapacityPricing {
         Quantity::new(self.refund_of(amount_freed))
     }
 
-    pub fn consume(
-        &self,
-        amount_consumed: u64,
-        user: AccountNumber,
-        sub_account: Option<String>,
-    ) -> u64 {
+    pub fn consume(&self, amount_consumed: u64) -> u64 {
         let resource = self.resource();
         let mut cost = 0u64;
-        let billing_active = is_billing_active();
-        let system_write = is_system(user);
         Self::update(resource, |p| {
             // Refilling a prealloc deficit is free; only the remainder is billed.
             let restored = amount_consumed.min(p.prealloc_deficit);
@@ -388,39 +373,13 @@ impl CapacityPricing {
                 .cost_of(billable);
             p.remaining_capacity -= billable;
         });
-
-        if cost > 0 && billing_active && !system_write {
-            let config = BillingConfig::get_assert();
-            let sys = config.sys;
-            let balance = UserSettings::get_resource_balance(user, sub_account.clone());
-            let amt = Quantity::new(cost);
-
-            if balance < amt {
-                abort_message(&format!(
-                    "{} has insufficient resource balance for {}",
-                    user,
-                    resource.name(),
-                ));
-            }
-
-            let sub_key = UserSettings::to_sub_account_key(user, sub_account);
-            Tokens::call().fromSub(sys, sub_key, amt);
-            Tokens::call().toSub(sys, relay_sub(resource), amt);
-        }
-
-        if !billing_active {
-            return 0;
-        }
-
         cost
     }
 
-    pub fn free(&self, amount_freed: u64, user: AccountNumber, sub_account: Option<String>) -> u64 {
+    pub fn free(&self, amount_freed: u64) -> (u64, u64) {
         let resource = self.resource();
         let mut gross_refund = 0u64;
         let mut fee_ppm_val = 0u32;
-        let billing_active = is_billing_active();
-        let system_write = is_system(user);
         Self::update(resource, |p| {
             let consumed = p.max_capacity - p.remaining_capacity;
 
@@ -438,29 +397,8 @@ impl CapacityPricing {
         });
 
         let fee = (gross_refund as u128 * fee_ppm_val as u128 / PPM) as u64;
-        let user_refund = gross_refund - fee;
-
-        if gross_refund > 0 && billing_active && !system_write {
-            let config = BillingConfig::get_assert();
-            let sys = config.sys;
-
-            Tokens::call().fromSub(sys, relay_sub(resource), Quantity::new(gross_refund));
-
-            if user_refund > 0 {
-                let sub_key = UserSettings::to_sub_account_key(user, sub_account);
-                Tokens::call().toSub(sys, sub_key, Quantity::new(user_refund));
-            }
-
-            if fee > 0 {
-                Self::credit_fee_receiver(resource, fee);
-            }
-        }
-
-        if !billing_active {
-            return 0;
-        }
-
-        user_refund
+        let refund = gross_refund - fee;
+        (refund, fee)
     }
 
     pub fn set_capacity(&self, new_max_capacity: u64) {
@@ -478,27 +416,17 @@ impl CapacityPricing {
     fn increase_capacity(&self, delta_bytes: u64) {
         check(delta_bytes > 0, "invalid capacity increase");
 
-        let resource = self.resource();
-        let mut delta_reserve = 0i64;
-        let billing_active = is_billing_active();
-        Self::update(resource, |p| {
+        Self::update(self.resource(), |p| {
             let old_reserve = p.required_reserve();
 
             p.max_capacity += delta_bytes;
             p.remaining_capacity += delta_bytes;
 
-            delta_reserve = p.required_reserve() as i64 - old_reserve as i64;
+            check(
+                p.required_reserve() <= old_reserve,
+                "Reserves drop after capacity increase",
+            );
         });
-        if delta_reserve != 0 && billing_active {
-            let config = BillingConfig::get_assert();
-            let amt = Quantity::new(delta_reserve.unsigned_abs());
-            let sub = relay_sub(resource);
-
-            check(delta_reserve < 0, "Reserves drop after capacity increase");
-
-            Tokens::call().fromSub(config.sys, sub, amt);
-            Self::credit_fee_receiver(resource, delta_reserve.unsigned_abs());
-        }
     }
 
     pub fn reduce_reserve_budget(&self, delta_supply: u64) {
@@ -509,10 +437,8 @@ impl CapacityPricing {
         );
         check_curve_params(new_max_reserve, self.max_capacity, self.curve_d);
 
-        let resource = self.resource();
         let mut to_remove = 0u64;
-        let billing_active = is_billing_active();
-        Self::update(resource, |p| {
+        Self::update(self.resource(), |p| {
             let old_reserve = p.required_reserve();
 
             p.max_reserve -= delta_supply;
@@ -526,88 +452,34 @@ impl CapacityPricing {
             consumed == 0 || to_remove > 0,
             "Reserves drop after reserve budget decrease",
         );
-
-        if to_remove > 0 && billing_active {
-            let config = BillingConfig::get_assert();
-            let amt = Quantity::new(to_remove);
-            Tokens::call().fromSub(config.sys, relay_sub(resource), amt);
-            Self::credit_fee_receiver(resource, to_remove);
-        }
     }
 
-    /// Credits `fee_receiver`, settling any outstanding relay balance first.
-    ///
-    /// The relay balance drifts from the curve `reserve` only when:
-    /// 1. special system writes occur (no payer to charge), or
-    /// 2. billing is disabled
-    ///
-    /// If the relay is short, part/all of the fee is redirected into it to cover the gap.
-    /// If the relay has excess, the surplus is pulled out and added to the fee payment.
-    fn credit_fee_receiver(resource: ResourceType, amount: u64) {
-        if amount == 0 {
-            return;
-        }
-        let config = BillingConfig::get_assert();
-        let sys = config.sys;
-        let net = Self::get_assert(resource).relay_net();
-
-        let mut to_relay = 0u64;
-        let mut from_relay = 0u64;
-        let mut to_fee = amount;
-        if net > 0 {
-            let settle = (net as u64).min(amount);
-            to_relay = settle;
-            to_fee = amount - settle;
-        } else if net < 0 {
-            let extra = (-net) as u64;
-            from_relay = extra;
-            to_fee = amount + extra;
-        }
-
+    /// Moves `delta` system tokens between vserver's primary balance and the relay
+    /// subaccount (positive = into the relay, negative = out).
+    pub(crate) fn settle_relay(resource: ResourceType, delta: i128) {
+        let sys = BillingConfig::get_assert().sys;
         let sub = relay_sub(resource);
-        if to_relay > 0 {
-            Tokens::call().toSub(sys, sub, Quantity::new(to_relay));
-        } else if from_relay > 0 {
-            Tokens::call().fromSub(sys, sub, Quantity::new(from_relay));
-        }
-        if to_fee > 0 {
-            Tokens::call().credit(sys, config.fee_receiver, Quantity::new(to_fee), "".into());
+        if delta > 0 {
+            Tokens::call().toSub(sys, sub, Quantity::new(delta as u64));
+        } else if delta < 0 {
+            Tokens::call().fromSub(sys, sub, Quantity::new((-delta) as u64));
         }
     }
 
-    /// Settles the relay balance by moving real tokens to match the curve `reserve`.
-    ///
-    /// If the relay is short (net > 0), debits `payer` and deposits into the
-    /// relay sub. If it has excess (net < 0), withdraws from the relay sub to
-    /// the fee_receiver.
-    pub fn settle_relay_balance(&self, payer: AccountNumber) {
-        let net = self.relay_net();
-        if net == 0 {
-            return;
-        }
-        let config = BillingConfig::get_assert();
-        let sys = config.sys;
-        let sub = relay_sub(self.resource());
-        if net > 0 {
-            let amt = Quantity::new(net as u64);
-            let service = get_service();
-            let shared = Tokens::call().getSharedBal(sys, payer, service);
-            if shared < amt {
-                let precision = BillingConfig::get_sys_token().precision;
-                let paid = Decimal::new(shared, precision);
-                let required = Decimal::new(amt, precision);
-                abort_message(&format!(
-                    "Account {payer} has paid {paid} tokens, but enabling billing requires {required} tokens"
-                ));
-            }
-            Tokens::call().debit(sys, payer, amt, "".into());
-            Tokens::call().toSub(sys, sub, amt);
-            Tokens::call().reject(sys, payer, "Change".into());
+    /// Settles the relay drift using up to `available` tokens, returning the leftover.
+    pub(crate) fn settle_drift(resource: ResourceType, available: u64) -> u64 {
+        let drift = Self::get_assert(resource).relay_net();
+        let available = available as i128;
+
+        let (relay_move, remaining): (i128, i128) = if drift > 0 {
+            let covered = drift.min(available);
+            (covered, available - covered)
         } else {
-            let amt = Quantity::new((-net) as u64);
-            Tokens::call().fromSub(sys, sub, amt);
-            Tokens::call().credit(sys, config.fee_receiver, amt, "".into());
-        }
+            (drift, available - drift)
+        };
+
+        Self::settle_relay(resource, relay_move);
+        remaining as u64
     }
 
     pub fn utilization_ppm(&self) -> u32 {

--- a/packages/system/VirtualServer/service/src/tables/rate_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/rate_limit_pricing.rs
@@ -4,7 +4,6 @@ use crate::tables::tables::*;
 use async_graphql::{ComplexObject, SimpleObject};
 use psibase::services::diff_adjust::Wrapper as DiffAdjust;
 use psibase::services::nft::Wrapper as Nft;
-use psibase::services::tokens::{Quantity, Wrapper as Tokens};
 use psibase::*;
 
 // In DiffAdjust, we use the discrete compounding equation to relate total change to a rate of change
@@ -95,26 +94,6 @@ fn update_average_usage(
     ppm
 }
 
-pub fn bill_user(user: AccountNumber, cost: u64, sub_account: Option<String>) {
-    if cost == 0 {
-        return;
-    }
-    let config = BillingConfig::get_assert();
-    let sys = config.sys;
-
-    let balance = UserSettings::get_resource_balance(user, sub_account.clone());
-    let amt = Quantity::new(cost);
-
-    if balance < amt {
-        abort_message(&format!("{} has insufficient resource balance", user));
-    }
-
-    let user_key = UserSettings::to_sub_account_key(user, sub_account);
-
-    Tokens::call().fromSub(sys, user_key, amt);
-    Tokens::call().credit(sys, config.fee_receiver, amt, "".into());
-}
-
 fn capacity(resource: ResourceType) -> u64 {
     let specs = NetworkSpecs::get_assert();
     match resource {
@@ -176,13 +155,7 @@ impl RateLimitPricing {
         Self::update(self.resource(), |r| r.num_blocks_to_average = num_blocks);
     }
 
-    pub fn consume(
-        &self,
-        amount: u64,
-        user: AccountNumber,
-        sub_account: Option<String>,
-        billing_enabled: bool,
-    ) -> u64 {
+    pub fn consume(&self, amount: u64) -> u64 {
         let resource = self.resource();
         let mut price = 0u64;
         let mut billable_unit = 0u64;
@@ -196,18 +169,10 @@ impl RateLimitPricing {
         // Round up to the nearest billable unit
         let amount_units = amount.div_ceil(billable_unit);
 
-        let mut cost = check_some(
+        check_some(
             amount_units.checked_mul(price),
             &format!("{} usage overflow", resource.name()),
-        );
-
-        if !billing_enabled {
-            cost = 0;
-        }
-
-        bill_user(user, cost, sub_account);
-
-        cost
+        )
     }
 
     pub fn new_block(&self) -> u32 {

--- a/packages/user/Tokens/service/src/lib.rs
+++ b/packages/user/Tokens/service/src/lib.rs
@@ -4,7 +4,7 @@ pub mod helpers;
 pub mod tables;
 pub use tables::tables::{BalanceFlags, TokenFlags};
 
-#[psibase::service(tables = "tables::tables", recursive = true)]
+#[psibase::service(tables = "tables::tables")]
 pub mod service {
     pub use crate::tables::tables::{BalanceFlags, TokenFlags};
     use crate::tables::tables::{ConfigRow, SubAccount, *};

--- a/rust/psibase/src/services/transact.rs
+++ b/rust/psibase/src/services/transact.rs
@@ -346,6 +346,14 @@ mod service {
         unimplemented!()
     }
 
+    /// Attribute subsequent disk writes to the system account until `numBytes`
+    /// bytes have been written or the transaction ends. `numBytes = 0` clears
+    ///  the override. Callable only by the VirtualServer service.
+    #[action]
+    fn systemWrite(numBytes: u64) {
+        unimplemented!()
+    }
+
     /// Get the currently executing transaction
     #[action]
     fn getTransaction() -> crate::Transaction {


### PR DESCRIPTION
Instead of doing token transfers in real time as billing charges occur, we lazily cache a user's resource balance the first time it's needed, and then accumulate billing charges/refunds throughout the tx (aborting if there would be any overdraft). Then we do a one-time settlement at the end of the tx.

This also applies to:
* The fees that would be sent to the fee receiver.
* The transfers in/out of the disk-billing relay
