### PR TITLE
Print informational messages to stderr

### DIFF
--- a/programs/psinode/tests/test_psibase.py
+++ b/programs/psinode/tests/test_psibase.py
@@ -451,6 +451,19 @@ class TestPsibase(unittest.TestCase):
         result = a.graphql('accounts', '''query { getAccount(accountName: "symbol") { accountNum authService } }''')
         self.assertIsNotNone(result['getAccount'])
 
+    @testutil.psinode_test
+    def test_json_trace(self, cluster):
+        (a,) = cluster.complete(*testutil.generate_names(1));
+        a.boot(packages=['Minimal', 'Explorer'])
+        p = a.run_psibase(['install', '-y']  + a.node_args() + ['TokenUsers', '--trace=json'], stdout=subprocess.PIPE, encoding="utf-8")
+        text = p.stdout.strip(' \t\r\n')
+        decoder = json.JSONDecoder()
+        while text != "":
+            print("'%s'" % text[:20])
+            (_, pos) = decoder.raw_decode(text)
+            print('pos = %d' % pos);
+            text = text[pos:].strip(' \t\r\n')
+
     def assertResponse(self, response, expected):
         response.raise_for_status()
         self.assertEqual(response.text, expected)

--- a/rust/psibase/src/main.rs
+++ b/rust/psibase/src/main.rs
@@ -1849,10 +1849,10 @@ async fn do_install<T: Read + Seek>(
 
 fn confirm_install(yes: bool, to_install: &[PackageOp]) -> Result<bool, anyhow::Error> {
     if to_install.is_empty() {
-        println!("Nothing to install.");
+        eprintln!("Nothing to install.");
         return Ok(false);
     } else {
-        println!("The following changes will be applied:");
+        eprintln!("The following changes will be applied:");
         to_install
             .iter()
             .map(|op| match op {
@@ -1866,7 +1866,7 @@ fn confirm_install(yes: bool, to_install: &[PackageOp]) -> Result<bool, anyhow::
                 }
                 PackageOp::Remove(meta) => format!("Remove {}-{}", meta.name, meta.version),
             })
-            .for_each(|line| println!("  {}", line));
+            .for_each(|line| eprintln!("  {}", line));
     }
 
     if !yes {
@@ -1877,7 +1877,7 @@ fn confirm_install(yes: bool, to_install: &[PackageOp]) -> Result<bool, anyhow::
                 .default(true)
                 .interact_on(&term)?;
             if !proceed {
-                println!("Install aborted.");
+                eprintln!("Install aborted.");
                 return Ok(false);
             }
         }


### PR DESCRIPTION
This ensures that `--trace=json` can be piped to another process