### PR TITLE
Add support for verify to CustomHandler. 

### DIFF
--- a/rust/fracpack/src/schema.rs
+++ b/rust/fracpack/src/schema.rs
@@ -572,6 +572,15 @@ pub trait CustomHandler {
         val: &serde_json::Value,
         dest: &mut Vec<u8>,
     ) -> Result<(), serde_json::Error>;
+    fn fracpack_verify(
+        &self,
+        schema: &CompiledSchema,
+        ty: &CompiledType,
+        src: &mut FracInputStream,
+        allow_empty_container: bool,
+    ) -> Result<(), Error> {
+        fracpack_verify_impl(schema, ty, src, allow_empty_container)
+    }
     fn is_empty_container(&self, ty: &CompiledType, value: &serde_json::Value) -> bool;
 }
 
@@ -615,6 +624,16 @@ impl<'a> CustomTypes<'a> {
         dest: &mut Vec<u8>,
     ) -> Result<(), serde_json::Error> {
         self.handlers[id].json2frac(schema, ty, val, dest)
+    }
+    fn fracpack_verify(
+        &self,
+        id: usize,
+        schema: &CompiledSchema,
+        ty: &CompiledType,
+        src: &mut FracInputStream,
+        allow_empty_container: bool,
+    ) -> Result<(), Error> {
+        self.handlers[id].fracpack_verify(schema, ty, src, allow_empty_container)
     }
     fn is_empty_container(&self, id: usize, ty: &CompiledType, value: &serde_json::Value) -> bool {
         self.handlers[id].is_empty_container(ty, value)
@@ -2291,9 +2310,11 @@ fn fracpack_verify_impl(
             stream.has_unknown |= substream.has_unknown;
             substream.finish()?;
         }
-        Custom { repr, .. } => {
+        Custom { id, repr, .. } => {
             let repr = schema.get_by_id(*repr);
-            fracpack_verify_impl(schema, repr, stream, allow_empty_container)?;
+            schema
+                .custom
+                .fracpack_verify(*id, schema, repr, stream, allow_empty_container)?;
         }
         _ => {
             unimplemented!();

--- a/rust/psibase/src/trace.rs
+++ b/rust/psibase/src/trace.rs
@@ -416,7 +416,7 @@ impl<'a, F: SchemaFetcher + 'a> ActionFormatter<'a, F> {
                 if let Some(action_type) = schema.actions.get(&action_name) {
                     if atrace.action.rawData.is_empty() {
                         cschema.extend(&action_type.params);
-                        let _ = cschema.to_value(&action_type.params, &atrace.action.rawData);
+                        let _ = cschema.verify(&action_type.params, &atrace.action.rawData);
                         for service in &*service_method.missing.borrow() {
                             res = res.and(self.add_service(*service).await);
                         }
@@ -792,6 +792,22 @@ impl<'a> CustomHandler for CustomResolvedServiceMethod<'a> {
                 })?)?,
             };
         Ok(value.pack(dest))
+    }
+    fn fracpack_verify(
+        &self,
+        _schema: &CompiledSchema,
+        ty: &CompiledType,
+        src: &mut FracInputStream,
+        _allow_empty_container: bool,
+    ) -> Result<(), fracpack::Error> {
+        if !service_method_type(ty).is_some() {
+            panic!("Wrong type");
+        };
+        let value = ServiceMethod::unpack(src)?;
+        if !self.schemas.contains_key(&value.service) {
+            self.missing.borrow_mut().insert(value.service);
+        }
+        Ok(())
     }
     fn is_empty_container(&self, _ty: &CompiledType, _value: &serde_json::Value) -> bool {
         false


### PR DESCRIPTION
Minor follow on to #1903. This should not cause any change in behavior, but avoids constructing an unused json object.