### PR TITLE
move skipBilling logic to transact

### DIFF
--- a/packages/system/Transact/include/services/system/Transact.hpp
+++ b/packages/system/Transact/include/services/system/Transact.hpp
@@ -433,13 +433,18 @@ namespace SystemService
       /// Enable/disable resource monitoring
       void resMonitoring(bool enable);
 
-      /// The next `numWrites` db writes will not be billed.
-      /// This may only be called by privileged services, and must be paired
-      /// with a call to `endSkipBilling` when the specified number of writes
-      /// have been performed.
+      /// Suppress billing/tracking for the next `numWrites` disk writes.
+      ///
+      /// Intended for wrapping privileged-service writes that are modified
+      /// by both wasm and native code (e.g. status row). The caller is expected
+      /// to perform exactly `numWrites` writes/frees and then call `endSkipBilling`.
+      ///
+      /// Only callable by privileged services.
       void skipBilling(uint32_t numWrites);
 
       /// Asserts that all writes promised by `skipBilling` were consumed.
+      ///
+      /// Only callable by privileged services.
       void endSkipBilling();
 
       /// Get the currently executing transaction

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -35,6 +35,10 @@ namespace SystemService
       // When set, kv writes are attributed to the system account (`{}`) instead of `trxSender`
       bool systemWrite = false;
 
+      // When set with `skipBilling`, the next `N` disk writes are not billed; exactly N unbilled
+      // writes must occur before `endSkipBilling` is called.
+      std::optional<uint32_t> skipDiskWrites;
+
       // RAII guard that marks the enclosing scope as performing authorized system
       // writes. Restores the previous value on destruction so nesting is safe.
       struct SystemWriteGuard
@@ -619,15 +623,16 @@ namespace SystemService
    void Transact::skipBilling(uint32_t numWrites)
    {
       checkPrivilegedSender();
-      systemWrite = true;
-      to<VirtualServer>().skip_billing(numWrites);
+      check(!skipDiskWrites.has_value(), "skipBilling already active");
+      skipDiskWrites = numWrites;
    }
 
    void Transact::endSkipBilling()
    {
       checkPrivilegedSender();
-      to<VirtualServer>().end_skip_billing();
-      systemWrite = false;
+      check(skipDiskWrites.has_value(), "endSkipBilling without active skipBilling");
+      check(*skipDiskWrites == 0, "endSkipBilling called before all skipped writes occurred");
+      skipDiskWrites.reset();
    }
 
    static void processTransactionImpl(
@@ -752,6 +757,13 @@ namespace SystemService
 
       if (isResMonitoring())
       {
+         if (skipDiskWrites.has_value())
+         {
+            check(*skipDiskWrites > 0, "more writes occurred than promised by skipBilling");
+            --*skipDiskWrites;
+            return;
+         }
+
          int64_t delta = 0;
          if (oldValueLen == DNE)
          {

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -287,20 +287,6 @@ namespace SystemService
       /// this resource.
       void useCpuSys(psibase::AccountNumber user, uint64_t amount_ns);
 
-      /// Suppress billing/tracking for the next `num_writes` `useDiskSys` calls.
-      ///
-      /// Intended for wrapping privileged-service writes that should not
-      /// be billed. The caller is expected to perform exactly `num_writes`
-      /// writes/frees and then call `end_skip_billing`.
-      ///
-      /// Only callable by privileged services.
-      void skip_billing(uint32_t num_writes);
-
-      /// Asserts that all writes promised by `skip_billing` were consumed.
-      ///
-      /// Only callable by privileged services.
-      void end_skip_billing();
-
       /// Called by the system when `user` causes a write to any database.
       ///
       /// `amount_bytes` is positive for consumption and negative for a free
@@ -377,8 +363,6 @@ namespace SystemService
                 method(disk_ref_quote, bytes),
                 method(useNetSys, user, amount_bytes),
                 method(useCpuSys, user, amount_ns),
-                method(skip_billing, num_writes),
-                method(end_skip_billing),
                 method(useDiskSys, user, db_id, amount_bytes),
                 method(get_resources, user),
                 method(notifyBlock, block_num),

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -15,7 +15,6 @@ mod tx_cache {
     thread_local! {
         static BILLABLE_ACCOUNT: Cell<Option<AccountNumber>> = const { Cell::new(None) };
         static BILL_TO_SUB: RefCell<Option<HashMap<AccountNumber, String>>> = const { RefCell::new(None) };
-        static SKIP_BILLING_COUNT: Cell<u32> = const { Cell::new(0) };
         static DISK_NET: RefCell<Option<HashMap<AccountNumber, (i64, i64)>>> = const { RefCell::new(None) };
     }
 
@@ -36,26 +35,6 @@ mod tx_cache {
             map.get_or_insert_with(HashMap::new)
                 .insert(user, sub_account);
         });
-    }
-
-    pub fn get_skip_count() -> u32 {
-        SKIP_BILLING_COUNT.with(|c| c.get())
-    }
-
-    pub fn set_skip_count(n: u32) {
-        SKIP_BILLING_COUNT.with(|c| c.set(n));
-    }
-
-    pub fn dec_skip_count() -> bool {
-        SKIP_BILLING_COUNT.with(|c| {
-            let n = c.get();
-            if n == 0 {
-                false
-            } else {
-                c.set(n - 1);
-                true
-            }
-        })
     }
 
     pub fn add_disk_usage(user: AccountNumber, amount_bytes: i64, cost: i64) {
@@ -722,35 +701,6 @@ mod service {
         }
     }
 
-    /// Suppress billing/tracking for the next `num_writes` `useDiskSys` calls.
-    ///
-    /// Intended for wrapping privileged-service writes that should not
-    /// be billed. The caller is expected to perform exactly `num_writes`
-    /// writes/frees and then call `end_skip_billing`.
-    ///
-    /// Only callable by Transact
-    #[action]
-    fn skip_billing(num_writes: u32) {
-        check(get_sender() == Transact::SERVICE, "Unauthorized");
-        check(
-            tx_cache::get_skip_count() == 0,
-            "skip_billing already active",
-        );
-        tx_cache::set_skip_count(num_writes);
-    }
-
-    /// Asserts that all writes promised by `skip_billing` were consumed.
-    ///
-    /// Only callable by Transact
-    #[action]
-    fn end_skip_billing() {
-        check(get_sender() == Transact::SERVICE, "Unauthorized");
-        check(
-            tx_cache::get_skip_count() == 0,
-            "end_skip_billing called before all skipped writes occurred",
-        );
-    }
-
     /// Called by the system when `user` causes a write to any database.
     ///
     /// `amount_bytes` is positive for consumption and negative for a free
@@ -764,10 +714,6 @@ mod service {
             get_sender() == Transact::SERVICE,
             "[useDiskSys] Unauthorized",
         );
-
-        if tx_cache::dec_skip_count() {
-            return;
-        }
 
         if amount_bytes == 0 {
             return;

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -420,26 +420,6 @@ mod service {
         unimplemented!()
     }
 
-    /// Suppress billing/tracking for the next `num_writes` `useDiskSys` calls.
-    ///
-    /// Intended for wrapping privileged-service writes that should not
-    /// be billed. The caller is expected to perform exactly `num_writes`
-    /// writes/frees and then call `end_skip_billing`.
-    ///
-    /// Only callable by Transact
-    #[action]
-    fn skip_billing(num_writes: u32) {
-        unimplemented!()
-    }
-
-    /// Asserts that all writes promised by `skip_billing` were consumed.
-    ///
-    /// Only callable by Transact
-    #[action]
-    fn end_skip_billing() {
-        unimplemented!()
-    }
-
     /// Called by the system when `user` causes a write to any database.
     ///
     /// `amount_bytes` is positive for consumption and negative for a free


### PR DESCRIPTION
Moved skip_billing entirely out of `virtual-server` and into `transact`.
`transact` sees delta == 0 writes/frees, which should be counted when we are enforcing `num_writes`
