### PR TITLE
Move action functions into the `ServiceWrapper` trait

### DIFF
--- a/packages/system/AuthDyn/service/src/lib.rs
+++ b/packages/system/AuthDyn/service/src/lib.rs
@@ -4,8 +4,8 @@ pub mod tables {
     use psibase::services::auth_dyn::int_wrapper;
     use psibase::services::transact::ServiceMethod;
     use psibase::{
-        check, check_some, services::auth_dyn::policy::DynamicAuthPolicy, AccountNumber, Call,
-        Fracpack, Table, ToSchema,
+        check, check_some, services::auth_dyn::policy::DynamicAuthPolicy, AccountNumber, Fracpack,
+        ServiceWrapper, Table, ToSchema,
     };
     use serde::{Deserialize, Serialize};
 

--- a/packages/system/AuthDyn/service/src/lib.rs
+++ b/packages/system/AuthDyn/service/src/lib.rs
@@ -4,8 +4,8 @@ pub mod tables {
     use psibase::services::auth_dyn::int_wrapper;
     use psibase::services::transact::ServiceMethod;
     use psibase::{
-        check, check_some, services::auth_dyn::policy::DynamicAuthPolicy, AccountNumber, Fracpack,
-        Table, ToSchema,
+        check, check_some, services::auth_dyn::policy::DynamicAuthPolicy, AccountNumber, Call,
+        Fracpack, Table, ToSchema,
     };
     use serde::{Deserialize, Serialize};
 

--- a/packages/system/StagedTx/service/src/db.rs
+++ b/packages/system/StagedTx/service/src/db.rs
@@ -130,7 +130,7 @@ pub mod impls {
     use psibase::fracpack::Pack;
     use psibase::services::transact::ServiceMethod;
     use psibase::services::{accounts::Wrapper as Accounts, transact::Wrapper as Transact};
-    use psibase::{check, get_sender, AccountNumber, Action, Call, Checksum256, Table};
+    use psibase::{check, get_sender, AccountNumber, Action, Checksum256, ServiceWrapper, Table};
 
     impl StagedTx {
         pub fn add(actions: Vec<Action>, auto_exec: bool) -> Self {

--- a/packages/system/StagedTx/service/src/db.rs
+++ b/packages/system/StagedTx/service/src/db.rs
@@ -130,7 +130,7 @@ pub mod impls {
     use psibase::fracpack::Pack;
     use psibase::services::transact::ServiceMethod;
     use psibase::services::{accounts::Wrapper as Accounts, transact::Wrapper as Transact};
-    use psibase::{check, get_sender, AccountNumber, Action, Checksum256, Table};
+    use psibase::{check, get_sender, AccountNumber, Action, Call, Checksum256, Table};
 
     impl StagedTx {
         pub fn add(actions: Vec<Action>, auto_exec: bool) -> Self {

--- a/packages/system/StagedTx/service/src/policy.rs
+++ b/packages/system/StagedTx/service/src/policy.rs
@@ -1,7 +1,7 @@
 use psibase::services::accounts::Wrapper as Accounts;
 use psibase::services::transact::auth_interface::auth_action_structs;
 use psibase::services::transact::ServiceMethod;
-use psibase::{AccountNumber, Caller, MethodNumber, ServiceCaller};
+use psibase::{AccountNumber, Call, Caller, MethodNumber, ServiceCaller};
 
 use crate::service::Wrapper;
 

--- a/packages/system/StagedTx/service/src/policy.rs
+++ b/packages/system/StagedTx/service/src/policy.rs
@@ -1,7 +1,7 @@
 use psibase::services::accounts::Wrapper as Accounts;
 use psibase::services::transact::auth_interface::auth_action_structs;
 use psibase::services::transact::ServiceMethod;
-use psibase::{AccountNumber, Call, Caller, MethodNumber, ServiceCaller};
+use psibase::{AccountNumber, Caller, MethodNumber, ServiceCaller, ServiceWrapper};
 
 use crate::service::Wrapper;
 

--- a/packages/system/VirtualServer/service/src/rpc.rs
+++ b/packages/system/VirtualServer/service/src/rpc.rs
@@ -16,7 +16,7 @@ use psibase::{
         tokens::{Decimal, Quantity, Wrapper as Tokens},
         transact::ServiceMethod,
     },
-    AccountNumber, EventConnection, EventQuery, MethodNumber, Table,
+    AccountNumber, Call, EventConnection, EventQuery, MethodNumber, Table,
 };
 use serde::Deserialize;
 use serde_aux::field_attributes::deserialize_number_from_string;

--- a/packages/system/VirtualServer/service/src/rpc.rs
+++ b/packages/system/VirtualServer/service/src/rpc.rs
@@ -16,7 +16,7 @@ use psibase::{
         tokens::{Decimal, Quantity, Wrapper as Tokens},
         transact::ServiceMethod,
     },
-    AccountNumber, Call, EventConnection, EventQuery, MethodNumber, Table,
+    AccountNumber, EventConnection, EventQuery, MethodNumber, ServiceWrapper, Table,
 };
 use serde::Deserialize;
 use serde_aux::field_attributes::deserialize_number_from_string;

--- a/packages/system/VirtualServer/service/src/tests.rs
+++ b/packages/system/VirtualServer/service/src/tests.rs
@@ -19,8 +19,8 @@ mod tests {
             tokens::{self, Decimal, Precision, Quantity, Wrapper as Tokens},
             verify_sig,
         },
-        tester, AccountNumber, Action, ChainEmptyResult, Claim, MethodNumber, SignedTransaction,
-        Transaction,
+        tester, AccountNumber, Action, ChainEmptyResult, Claim, MethodNumber, Push,
+        SignedTransaction, Transaction,
     };
     use rand::Rng;
     use serde::Deserialize;

--- a/packages/user/Chainmail/service/src/event_query_helpers.rs
+++ b/packages/user/Chainmail/service/src/event_query_helpers.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::helpers::validate_user;
 
 use psibase::services::r_events::Wrapper as REventsSvc;
-use psibase::{allow_cors_with_origin, Hex, HttpReply, HttpRequest};
+use psibase::{allow_cors_with_origin, Call, Hex, HttpReply, HttpRequest};
 
 fn build_query_by_id(params: HashMap<String, String>) -> Option<String> {
     if params.get("id").is_none() {

--- a/packages/user/Chainmail/service/src/event_query_helpers.rs
+++ b/packages/user/Chainmail/service/src/event_query_helpers.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::helpers::validate_user;
 
 use psibase::services::r_events::Wrapper as REventsSvc;
-use psibase::{allow_cors_with_origin, Call, Hex, HttpReply, HttpRequest};
+use psibase::{allow_cors_with_origin, Hex, HttpReply, HttpRequest, ServiceWrapper};
 
 fn build_query_by_id(params: HashMap<String, String>) -> Option<String> {
     if params.get("id").is_none() {

--- a/packages/user/Chainmail/service/src/helpers.rs
+++ b/packages/user/Chainmail/service/src/helpers.rs
@@ -1,4 +1,4 @@
-use psibase::{services::accounts::Wrapper as AccountsSvc, AccountNumber, Call};
+use psibase::{services::accounts::Wrapper as AccountsSvc, AccountNumber, ServiceWrapper};
 
 pub fn validate_user(user: &str) -> bool {
     let acc = AccountNumber::from_exact(user).unwrap();

--- a/packages/user/Chainmail/service/src/helpers.rs
+++ b/packages/user/Chainmail/service/src/helpers.rs
@@ -1,4 +1,4 @@
-use psibase::{services::accounts::Wrapper as AccountsSvc, AccountNumber};
+use psibase::{services::accounts::Wrapper as AccountsSvc, AccountNumber, Call};
 
 pub fn validate_user(user: &str) -> bool {
     let acc = AccountNumber::from_exact(user).unwrap();

--- a/packages/user/Chainmail/service/src/lib.rs
+++ b/packages/user/Chainmail/service/src/lib.rs
@@ -16,7 +16,7 @@ mod service {
     use psibase::services::sites::Wrapper as SitesSvc;
     use psibase::services::transact::Wrapper as TransactSvc;
     use psibase::{
-        check, get_sender, serve_graphql, AccountNumber, DbId, HttpReply, HttpRequest,
+        check, get_sender, serve_graphql, AccountNumber, Call, DbId, HttpReply, HttpRequest,
         MethodNumber, RawKey, Table, TableQuery, TimePointSec,
     };
 

--- a/packages/user/Chainmail/service/src/lib.rs
+++ b/packages/user/Chainmail/service/src/lib.rs
@@ -16,8 +16,8 @@ mod service {
     use psibase::services::sites::Wrapper as SitesSvc;
     use psibase::services::transact::Wrapper as TransactSvc;
     use psibase::{
-        check, get_sender, serve_graphql, AccountNumber, Call, DbId, HttpReply, HttpRequest,
-        MethodNumber, RawKey, Table, TableQuery, TimePointSec,
+        check, get_sender, serve_graphql, AccountNumber, DbId, HttpReply, HttpRequest,
+        MethodNumber, RawKey, ServiceWrapper, Table, TableQuery, TimePointSec,
     };
 
     #[action]

--- a/packages/user/DiffAdjust/service/src/lib.rs
+++ b/packages/user/DiffAdjust/service/src/lib.rs
@@ -3,7 +3,7 @@ pub mod tables {
     use psibase::services::nft::Wrapper as Nft;
     use psibase::services::transact::Wrapper as TransactSvc;
     use psibase::{
-        check, check_some, get_sender, AccountNumber, Fracpack, Table, TimePointSec, ToSchema,
+        check, check_some, get_sender, AccountNumber, Call, Fracpack, Table, TimePointSec, ToSchema,
     };
 
     use async_graphql::{ComplexObject, SimpleObject};

--- a/packages/user/DiffAdjust/service/src/lib.rs
+++ b/packages/user/DiffAdjust/service/src/lib.rs
@@ -3,7 +3,8 @@ pub mod tables {
     use psibase::services::nft::Wrapper as Nft;
     use psibase::services::transact::Wrapper as TransactSvc;
     use psibase::{
-        check, check_some, get_sender, AccountNumber, Call, Fracpack, Table, TimePointSec, ToSchema,
+        check, check_some, get_sender, AccountNumber, Fracpack, ServiceWrapper, Table,
+        TimePointSec, ToSchema,
     };
 
     use async_graphql::{ComplexObject, SimpleObject};

--- a/packages/user/Evaluations/service/src/db.rs
+++ b/packages/user/Evaluations/service/src/db.rs
@@ -97,7 +97,7 @@ pub mod impls {
     };
     use psibase::services::evaluations::Hooks::hooks_wrapper as EvalHooks;
     use psibase::services::subgroups::Wrapper as Subgroups;
-    use psibase::{AccountNumber, Table};
+    use psibase::{AccountNumber, Call, Table};
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
     impl ConfigRow {

--- a/packages/user/Evaluations/service/src/db.rs
+++ b/packages/user/Evaluations/service/src/db.rs
@@ -97,7 +97,7 @@ pub mod impls {
     };
     use psibase::services::evaluations::Hooks::hooks_wrapper as EvalHooks;
     use psibase::services::subgroups::Wrapper as Subgroups;
-    use psibase::{AccountNumber, Call, Table};
+    use psibase::{AccountNumber, ServiceWrapper, Table};
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
     impl ConfigRow {

--- a/packages/user/Evaluations/service/src/helpers.rs
+++ b/packages/user/Evaluations/service/src/helpers.rs
@@ -1,3 +1,4 @@
+use psibase::Call;
 use std::collections::HashMap;
 use std::fmt;
 

--- a/packages/user/Evaluations/service/src/helpers.rs
+++ b/packages/user/Evaluations/service/src/helpers.rs
@@ -1,4 +1,4 @@
-use psibase::Call;
+use psibase::ServiceWrapper;
 use std::collections::HashMap;
 use std::fmt;
 

--- a/packages/user/Fractals/service/src/helpers/create_managed_account.rs
+++ b/packages/user/Fractals/service/src/helpers/create_managed_account.rs
@@ -1,5 +1,5 @@
 use psibase::services::{accounts, auth_delegate, auth_dyn};
-use psibase::{AccountNumber, Call};
+use psibase::{AccountNumber, ServiceWrapper};
 
 pub fn create_managed_account<F>(new_account: AccountNumber, f: F)
 where

--- a/packages/user/Fractals/service/src/helpers/create_managed_account.rs
+++ b/packages/user/Fractals/service/src/helpers/create_managed_account.rs
@@ -1,5 +1,5 @@
 use psibase::services::{accounts, auth_delegate, auth_dyn};
-use psibase::AccountNumber;
+use psibase::{AccountNumber, Call};
 
 pub fn create_managed_account<F>(new_account: AccountNumber, f: F)
 where

--- a/packages/user/Fractals/service/src/tables/fractal.rs
+++ b/packages/user/Fractals/service/src/tables/fractal.rs
@@ -24,7 +24,7 @@ use crate::tables::tables::{
 };
 use psibase::{
     account, check_none, check_some, services::auth_dyn::policy::DynamicAuthPolicy, AccountNumber,
-    Call, Table,
+    ServiceWrapper, Table,
 };
 
 use psibase::services::fractals::{self, occu_wrapper};

--- a/packages/user/Fractals/service/src/tables/fractal.rs
+++ b/packages/user/Fractals/service/src/tables/fractal.rs
@@ -24,7 +24,7 @@ use crate::tables::tables::{
 };
 use psibase::{
     account, check_none, check_some, services::auth_dyn::policy::DynamicAuthPolicy, AccountNumber,
-    Table,
+    Call, Table,
 };
 
 use psibase::services::fractals::{self, occu_wrapper};

--- a/packages/user/Fractals/service/src/tables/fractal_member.rs
+++ b/packages/user/Fractals/service/src/tables/fractal_member.rs
@@ -1,6 +1,6 @@
 use std::u64;
 
-use psibase::{check_none, check_some, AccountNumber, Call, Table};
+use psibase::{check_none, check_some, AccountNumber, ServiceWrapper, Table};
 
 use crate::{
     constants::DEFAULT_RECRUITMENT_PPM,

--- a/packages/user/Fractals/service/src/tables/fractal_member.rs
+++ b/packages/user/Fractals/service/src/tables/fractal_member.rs
@@ -1,6 +1,6 @@
 use std::u64;
 
-use psibase::{check_none, check_some, AccountNumber, Table};
+use psibase::{check_none, check_some, AccountNumber, Call, Table};
 
 use crate::{
     constants::DEFAULT_RECRUITMENT_PPM,

--- a/packages/user/Fractals/service/src/tables/levy.rs
+++ b/packages/user/Fractals/service/src/tables/levy.rs
@@ -1,6 +1,6 @@
 use async_graphql::ComplexObject;
 use psibase::services::fractals::constants::PPM;
-use psibase::{check, check_some, services::tokens::Quantity, AccountNumber, Table};
+use psibase::{check, check_some, services::tokens::Quantity, AccountNumber, Call, Table};
 
 use crate::tables::tables::{Config, Fractal, FractalMember, Levy, LevyTable, RewardStream};
 

--- a/packages/user/Fractals/service/src/tables/levy.rs
+++ b/packages/user/Fractals/service/src/tables/levy.rs
@@ -1,6 +1,8 @@
 use async_graphql::ComplexObject;
 use psibase::services::fractals::constants::PPM;
-use psibase::{check, check_some, services::tokens::Quantity, AccountNumber, Call, Table};
+use psibase::{
+    check, check_some, services::tokens::Quantity, AccountNumber, ServiceWrapper, Table,
+};
 
 use crate::tables::tables::{Config, Fractal, FractalMember, Levy, LevyTable, RewardStream};
 

--- a/packages/user/Fractals/service/src/tables/reward_stream.rs
+++ b/packages/user/Fractals/service/src/tables/reward_stream.rs
@@ -1,4 +1,4 @@
-use psibase::{check, check_none, check_some, AccountNumber, Call, Memo, Table};
+use psibase::{check, check_none, check_some, AccountNumber, Memo, ServiceWrapper, Table};
 
 use crate::constants::{
     DEFAULT_MEMBER_DISTRIBUTION_INTERVAL, FRACTAL_STREAM_HALF_LIFE, MEMBER_STREAM_HALF_LIFE,

--- a/packages/user/Fractals/service/src/tables/reward_stream.rs
+++ b/packages/user/Fractals/service/src/tables/reward_stream.rs
@@ -1,4 +1,4 @@
-use psibase::{check, check_none, check_some, AccountNumber, Memo, Table};
+use psibase::{check, check_none, check_some, AccountNumber, Call, Memo, Table};
 
 use crate::constants::{
     DEFAULT_MEMBER_DISTRIBUTION_INTERVAL, FRACTAL_STREAM_HALF_LIFE, MEMBER_STREAM_HALF_LIFE,

--- a/packages/user/Fractals/service/src/tables/role.rs
+++ b/packages/user/Fractals/service/src/tables/role.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use psibase::services::auth_dyn::policy::DynamicAuthPolicy;
 use psibase::services::fractals::FractalRole;
-use psibase::{check, check_none, check_some, AccountNumber, Call, Table};
+use psibase::{check, check_none, check_some, AccountNumber, ServiceWrapper, Table};
 
 impl Role {
     fn new(

--- a/packages/user/Fractals/service/src/tables/role.rs
+++ b/packages/user/Fractals/service/src/tables/role.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use psibase::services::auth_dyn::policy::DynamicAuthPolicy;
 use psibase::services::fractals::FractalRole;
-use psibase::{check, check_none, check_some, AccountNumber, Table};
+use psibase::{check, check_none, check_some, AccountNumber, Call, Table};
 
 impl Role {
     fn new(

--- a/packages/user/Guilds/service/src/tables/evaluation_instance.rs
+++ b/packages/user/Guilds/service/src/tables/evaluation_instance.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use ::evaluations::service::{Evaluation, EvaluationTable, User, UserTable};
 use psibase::services::evaluations;
-use psibase::{check_some, get_service, AccountNumber, Table};
+use psibase::{check_some, get_service, AccountNumber, Call, Table};
 
 use crate::constants::GUILD_EVALUATION_GROUP_SIZE;
 use crate::helpers::assign_decreasing_levels;

--- a/packages/user/Guilds/service/src/tables/evaluation_instance.rs
+++ b/packages/user/Guilds/service/src/tables/evaluation_instance.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use ::evaluations::service::{Evaluation, EvaluationTable, User, UserTable};
 use psibase::services::evaluations;
-use psibase::{check_some, get_service, AccountNumber, Call, Table};
+use psibase::{check_some, get_service, AccountNumber, ServiceWrapper, Table};
 
 use crate::constants::GUILD_EVALUATION_GROUP_SIZE;
 use crate::helpers::assign_decreasing_levels;

--- a/packages/user/Guilds/service/src/tables/guild.rs
+++ b/packages/user/Guilds/service/src/tables/guild.rs
@@ -5,7 +5,7 @@ use psibase::services::fractals::weighted_normalization::{
     curves::{get_curve, Curve},
     weighted_normalization,
 };
-use psibase::{check, check_none, check_some, get_sender, AccountNumber, Flags, Memo, Table};
+use psibase::{check, check_none, check_some, get_sender, AccountNumber, Call, Flags, Memo, Table};
 
 use crate::constants::{
     COUNCIL_SEATS, DEFAULT_CANDIDACY_COOLDOWN, DEFAULT_RANK_ORDERING_THRESHOLD,

--- a/packages/user/Guilds/service/src/tables/guild.rs
+++ b/packages/user/Guilds/service/src/tables/guild.rs
@@ -5,7 +5,9 @@ use psibase::services::fractals::weighted_normalization::{
     curves::{get_curve, Curve},
     weighted_normalization,
 };
-use psibase::{check, check_none, check_some, get_sender, AccountNumber, Call, Flags, Memo, Table};
+use psibase::{
+    check, check_none, check_some, get_sender, AccountNumber, Flags, Memo, ServiceWrapper, Table,
+};
 
 use crate::constants::{
     COUNCIL_SEATS, DEFAULT_CANDIDACY_COOLDOWN, DEFAULT_RANK_ORDERING_THRESHOLD,

--- a/packages/user/Guilds/service/src/tables/guild_application.rs
+++ b/packages/user/Guilds/service/src/tables/guild_application.rs
@@ -1,7 +1,7 @@
 use async_graphql::ComplexObject;
 use async_graphql::{connection::Connection, SimpleObject};
 
-use psibase::{check_none, check_some, AccountNumber, RawKey, Table, TableQuery};
+use psibase::{check_none, check_some, AccountNumber, Call, RawKey, Table, TableQuery};
 
 use crate::{
     constants::{GUILD_APP_ENDORSEMENT_THRESHOLD, GUILD_APP_REJECT_THRESHOLD},

--- a/packages/user/Guilds/service/src/tables/guild_application.rs
+++ b/packages/user/Guilds/service/src/tables/guild_application.rs
@@ -1,7 +1,7 @@
 use async_graphql::ComplexObject;
 use async_graphql::{connection::Connection, SimpleObject};
 
-use psibase::{check_none, check_some, AccountNumber, Call, PackAction, RawKey, Table, TableQuery};
+use psibase::{check_none, check_some, AccountNumber, RawKey, ServiceWrapper, Table, TableQuery};
 
 use crate::{
     constants::{GUILD_APP_ENDORSEMENT_THRESHOLD, GUILD_APP_REJECT_THRESHOLD},

--- a/packages/user/Guilds/service/src/tables/guild_application.rs
+++ b/packages/user/Guilds/service/src/tables/guild_application.rs
@@ -1,7 +1,7 @@
 use async_graphql::ComplexObject;
 use async_graphql::{connection::Connection, SimpleObject};
 
-use psibase::{check_none, check_some, AccountNumber, Call, RawKey, Table, TableQuery};
+use psibase::{check_none, check_some, AccountNumber, Call, PackAction, RawKey, Table, TableQuery};
 
 use crate::{
     constants::{GUILD_APP_ENDORSEMENT_THRESHOLD, GUILD_APP_REJECT_THRESHOLD},

--- a/packages/user/Guilds/service/src/tables/guild_invite.rs
+++ b/packages/user/Guilds/service/src/tables/guild_invite.rs
@@ -1,8 +1,8 @@
 use async_graphql::ComplexObject;
 
 use psibase::{
-    check, check_some, get_sender, services::tokens::Quantity, AccountNumber, Call, Memo, Table,
-    TimePointSec,
+    check, check_some, get_sender, services::tokens::Quantity, AccountNumber, Memo, ServiceWrapper,
+    Table, TimePointSec,
 };
 
 use crate::{

--- a/packages/user/Guilds/service/src/tables/guild_invite.rs
+++ b/packages/user/Guilds/service/src/tables/guild_invite.rs
@@ -1,7 +1,7 @@
 use async_graphql::ComplexObject;
 
 use psibase::{
-    check, check_some, get_sender, services::tokens::Quantity, AccountNumber, Memo, Table,
+    check, check_some, get_sender, services::tokens::Quantity, AccountNumber, Call, Memo, Table,
     TimePointSec,
 };
 

--- a/packages/user/Guilds/service/src/tables/guild_member.rs
+++ b/packages/user/Guilds/service/src/tables/guild_member.rs
@@ -1,7 +1,7 @@
 use async_graphql::ComplexObject;
 use psibase::services::fractals::weighted_normalization::HasScore;
 use psibase::services::tokens::{Decimal, Precision, Quantity};
-use psibase::{check, check_none, check_some, AccountNumber, Table};
+use psibase::{check, check_none, check_some, AccountNumber, Call, Table};
 
 use crate::constants::{EMA_ALPHA_DENOMINATOR, GUILD_EVALUATION_GROUP_SIZE, SCORE_SCALE};
 use crate::helpers::{calculate_ema_u32, Fraction, RollingBits16};

--- a/packages/user/Guilds/service/src/tables/guild_member.rs
+++ b/packages/user/Guilds/service/src/tables/guild_member.rs
@@ -1,7 +1,7 @@
 use async_graphql::ComplexObject;
 use psibase::services::fractals::weighted_normalization::HasScore;
 use psibase::services::tokens::{Decimal, Precision, Quantity};
-use psibase::{check, check_none, check_some, AccountNumber, Call, Table};
+use psibase::{check, check_none, check_some, AccountNumber, ServiceWrapper, Table};
 
 use crate::constants::{EMA_ALPHA_DENOMINATOR, GUILD_EVALUATION_GROUP_SIZE, SCORE_SCALE};
 use crate::helpers::{calculate_ema_u32, Fraction, RollingBits16};

--- a/packages/user/Identity/service/src/tests/helpers/test_helpers.rs
+++ b/packages/user/Identity/service/src/tests/helpers/test_helpers.rs
@@ -1,7 +1,7 @@
 use super::gql::Queryable;
 use crate::tables::{Attestation, AttestationStats};
 use crate::Wrapper as Identity;
-use psibase::AccountNumber;
+use psibase::{AccountNumber, Push, ServiceWrapper};
 use std::fmt::Debug;
 
 pub trait HasQueryFields {
@@ -48,30 +48,12 @@ impl HasQueryFields for AttestationStats {
         "subject, uniqueAttesters, numHighConfAttestations, mostRecentAttestation";
 }
 
-// Todo: implement a ServiceWrapper trait on the Wrapper itself, instead of needing a wrapper object
-pub trait IsServiceWrapper {
-    const SERVICE: psibase::AccountNumber;
-    fn push_from(
-        chain: &psibase::Chain,
-        account: AccountNumber,
-    ) -> crate::Actions<psibase::ChainPusher>;
-}
-impl IsServiceWrapper for Identity {
-    const SERVICE: psibase::AccountNumber = Identity::SERVICE;
-    fn push_from(
-        chain: &psibase::Chain,
-        account: AccountNumber,
-    ) -> crate::Actions<psibase::ChainPusher> {
-        Identity::push_from(chain, account)
-    }
-}
-
-pub struct ChainPusher<'a, T: IsServiceWrapper> {
+pub struct ChainPusher<'a, T: ServiceWrapper> {
     chain: &'a psibase::Chain,
     _marker: core::marker::PhantomData<T>,
 }
 
-impl<'a, T: IsServiceWrapper> ChainPusher<'a, T> {
+impl<'a, T: ServiceWrapper> ChainPusher<'a, T> {
     fn new(chain: &'a psibase::Chain) -> Self {
         ChainPusher::<T> {
             chain,
@@ -80,7 +62,7 @@ impl<'a, T: IsServiceWrapper> ChainPusher<'a, T> {
     }
 
     /// Push an action from the specified account
-    pub fn from(&self, account: &str) -> crate::Actions<psibase::ChainPusher> {
+    pub fn from(&self, account: &str) -> T::Actions<psibase::ChainPusher<'a>> {
         T::push_from(self.chain, account.parse().unwrap())
     }
 
@@ -94,7 +76,7 @@ impl<'a, T: IsServiceWrapper> ChainPusher<'a, T> {
     }
 }
 
-pub fn init_identity_svc(chain: &psibase::Chain) -> ChainPusher<Identity> {
+pub fn init_identity_svc<'a>(chain: &'a psibase::Chain) -> ChainPusher<'a, Identity> {
     chain.new_account(psibase::account!("alice")).unwrap();
     chain.new_account(psibase::account!("bob")).unwrap();
     ChainPusher::<Identity>::new(&chain)

--- a/packages/user/Nft/service/src/lib.rs
+++ b/packages/user/Nft/service/src/lib.rs
@@ -4,7 +4,7 @@ pub mod tables {
     use async_graphql::SimpleObject;
     use psibase::{
         abort_message, check, check_none, check_some, define_flags, get_sender, AccountNumber,
-        Call, FlagsType, Fracpack, Memo, Table, ToSchema,
+        FlagsType, Fracpack, Memo, ServiceWrapper, Table, ToSchema,
     };
     use serde::{Deserialize, Serialize};
 
@@ -278,8 +278,8 @@ pub mod tables {
 pub mod service {
     use crate::tables::*;
     use psibase::{
-        check, check_some, get_sender, get_service, services::events, AccountNumber, Call, DbId,
-        Memo, MethodNumber,
+        check, check_some, get_sender, get_service, services::events, AccountNumber, DbId, Memo,
+        MethodNumber, ServiceWrapper,
     };
 
     pub type NID = u32;

--- a/packages/user/Nft/service/src/lib.rs
+++ b/packages/user/Nft/service/src/lib.rs
@@ -4,7 +4,7 @@ pub mod tables {
     use async_graphql::SimpleObject;
     use psibase::{
         abort_message, check, check_none, check_some, define_flags, get_sender, AccountNumber,
-        FlagsType, Fracpack, Memo, Table, ToSchema,
+        Call, FlagsType, Fracpack, Memo, Table, ToSchema,
     };
     use serde::{Deserialize, Serialize};
 
@@ -278,8 +278,8 @@ pub mod tables {
 pub mod service {
     use crate::tables::*;
     use psibase::{
-        check, check_some, get_sender, get_service, services::events, AccountNumber, DbId, Memo,
-        MethodNumber,
+        check, check_some, get_sender, get_service, services::events, AccountNumber, Call, DbId,
+        Memo, MethodNumber,
     };
 
     pub type NID = u32;

--- a/packages/user/Packages/plugin/src/lib.rs
+++ b/packages/user/Packages/plugin/src/lib.rs
@@ -23,9 +23,9 @@ use exports::packages::plugin::queries::Guest as Queries;
 use psibase::fracpack::{Pack, Unpack};
 use psibase::services::packages::PackageSource;
 use psibase::{
-    make_refs, method, solve_dependencies, AccountNumber, Action, InstalledPackageInfo, PackAction,
-    PackageDisposition, PackageList, PackageManifest, PackagedService, SchemaMap, StagedUpload,
-    TransactionBuilder,
+    make_refs, method, solve_dependencies, AccountNumber, Action, InstalledPackageInfo,
+    PackageDisposition, PackageList, PackageManifest, PackagedService, SchemaMap, ServiceWrapper,
+    StagedUpload, TransactionBuilder,
 };
 
 use psibase::services::{

--- a/packages/user/Packages/plugin/src/lib.rs
+++ b/packages/user/Packages/plugin/src/lib.rs
@@ -23,7 +23,7 @@ use exports::packages::plugin::queries::Guest as Queries;
 use psibase::fracpack::{Pack, Unpack};
 use psibase::services::packages::PackageSource;
 use psibase::{
-    make_refs, method, solve_dependencies, AccountNumber, Action, InstalledPackageInfo,
+    make_refs, method, solve_dependencies, AccountNumber, Action, InstalledPackageInfo, PackAction,
     PackageDisposition, PackageList, PackageManifest, PackagedService, SchemaMap, StagedUpload,
     TransactionBuilder,
 };

--- a/packages/user/Registry/service/src/tests.rs
+++ b/packages/user/Registry/service/src/tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use constants::app_status;
     use constants::MAX_NAME_SIZE;
     use psibase::services::http_server;
-    use psibase::{account, ChainEmptyResult, TimePointUSec};
+    use psibase::{account, ChainEmptyResult, Push, TimePointUSec};
     use serde_json::{json, Value};
     use service::AppMetadata;
 

--- a/packages/user/Symbol/service/src/lib.rs
+++ b/packages/user/Symbol/service/src/lib.rs
@@ -6,7 +6,7 @@ pub mod tables {
     use psibase::services::nft::{Nft as NftRecord, Wrapper as Nft, NID};
     use psibase::services::tokens::Wrapper as Tokens;
     use psibase::services::tokens::{Decimal, Quantity, TokenRecord, TID};
-    use psibase::{check, check_some, get_sender, AccountNumber, Fracpack, Table, ToSchema};
+    use psibase::{check, check_some, get_sender, AccountNumber, Call, Fracpack, Table, ToSchema};
     use psibase::{check_none, get_service};
     use serde::{Deserialize, Serialize};
 
@@ -341,7 +341,10 @@ pub mod service {
 
     #[action]
     fn admin_create(symbol: AccountNumber, recipient: AccountNumber) {
-        check(get_sender() == get_service(), "only symbol service can call this action");
+        check(
+            get_sender() == get_service(),
+            "only symbol service can call this action",
+        );
         Symbol::add(symbol, recipient);
     }
 

--- a/packages/user/Symbol/service/src/lib.rs
+++ b/packages/user/Symbol/service/src/lib.rs
@@ -6,7 +6,9 @@ pub mod tables {
     use psibase::services::nft::{Nft as NftRecord, Wrapper as Nft, NID};
     use psibase::services::tokens::Wrapper as Tokens;
     use psibase::services::tokens::{Decimal, Quantity, TokenRecord, TID};
-    use psibase::{check, check_some, get_sender, AccountNumber, Call, Fracpack, Table, ToSchema};
+    use psibase::{
+        check, check_some, get_sender, AccountNumber, Fracpack, ServiceWrapper, Table, ToSchema,
+    };
     use psibase::{check_none, get_service};
     use serde::{Deserialize, Serialize};
 

--- a/packages/user/TokenStream/service/src/lib.rs
+++ b/packages/user/TokenStream/service/src/lib.rs
@@ -3,7 +3,7 @@ pub mod tables {
     use async_graphql::{ComplexObject, SimpleObject};
     use psibase::services::tokens::{Decimal, Precision, Quantity, TID};
     use psibase::{
-        check, check_some, AccountNumber, Call, Fracpack, Table, TimePointSec, ToSchema,
+        check, check_some, AccountNumber, Fracpack, ServiceWrapper, Table, TimePointSec, ToSchema,
     };
     use serde::{Deserialize, Serialize};
 
@@ -176,7 +176,7 @@ pub mod service {
 
     use psibase::services::nft::Wrapper as Nft;
     use psibase::services::tokens::Wrapper as Tokens;
-    use psibase::{get_sender, AccountNumber, Call, Memo};
+    use psibase::{get_sender, AccountNumber, Memo, ServiceWrapper};
 
     use crate::tables::Stream;
 

--- a/packages/user/TokenStream/service/src/lib.rs
+++ b/packages/user/TokenStream/service/src/lib.rs
@@ -2,7 +2,9 @@
 pub mod tables {
     use async_graphql::{ComplexObject, SimpleObject};
     use psibase::services::tokens::{Decimal, Precision, Quantity, TID};
-    use psibase::{check, check_some, AccountNumber, Fracpack, Table, TimePointSec, ToSchema};
+    use psibase::{
+        check, check_some, AccountNumber, Call, Fracpack, Table, TimePointSec, ToSchema,
+    };
     use serde::{Deserialize, Serialize};
 
     use psibase::services::nft::{Wrapper as Nfts, NID};
@@ -174,7 +176,7 @@ pub mod service {
 
     use psibase::services::nft::Wrapper as Nft;
     use psibase::services::tokens::Wrapper as Tokens;
-    use psibase::{get_sender, AccountNumber, Memo};
+    use psibase::{get_sender, AccountNumber, Call, Memo};
 
     use crate::tables::Stream;
 

--- a/packages/user/TokenSwap/service/src/tables.rs
+++ b/packages/user/TokenSwap/service/src/tables.rs
@@ -6,8 +6,8 @@ pub mod tables {
     use psibase::services::token_swap::{swap, Wrapper as TokenSwap, PPM};
     use psibase::services::tokens::{Decimal, Quantity, TokenRecord, Wrapper as Tokens, TID};
     use psibase::{
-        abort_message, check, check_none, check_some, get_sender, AccountNumber, Fracpack, Memo,
-        Table, ToSchema,
+        abort_message, check, check_none, check_some, get_sender, AccountNumber, Call, Fracpack,
+        Memo, Table, ToSchema,
     };
 
     use crate::helpers::{mul_div, sqrt};

--- a/packages/user/TokenSwap/service/src/tables.rs
+++ b/packages/user/TokenSwap/service/src/tables.rs
@@ -6,8 +6,8 @@ pub mod tables {
     use psibase::services::token_swap::{swap, Wrapper as TokenSwap, PPM};
     use psibase::services::tokens::{Decimal, Quantity, TokenRecord, Wrapper as Tokens, TID};
     use psibase::{
-        abort_message, check, check_none, check_some, get_sender, AccountNumber, Call, Fracpack,
-        Memo, Table, ToSchema,
+        abort_message, check, check_none, check_some, get_sender, AccountNumber, Fracpack, Memo,
+        ServiceWrapper, Table, ToSchema,
     };
 
     use crate::helpers::{mul_div, sqrt};

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -6,7 +6,8 @@ pub mod tables {
     use psibase::services::nft::{Wrapper as Nfts, NID};
     use psibase::services::tokens::{Decimal, Precision, Quantity};
     use psibase::{
-        abort_message, check, check_none, check_some, get_sender, AccountNumber, Memo, TableRecord,
+        abort_message, check, check_none, check_some, get_sender, AccountNumber, Call, Memo,
+        TableRecord,
     };
     use psibase::{define_flags, Flags};
     use psibase::{Fracpack, Table, ToSchema};

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -6,8 +6,8 @@ pub mod tables {
     use psibase::services::nft::{Wrapper as Nfts, NID};
     use psibase::services::tokens::{Decimal, Precision, Quantity};
     use psibase::{
-        abort_message, check, check_none, check_some, get_sender, AccountNumber, Call, Memo,
-        TableRecord,
+        abort_message, check, check_none, check_some, get_sender, AccountNumber, Memo,
+        ServiceWrapper, TableRecord,
     };
     use psibase::{define_flags, Flags};
     use psibase::{Fracpack, Table, ToSchema};

--- a/rust/burst-transfer/src/main.rs
+++ b/rust/burst-transfer/src/main.rs
@@ -6,7 +6,7 @@ use psibase::fracpack::Pack;
 use psibase::services::tokens::{Quantity, Wrapper as Tokens};
 use psibase::{
     new_account_action, preapprove_action, ActionFormatter, AnyPrivateKey, HttpSchemaFetcher,
-    PackageList, TraceFormat,
+    PackageList, ServiceWrapper, TraceFormat,
 };
 
 const ACCOUNTS_PER_SETUP: usize = 10;

--- a/rust/psibase/src/actions.rs
+++ b/rust/psibase/src/actions.rs
@@ -1,7 +1,9 @@
 use crate::services::{
     accounts, auth_delegate, auth_sig, http_server, producers, setcode, verify_sig,
 };
-use crate::{account_raw, method_raw, AccountNumber, Action, AnyPublicKey, MethodNumber};
+use crate::{
+    account_raw, method_raw, AccountNumber, Action, AnyPublicKey, MethodNumber, PackAction,
+};
 use fracpack::Pack;
 
 macro_rules! account {

--- a/rust/psibase/src/actions.rs
+++ b/rust/psibase/src/actions.rs
@@ -2,7 +2,7 @@ use crate::services::{
     accounts, auth_delegate, auth_sig, http_server, producers, setcode, verify_sig,
 };
 use crate::{
-    account_raw, method_raw, AccountNumber, Action, AnyPublicKey, MethodNumber, PackAction,
+    account_raw, method_raw, AccountNumber, Action, AnyPublicKey, MethodNumber, ServiceWrapper,
 };
 use fracpack::Pack;
 

--- a/rust/psibase/src/auth.rs
+++ b/rust/psibase/src/auth.rs
@@ -2,7 +2,7 @@ use crate::services::{
     accounts,
     transact::{auth_interface::auth_action_structs, ServiceMethod},
 };
-use crate::{get_service, AccountNumber, Caller, MethodNumber, ServiceCaller};
+use crate::{get_service, AccountNumber, Call, Caller, MethodNumber, ServiceCaller};
 
 /// Looks up the sender's auth service and checks if it would authorize the specified
 /// action by the sender given the specified authorizers.

--- a/rust/psibase/src/auth.rs
+++ b/rust/psibase/src/auth.rs
@@ -2,7 +2,7 @@ use crate::services::{
     accounts,
     transact::{auth_interface::auth_action_structs, ServiceMethod},
 };
-use crate::{get_service, AccountNumber, Call, Caller, MethodNumber, ServiceCaller};
+use crate::{get_service, AccountNumber, Caller, MethodNumber, ServiceCaller, ServiceWrapper};
 
 /// Looks up the sender's auth service and checks if it would authorize the specified
 /// action by the sender given the specified authorizers.

--- a/rust/psibase/src/boot.rs
+++ b/rust/psibase/src/boot.rs
@@ -2,8 +2,8 @@ use crate::services::{accounts, auth_delegate, auth_sig, producers, transact};
 use crate::{
     get_schemas, method_raw, new_account_action, set_key_action, validate_dependencies,
     AccountNumber, Action, AnyPublicKey, Claim, EssentialServices, GenesisActionData, MethodNumber,
-    PackageList, PackageOrigin, PackagedService, Producer, SchemaMap, SignedTransaction, Tapos,
-    TimePointSec, Transaction, TransactionBuilder,
+    PackAction, PackageList, PackageOrigin, PackagedService, Producer, SchemaMap,
+    SignedTransaction, Tapos, TimePointSec, Transaction, TransactionBuilder,
 };
 use fracpack::Pack;
 use sha2::{Digest, Sha256};

--- a/rust/psibase/src/boot.rs
+++ b/rust/psibase/src/boot.rs
@@ -2,7 +2,7 @@ use crate::services::{accounts, auth_delegate, auth_sig, producers, transact};
 use crate::{
     get_schemas, method_raw, new_account_action, set_key_action, validate_dependencies,
     AccountNumber, Action, AnyPublicKey, Claim, EssentialServices, GenesisActionData, MethodNumber,
-    PackAction, PackageList, PackageOrigin, PackagedService, Producer, SchemaMap,
+    PackageList, PackageOrigin, PackagedService, Producer, SchemaMap, ServiceWrapper,
     SignedTransaction, Tapos, TimePointSec, Transaction, TransactionBuilder,
 };
 use fracpack::Pack;

--- a/rust/psibase/src/graph_ql.rs
+++ b/rust/psibase/src/graph_ql.rs
@@ -1,6 +1,6 @@
 use crate::{
     get_key_bytes, get_sequential_bytes, kv_get, kv_greater_equal_bytes, kv_less_than_bytes,
-    kv_max_bytes, AccountNumber, BlockNum, BlockTime, DbId, MethodNumber, RawKey, TableIndex,
+    kv_max_bytes, AccountNumber, BlockNum, BlockTime, Call, DbId, MethodNumber, RawKey, TableIndex,
     TableRecord, ToKey,
 };
 use anyhow::anyhow;

--- a/rust/psibase/src/graph_ql.rs
+++ b/rust/psibase/src/graph_ql.rs
@@ -1,7 +1,7 @@
 use crate::{
     get_key_bytes, get_sequential_bytes, kv_get, kv_greater_equal_bytes, kv_less_than_bytes,
-    kv_max_bytes, AccountNumber, BlockNum, BlockTime, Call, DbId, MethodNumber, RawKey, TableIndex,
-    TableRecord, ToKey,
+    kv_max_bytes, AccountNumber, BlockNum, BlockTime, DbId, MethodNumber, RawKey, ServiceWrapper,
+    TableIndex, TableRecord, ToKey,
 };
 use anyhow::anyhow;
 use async_graphql::connection::{query_with, Connection, Edge, EmptyFields};

--- a/rust/psibase/src/main.rs
+++ b/rust/psibase/src/main.rs
@@ -20,7 +20,7 @@ use psibase::{
     set_owner_action, sign_transaction, AccountNumber, Action, ActionFormatter, AnyPrivateKey,
     AnyPublicKey, ChainUrl, Checksum256, DirectoryRegistry, ExactAccountNumber, FileSetRegistry,
     FilteredRegistry, HTTPRegistry, HttpSchemaFetcher, JointRegistry, Meta, NullSchemaFetcher,
-    PackageDataFile, PackageInfo, PackageList, PackageOp, PackageOpFull, PackageOrigin,
+    PackAction, PackageDataFile, PackageInfo, PackageList, PackageOp, PackageOpFull, PackageOrigin,
     PackagePreference, PackageRef, PackageRegistry, PackagedService, PrettyAction, SchemaFetcher,
     SchemaMap, Seconds, ServiceInfo, SignedTransaction, StagedUpload, Tapos, TaposRefBlock,
     TimePointSec, TraceFormat, Transaction, TransactionBuilder, TransactionTrace, Version,

--- a/rust/psibase/src/main.rs
+++ b/rust/psibase/src/main.rs
@@ -20,10 +20,11 @@ use psibase::{
     set_owner_action, sign_transaction, AccountNumber, Action, ActionFormatter, AnyPrivateKey,
     AnyPublicKey, ChainUrl, Checksum256, DirectoryRegistry, ExactAccountNumber, FileSetRegistry,
     FilteredRegistry, HTTPRegistry, HttpSchemaFetcher, JointRegistry, Meta, NullSchemaFetcher,
-    PackAction, PackageDataFile, PackageInfo, PackageList, PackageOp, PackageOpFull, PackageOrigin,
+    PackageDataFile, PackageInfo, PackageList, PackageOp, PackageOpFull, PackageOrigin,
     PackagePreference, PackageRef, PackageRegistry, PackagedService, PrettyAction, SchemaFetcher,
-    SchemaMap, Seconds, ServiceInfo, SignedTransaction, StagedUpload, Tapos, TaposRefBlock,
-    TimePointSec, TraceFormat, Transaction, TransactionBuilder, TransactionTrace, Version,
+    SchemaMap, Seconds, ServiceInfo, ServiceWrapper, SignedTransaction, StagedUpload, Tapos,
+    TaposRefBlock, TimePointSec, TraceFormat, Transaction, TransactionBuilder, TransactionTrace,
+    Version,
 };
 use regex::Regex;
 use reqwest::Url;

--- a/rust/psibase/src/package.rs
+++ b/rust/psibase/src/package.rs
@@ -7,8 +7,8 @@ use crate::services::{
 use crate::{
     new_account_owned_action, preapprove_action, reg_server, schema_types, set_code_action,
     solve_dependencies, version_match, AccountNumber, Action, Checksum256, CodeRow, GenesisService,
-    Hex, MethodNumber, MethodString, Pack, PackageDisposition, PackageOp, PackagePreference,
-    Schema, ToSchema, Unpack, Version,
+    Hex, MethodNumber, MethodString, Pack, PackAction, PackageDisposition, PackageOp,
+    PackagePreference, Schema, ToSchema, Unpack, Version,
 };
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;

--- a/rust/psibase/src/package.rs
+++ b/rust/psibase/src/package.rs
@@ -7,8 +7,8 @@ use crate::services::{
 use crate::{
     new_account_owned_action, preapprove_action, reg_server, schema_types, set_code_action,
     solve_dependencies, version_match, AccountNumber, Action, Checksum256, CodeRow, GenesisService,
-    Hex, MethodNumber, MethodString, Pack, PackAction, PackageDisposition, PackageOp,
-    PackagePreference, Schema, ToSchema, Unpack, Version,
+    Hex, MethodNumber, MethodString, Pack, PackageDisposition, PackageOp, PackagePreference,
+    Schema, ServiceWrapper, ToSchema, Unpack, Version,
 };
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;

--- a/rust/psibase/src/service.rs
+++ b/rust/psibase/src/service.rs
@@ -309,7 +309,7 @@ pub trait Call: ServiceWrapper {
         Self::with_caller(ServiceCaller {
             sender: get_service(),
             service: Self::SERVICE,
-            flags: 0,
+            flags: 1,
         })
     }
 }

--- a/rust/psibase/src/service.rs
+++ b/rust/psibase/src/service.rs
@@ -315,3 +315,57 @@ pub trait Call: ServiceWrapper {
 }
 
 impl<T: ServiceWrapper> Call for T {}
+
+pub trait PackAction: ServiceWrapper {
+    /// Pack actions into [psibase::Action](psibase::Action).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which pack the action's arguments using [fracpack] and
+    /// return a [psibase::Action](psibase::Action). The `pack_*` series of
+    /// functions is mainly useful to applications which push transactions
+    /// to blockchains.
+    ///
+    /// This method defaults both `sender` and `service` to `Self::SERVICE`.
+    fn pack() -> Self::Actions<ActionPacker> {
+        Self::pack_from_to(Self::SERVICE, Self::SERVICE)
+    }
+
+    /// Pack actions into [psibase::Action](psibase::Action).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which pack the action's arguments using [fracpack] and
+    /// return a [psibase::Action](psibase::Action). The `pack_*` series of
+    /// functions is mainly useful to applications which push transactions
+    /// to blockchains.
+    ///
+    /// This method defaults `sender` to `Self::SERVICE`.
+    fn pack_to(service: AccountNumber) -> Self::Actions<ActionPacker> {
+        Self::pack_from_to(Self::SERVICE, service)
+    }
+
+    /// Pack actions into [psibase::Action](psibase::Action).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which pack the action's arguments using [fracpack] and
+    /// return a [psibase::Action](psibase::Action). The `pack_*` series of
+    /// functions is mainly useful to applications which push transactions
+    /// to blockchains.
+    ///
+    /// This method defaults `service` to `Self::SERVICE`.
+    fn pack_from(sender: AccountNumber) -> Self::Actions<ActionPacker> {
+        Self::pack_from_to(sender, Self::SERVICE)
+    }
+
+    /// Pack actions into [psibase::Action](psibase::Action).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which pack the action's arguments using [fracpack] and
+    /// return a [psibase::Action](psibase::Action). The `pack_*` series of
+    /// functions is mainly useful to applications which push transactions
+    /// to blockchains.
+    fn pack_from_to(sender: AccountNumber, service: AccountNumber) -> Self::Actions<ActionPacker> {
+        Self::with_caller(ActionPacker { sender, service })
+    }
+}
+
+impl<T: ServiceWrapper> PackAction for T {}

--- a/rust/psibase/src/service.rs
+++ b/rust/psibase/src/service.rs
@@ -179,6 +179,7 @@ impl Caller for ActionPacker {
 }
 
 pub trait ServiceWrapper {
+    const SERVICE: AccountNumber;
     type Actions<T: Caller>;
     fn with_caller<T: Caller>(caller: T) -> Self::Actions<T>;
 }
@@ -216,3 +217,101 @@ impl Caller for RunAsCaller {
         Ret::unpacked(&ret.0).unwrap()
     }
 }
+
+pub trait Call: ServiceWrapper {
+    /// Call another service.
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which call another service and return the result from the call.
+    /// This method is only usable by services.
+    ///
+    /// This method defaults `sender` to [`psibase::get_sender`] and `service` to `Self::SERVICE`.
+    fn call() -> Self::Actions<ServiceCaller> {
+        Self::call_from_to(get_service(), Self::SERVICE)
+    }
+
+    /// Call another service.
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which call another service and return the result from the call.
+    /// This method is only usable by services.
+    ///
+    /// This method defaults `sender` to [`psibase::get_sender`].
+    fn call_to(service: AccountNumber) -> Self::Actions<ServiceCaller> {
+        Self::call_from_to(get_service(), service)
+    }
+
+    /// Call another service.
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which call another service and return the result from the call.
+    /// This method is only usable by services.
+    ///
+    /// This method defaults `service` to `Self::SERVICE`.
+    fn call_from(sender: AccountNumber) -> Self::Actions<ServiceCaller> {
+        Self::call_from_to(sender, Self::SERVICE)
+    }
+
+    /// Call another service.
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which call another service and return the result from the call.
+    /// This method is only usable by services.
+    fn call_from_to(sender: AccountNumber, service: AccountNumber) -> Self::Actions<ServiceCaller> {
+        Self::with_caller(ServiceCaller {
+            sender,
+            service,
+            flags: 0,
+        })
+    }
+
+    /// Call another service using [runAs](psibase::services::transact::Actions::runAs).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which call another service via `runAs` and return the result from the call.
+    /// The action will run with `sender` set to the provided account and `service` to `Self::SERVICE`.
+    ///
+    /// This will fail unless certain conditions are met. See [runAs](psibase::services::transact::Actions::runAs)
+    /// documentation for more details.
+    fn call_as(sender: AccountNumber) -> Self::Actions<RunAsCaller> {
+        Self::call_as_extend(sender, Vec::new())
+    }
+
+    /// Call another service using [runAs](psibase::services::transact::Actions::runAs).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which call another service via `runAs` and return the result from the call.
+    /// The action will run with `sender` set to the provided account and `service` to `Self::SERVICE`.
+    ///
+    /// This will fail unless certain conditions are met. See [runAs](psibase::services::transact::Actions::runAs)
+    /// documentation for more details.
+    ///
+    /// This method also accepts `allowedActions` for nested `runAs` calls.
+    fn call_as_extend(
+        sender: AccountNumber,
+        allowed_actions: Vec<ServiceMethod>,
+    ) -> Self::Actions<RunAsCaller> {
+        Self::with_caller(RunAsCaller {
+            sender,
+            service: Self::SERVICE,
+            allowed_actions,
+        })
+    }
+
+    /// Call another service in RPC mode.
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which call another service and return the result from the call.
+    /// This method is only usable by services.
+    ///
+    /// This method defaults `sender` to [`psibase::get_sender`] and `service` to `Self::SERVICE`.
+    fn rpc() -> Self::Actions<ServiceCaller> {
+        Self::with_caller(ServiceCaller {
+            sender: get_service(),
+            service: Self::SERVICE,
+            flags: 0,
+        })
+    }
+}
+
+impl<T: ServiceWrapper> Call for T {}

--- a/rust/psibase/src/service.rs
+++ b/rust/psibase/src/service.rs
@@ -182,43 +182,7 @@ pub trait ServiceWrapper {
     const SERVICE: AccountNumber;
     type Actions<T: Caller>;
     fn with_caller<T: Caller>(caller: T) -> Self::Actions<T>;
-}
 
-#[derive(Clone, Default)]
-pub struct RunAsCaller {
-    pub sender: AccountNumber,
-    pub service: AccountNumber,
-    pub allowed_actions: Vec<ServiceMethod>,
-}
-
-impl Caller for RunAsCaller {
-    type ReturnsNothing = ();
-    type ReturnType<T: UnpackOwned> = T;
-
-    fn call_returns_nothing<Args: Pack>(&self, method: MethodNumber, args: Args) {
-        let action = Action {
-            sender: self.sender,
-            service: self.service,
-            method,
-            rawData: args.packed().into(),
-        };
-        crate::services::transact::Wrapper::call().runAs(action, self.allowed_actions.clone());
-    }
-
-    fn call<Ret: UnpackOwned, Args: Pack>(&self, method: MethodNumber, args: Args) -> Ret {
-        let action = Action {
-            sender: self.sender,
-            service: self.service,
-            method,
-            rawData: args.packed().into(),
-        };
-        let ret =
-            crate::services::transact::Wrapper::call().runAs(action, self.allowed_actions.clone());
-        Ret::unpacked(&ret.0).unwrap()
-    }
-}
-
-pub trait Call: ServiceWrapper {
     /// Call another service.
     ///
     /// This method returns an object which has methods
@@ -312,11 +276,7 @@ pub trait Call: ServiceWrapper {
             flags: 1,
         })
     }
-}
 
-impl<T: ServiceWrapper> Call for T {}
-
-pub trait PackAction: ServiceWrapper {
     /// Pack actions into [psibase::Action](psibase::Action).
     ///
     /// This method returns an object which has methods
@@ -368,4 +328,36 @@ pub trait PackAction: ServiceWrapper {
     }
 }
 
-impl<T: ServiceWrapper> PackAction for T {}
+#[derive(Clone, Default)]
+pub struct RunAsCaller {
+    pub sender: AccountNumber,
+    pub service: AccountNumber,
+    pub allowed_actions: Vec<ServiceMethod>,
+}
+
+impl Caller for RunAsCaller {
+    type ReturnsNothing = ();
+    type ReturnType<T: UnpackOwned> = T;
+
+    fn call_returns_nothing<Args: Pack>(&self, method: MethodNumber, args: Args) {
+        let action = Action {
+            sender: self.sender,
+            service: self.service,
+            method,
+            rawData: args.packed().into(),
+        };
+        crate::services::transact::Wrapper::call().runAs(action, self.allowed_actions.clone());
+    }
+
+    fn call<Ret: UnpackOwned, Args: Pack>(&self, method: MethodNumber, args: Args) -> Ret {
+        let action = Action {
+            sender: self.sender,
+            service: self.service,
+            method,
+            rawData: args.packed().into(),
+        };
+        let ret =
+            crate::services::transact::Wrapper::call().runAs(action, self.allowed_actions.clone());
+        Ret::unpacked(&ret.0).unwrap()
+    }
+}

--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -13,7 +13,7 @@ use crate::{
     fetch_packages, get_optional_result_bytes, get_result_bytes, services, status_key, tester_raw,
     AccountNumber, Action, ActionFormatter, BlockTime, Caller, Checksum256, CodeByHashRow, CodeRow,
     DbId, DirectoryRegistry, Error, HostConfigRow, HttpBody, HttpHeader, HttpReply, HttpRequest,
-    InnerTraceEnum, JointRegistry, KvHandle, KvMode, PackageOpFull, PackageRegistry,
+    InnerTraceEnum, JointRegistry, KvHandle, KvMode, PackAction, PackageOpFull, PackageRegistry,
     PackagedService, RunMode, Schema, SchemaFetcher, SchemaMap, Seconds, ServiceWrapper,
     SignedTransaction, StatusRow, Table, TableRecord, Tapos, TimePointSec, TimePointUSec, ToKey,
     Transaction, TransactionBuilder, TransactionTrace,

--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -14,9 +14,9 @@ use crate::{
     AccountNumber, Action, ActionFormatter, BlockTime, Caller, Checksum256, CodeByHashRow, CodeRow,
     DbId, DirectoryRegistry, Error, HostConfigRow, HttpBody, HttpHeader, HttpReply, HttpRequest,
     InnerTraceEnum, JointRegistry, KvHandle, KvMode, PackageOpFull, PackageRegistry,
-    PackagedService, RunMode, Schema, SchemaFetcher, SchemaMap, Seconds, SignedTransaction,
-    StatusRow, Table, TableRecord, Tapos, TimePointSec, TimePointUSec, ToKey, Transaction,
-    TransactionBuilder, TransactionTrace,
+    PackagedService, RunMode, Schema, SchemaFetcher, SchemaMap, Seconds, ServiceWrapper,
+    SignedTransaction, StatusRow, Table, TableRecord, Tapos, TimePointSec, TimePointUSec, ToKey,
+    Transaction, TransactionBuilder, TransactionTrace,
 };
 #[cfg(target_family = "wasm")]
 use crate::{MicroSeconds, PackageList};
@@ -1112,6 +1112,68 @@ impl<'a> Caller for ChainPusher<'a> {
         ret
     }
 }
+
+pub trait Push: ServiceWrapper {
+    /// push transactions to [psibase::Chain](psibase::Chain).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which push transactions to a test chain and return a
+    /// [psibase::ChainResult](psibase::ChainResult) or
+    /// [psibase::ChainEmptyResult](psibase::ChainEmptyResult). This final object
+    /// can verify success or failure and can retrieve the return value, if any.
+    ///
+    /// This method defaults both `sender` and `service` to Self::SERVICE
+    fn push<'a>(chain: &'a Chain) -> Self::Actions<ChainPusher<'a>> {
+        Self::push_from_to(chain, Self::SERVICE, Self::SERVICE)
+    }
+
+    /// push transactions to [psibase::Chain](psibase::Chain).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which push transactions to a test chain and return a
+    /// [psibase::ChainResult](psibase::ChainResult) or
+    /// [psibase::ChainEmptyResult](psibase::ChainEmptyResult). This final object
+    /// can verify success or failure and can retrieve the return value, if any.
+    ///
+    /// This method defaults `sender` to Self::SERVICE
+    fn push_to<'a>(chain: &'a Chain, service: AccountNumber) -> Self::Actions<ChainPusher<'a>> {
+        Self::push_from_to(chain, Self::SERVICE, service)
+    }
+
+    /// push transactions to [psibase::Chain](psibase::Chain).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which push transactions to a test chain and return a
+    /// [psibase::ChainResult](psibase::ChainResult) or
+    /// [psibase::ChainEmptyResult](psibase::ChainEmptyResult). This final object
+    /// can verify success or failure and can retrieve the return value, if any.
+    ///
+    /// This method defaults `service` to Self::SERVICE
+    fn push_from<'a>(chain: &'a Chain, sender: AccountNumber) -> Self::Actions<ChainPusher<'a>> {
+        Self::push_from_to(chain, sender, Self::SERVICE)
+    }
+
+    /// push transactions to [psibase::Chain](psibase::Chain).
+    ///
+    /// This method returns an object which has methods
+    /// (one per action) which push transactions to a test chain and return a
+    /// [psibase::ChainResult](psibase::ChainResult) or
+    /// [psibase::ChainEmptyResult](psibase::ChainEmptyResult). This final object
+    /// can verify success or failure and can retrieve the return value, if any.
+    fn push_from_to<'a>(
+        chain: &'a Chain,
+        sender: AccountNumber,
+        service: AccountNumber,
+    ) -> Self::Actions<ChainPusher<'a>> {
+        Self::with_caller(ChainPusher {
+            chain,
+            sender,
+            service,
+        })
+    }
+}
+
+impl<T: ServiceWrapper> Push for T {}
 
 #[cfg(target_family = "wasm")]
 #[allow(non_snake_case)]

--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -13,7 +13,7 @@ use crate::{
     fetch_packages, get_optional_result_bytes, get_result_bytes, services, status_key, tester_raw,
     AccountNumber, Action, ActionFormatter, BlockTime, Caller, Checksum256, CodeByHashRow, CodeRow,
     DbId, DirectoryRegistry, Error, HostConfigRow, HttpBody, HttpHeader, HttpReply, HttpRequest,
-    InnerTraceEnum, JointRegistry, KvHandle, KvMode, PackAction, PackageOpFull, PackageRegistry,
+    InnerTraceEnum, JointRegistry, KvHandle, KvMode, PackageOpFull, PackageRegistry,
     PackagedService, RunMode, Schema, SchemaFetcher, SchemaMap, Seconds, ServiceWrapper,
     SignedTransaction, StatusRow, Table, TableRecord, Tapos, TimePointSec, TimePointUSec, ToKey,
     Transaction, TransactionBuilder, TransactionTrace,

--- a/rust/psibase_macros/psibase-macros-lib/src/service_macro/mod.rs
+++ b/rust/psibase_macros/psibase-macros-lib/src/service_macro/mod.rs
@@ -236,32 +236,6 @@ fn process_mod(
             pub struct #wrapper;
         });
 
-        let pack_from_to_doc = format!(
-            "
-            Pack actions into [psibase::Action]({psibase}::Action).
-
-            This method returns an object which has [methods]({actions}#implementations)
-            (one per action) which pack the action's arguments using [fracpack] and
-            return a [psibase::Action]({psibase}::Action). The `pack_*` series of
-            functions is mainly useful to applications which push transactions
-            to blockchains.
-
-            ",
-            psibase = options.psibase_mod,
-            actions = options.actions
-        );
-        let pack_doc = format!(
-            "{} This method defaults both `sender` and `service` to \"{}\".",
-            pack_from_to_doc, options.name
-        );
-        let pack_to_doc = format!(
-            "{} This method defaults `sender` to \"{}\".",
-            pack_from_to_doc, options.name
-        );
-        let pack_from_doc = format!(
-            "{} This method defaults `service` to \"{}\".",
-            pack_from_to_doc, options.name
-        );
         let emit_from_doc = format!(
             "
             Emit events from a service.
@@ -279,44 +253,6 @@ fn process_mod(
                 #[doc = #constant_doc]
                 pub const SERVICE: #psibase_mod::AccountNumber =
                     #psibase_mod::AccountNumber::new(#psibase_mod::account_raw!(#service_account));
-
-                #[doc = #pack_doc]
-                pub fn pack() -> #actions<#psibase_mod::ActionPacker> {
-                    #psibase_mod::ActionPacker {
-                        sender: Self::#constant,
-                        service: Self::#constant,
-                    }
-                    .into()
-                }
-
-                #[doc = #pack_to_doc]
-                pub fn pack_to(service: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ActionPacker>
-                {
-                    #psibase_mod::ActionPacker {
-                        sender: Self::#constant,
-                        service,
-                    }
-                    .into()
-                }
-
-                #[doc = #pack_from_doc]
-                pub fn pack_from(sender: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ActionPacker>
-                {
-                    #psibase_mod::ActionPacker {
-                        sender,
-                        service: Self::#constant,
-                    }
-                    .into()
-                }
-
-                #[doc = #pack_from_to_doc]
-                pub fn pack_from_to(sender: #psibase_mod::AccountNumber, service: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ActionPacker>
-                {
-                    #psibase_mod::ActionPacker { sender, service }.into()
-                }
 
                 #[doc = #emit_doc]
                 pub fn emit() -> EmitEvent {

--- a/rust/psibase_macros/psibase-macros-lib/src/service_macro/mod.rs
+++ b/rust/psibase_macros/psibase-macros-lib/src/service_macro/mod.rs
@@ -236,51 +236,6 @@ fn process_mod(
             pub struct #wrapper;
         });
 
-        let call_from_to_doc = format!(
-            "
-            Call another service.
-
-            This method returns an object which has [methods]({actions}#implementations)
-            (one per action) which call another service and return the result from the call.
-            This method is only usable by services.
-
-            ",
-            actions = options.actions
-        );
-        let call_doc = format!(
-            "{} This method defaults `sender` to [`{psibase}::get_sender`] and `service` to \"{}\".",
-            call_from_to_doc, options.name,            psibase = options.psibase_mod,
-        );
-        let call_to_doc = format!(
-            "{} This method defaults `sender` to [`{psibase}::get_sender`].",
-            call_from_to_doc,
-            psibase = options.psibase_mod,
-        );
-        let call_from_doc = format!(
-            "{} This method defaults `service` to \"{}\".",
-            call_from_to_doc, options.name
-        );
-        let call_as_doc = format!(
-            "
-            Call another service using [runAs]({psibase}::services::transact::Actions::runAs).
-
-            This method returns an object which has [methods]({actions}#implementations)
-            (one per action) which call another service via `runAs` and return the result from the call.
-            The action will run with `sender` set to the provided account. This method defaults `service` to \"{name}\".
-
-            This will fail unless certain conditions are met. See [runAs]({psibase}::services::transact::Actions::runAs) 
-            documentation for more details.
-
-            ",
-            psibase = options.psibase_mod,
-            actions = options.actions,
-            name = options.name
-        );
-        let call_as_extend_doc = format!(
-            "{} This method also accepts `allowedActions` for nested `runAs` calls.",
-            call_as_doc
-        );
-
         let push_from_to_doc = format!(
             "
             push transactions to [psibase::Chain]({psibase}::Chain).
@@ -351,86 +306,6 @@ fn process_mod(
                 #[doc = #constant_doc]
                 pub const SERVICE: #psibase_mod::AccountNumber =
                     #psibase_mod::AccountNumber::new(#psibase_mod::account_raw!(#service_account));
-
-                #[doc = #call_doc]
-                pub fn call() -> #actions<#psibase_mod::ServiceCaller> {
-                    #psibase_mod::ServiceCaller {
-                        sender: #psibase_mod::get_service(),
-                        service: Self::#constant,
-                        flags: 0,
-                    }
-                    .into()
-                }
-
-                #[doc = #call_to_doc]
-                pub fn call_to(service: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ServiceCaller>
-                {
-                    #psibase_mod::ServiceCaller {
-                        sender: #psibase_mod::get_service(),
-                        service,
-                        flags: 0,
-                    }
-                    .into()
-                }
-
-                #[doc = #call_from_doc]
-                pub fn call_from(sender: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ServiceCaller>
-                {
-                    #psibase_mod::ServiceCaller {
-                        sender,
-                        service: Self::#constant,
-                        flags: 0,
-                    }
-                    .into()
-                }
-
-                #[doc = #call_from_to_doc]
-                pub fn call_from_to(
-                    sender: #psibase_mod::AccountNumber,
-                    service: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ServiceCaller>
-                {
-                    #psibase_mod::ServiceCaller { sender, service,
-                        flags: 0, }.into()
-                }
-
-                #[doc = #call_as_doc]
-                pub fn call_as(sender: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::RunAsCaller>
-                {
-                    #psibase_mod::RunAsCaller {
-                        sender,
-                        service: Self::#constant,
-                        allowed_actions: vec![],
-                    }
-                    .into()
-                }
-
-                #[doc = #call_as_extend_doc]
-                pub fn call_as_extend(
-                    sender: #psibase_mod::AccountNumber,
-                    allowed_actions: Vec<#psibase_mod::services::transact::ServiceMethod>)
-                -> #actions<#psibase_mod::RunAsCaller>
-                {
-                    #psibase_mod::RunAsCaller {
-                        sender,
-                        service: Self::#constant,
-                        allowed_actions,
-                    }
-                    .into()
-                }
-
-                #[doc = #call_doc]
-                pub fn rpc() -> #actions<#psibase_mod::ServiceCaller> {
-                    #psibase_mod::ServiceCaller {
-                        sender: #psibase_mod::get_service(),
-                        service: Self::#constant,
-                        flags: 1,
-                    }
-                    .into()
-                }
 
                 #[doc = #push_doc]
                 pub fn push(chain: &#psibase_mod::Chain) -> #actions<#psibase_mod::ChainPusher> {
@@ -545,6 +420,7 @@ fn process_mod(
         items.push(parse_quote! {
             #[automatically_derived]
             impl #psibase_mod::ServiceWrapper for #wrapper {
+                const SERVICE: #psibase_mod::AccountNumber = Self::SERVICE;
                 type Actions<T: #psibase_mod::Caller> = #actions<T>;
                 fn with_caller<T: #psibase_mod::Caller>(caller: T) -> #actions<T> {
                     caller.into()

--- a/rust/psibase_macros/psibase-macros-lib/src/service_macro/mod.rs
+++ b/rust/psibase_macros/psibase-macros-lib/src/service_macro/mod.rs
@@ -236,33 +236,6 @@ fn process_mod(
             pub struct #wrapper;
         });
 
-        let push_from_to_doc = format!(
-            "
-            push transactions to [psibase::Chain]({psibase}::Chain).
-
-            This method returns an object which has [methods]({actions}#implementations)
-            (one per action) which push transactions to a test chain and return a
-            [psibase::ChainResult]({psibase}::ChainResult) or
-            [psibase::ChainEmptyResult]({psibase}::ChainEmptyResult). This final object
-            can verify success or failure and can retrieve the return value, if any.
-
-            ",
-            psibase = options.psibase_mod,
-            actions = options.actions
-        );
-        let push_doc = format!(
-            "{} This method defaults both `sender` and `service` to \"{}\".",
-            push_from_to_doc, options.name
-        );
-        let push_to_doc = format!(
-            "{} This method defaults `sender` to \"{}\".",
-            push_from_to_doc, options.name
-        );
-        let push_from_doc = format!(
-            "{} This method defaults `service` to \"{}\".",
-            push_from_to_doc, options.name
-        );
-
         let pack_from_to_doc = format!(
             "
             Pack actions into [psibase::Action]({psibase}::Action).
@@ -306,50 +279,6 @@ fn process_mod(
                 #[doc = #constant_doc]
                 pub const SERVICE: #psibase_mod::AccountNumber =
                     #psibase_mod::AccountNumber::new(#psibase_mod::account_raw!(#service_account));
-
-                #[doc = #push_doc]
-                pub fn push(chain: &#psibase_mod::Chain) -> #actions<#psibase_mod::ChainPusher> {
-                    #psibase_mod::ChainPusher {
-                        chain,
-                        sender: Self::#constant,
-                        service: Self::#constant,
-                    }
-                    .into()
-                }
-
-                #[doc = #push_to_doc]
-                pub fn push_to(chain: &#psibase_mod::Chain, service: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ChainPusher>
-                {
-                    #psibase_mod::ChainPusher {
-                        chain,
-                        sender: Self::#constant,
-                        service,
-                    }
-                    .into()
-                }
-
-                #[doc = #push_from_doc]
-                pub fn push_from(chain: &#psibase_mod::Chain, sender: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ChainPusher>
-                {
-                    #psibase_mod::ChainPusher {
-                        chain,
-                        sender,
-                        service: Self::#constant,
-                    }
-                    .into()
-                }
-
-                #[doc = #push_from_to_doc]
-                pub fn push_from_to(
-                    chain: &#psibase_mod::Chain,
-                    sender: #psibase_mod::AccountNumber,
-                    service: #psibase_mod::AccountNumber)
-                -> #actions<#psibase_mod::ChainPusher>
-                {
-                    #psibase_mod::ChainPusher { chain, sender, service }.into()
-                }
 
                 #[doc = #pack_doc]
                 pub fn pack() -> #actions<#psibase_mod::ActionPacker> {

--- a/rust/psibase_service/src/lib.rs
+++ b/rust/psibase_service/src/lib.rs
@@ -1,4 +1,4 @@
-use psibase::{native_raw, services, DbId, KvHandle, KvMode};
+use psibase::{native_raw, services, Call, DbId, KvHandle, KvMode};
 
 pub unsafe fn psibase_proxy_kv_open_impl(
     db: u32,

--- a/rust/psibase_service/src/lib.rs
+++ b/rust/psibase_service/src/lib.rs
@@ -1,4 +1,4 @@
-use psibase::{native_raw, services, Call, DbId, KvHandle, KvMode};
+use psibase::{native_raw, services, DbId, KvHandle, KvMode, ServiceWrapper};
 
 pub unsafe fn psibase_proxy_kv_open_impl(
     db: u32,

--- a/rust/test_contract/src/lib.rs
+++ b/rust/test_contract/src/lib.rs
@@ -34,6 +34,7 @@ mod service {
 
 #[psibase::test_case(packages("test_contract"))]
 fn test1(chain: psibase::Chain) -> Result<(), psibase::Error> {
+    use psibase::*;
     assert_eq!(Wrapper::push(&chain).add(3, 4).get()?, 7);
     assert_eq!(Wrapper::push(&chain).multiply(3, 4).get()?, 12);
 

--- a/rust/test_contract_2/src/lib.rs
+++ b/rust/test_contract_2/src/lib.rs
@@ -175,7 +175,7 @@ mod service {
 #[psibase::test_case(packages("TestContract2"))]
 fn test_arith(chain: psibase::Chain) -> Result<(), psibase::Error> {
     use psibase::services::http_server;
-    use psibase::{HttpBody, Table};
+    use psibase::{HttpBody, Push, Table};
     use serde_json::{json, Value};
     http_server::Wrapper::push_from(&chain, SERVICE).registerServer(SERVICE);
     let result = Wrapper::push(&chain).add(3, 4);
@@ -234,6 +234,7 @@ fn test_arith(chain: psibase::Chain) -> Result<(), psibase::Error> {
 #[psibase::test_case(packages("TestContract2"))]
 fn test_add_events(chain: psibase::Chain) -> Result<(), psibase::Error> {
     use psibase::services::http_server;
+    use psibase::Push;
     use serde_json::{json, Value};
 
     http_server::Wrapper::push_from(&chain, SERVICE).registerServer(SERVICE);
@@ -449,6 +450,7 @@ fn test_add_events(chain: psibase::Chain) -> Result<(), psibase::Error> {
 #[psibase::test_case(packages("TestContract2"))]
 fn test_example_records(chain: psibase::Chain) -> Result<(), psibase::Error> {
     use psibase::services::http_server;
+    use psibase::Push;
     use serde_json::{json, Value};
 
     http_server::Wrapper::push_from(&chain, SERVICE).registerServer(SERVICE);

--- a/rust/test_package/service/src/lib.rs
+++ b/rust/test_package/service/src/lib.rs
@@ -11,6 +11,7 @@ mod service {
 
 #[psibase::test_case(packages("TestPackage"))]
 fn test_foo(chain: psibase::Chain) -> Result<(), psibase::Error> {
+    use psibase::Push;
     assert_eq!(Wrapper::push(&chain).foo(42).get()?, 42);
     Ok(())
 }

--- a/rust/test_psibase_macros/services/basic-w-query/src/lib.rs
+++ b/rust/test_psibase_macros/services/basic-w-query/src/lib.rs
@@ -1,7 +1,7 @@
 #[psibase::service(name = "basicquery")]
 #[allow(non_snake_case)]
 mod service {
-    use psibase::{serve_graphql, serve_simple_ui, HttpReply, HttpRequest};
+    use psibase::{serve_graphql, serve_simple_ui, Call, HttpReply, HttpRequest};
 
     #[action]
     fn add(a: i32, b: i32) -> i32 {

--- a/rust/test_psibase_macros/services/basic-w-query/src/lib.rs
+++ b/rust/test_psibase_macros/services/basic-w-query/src/lib.rs
@@ -1,7 +1,7 @@
 #[psibase::service(name = "basicquery")]
 #[allow(non_snake_case)]
 mod service {
-    use psibase::{serve_graphql, serve_simple_ui, Call, HttpReply, HttpRequest};
+    use psibase::{serve_graphql, serve_simple_ui, HttpReply, HttpRequest, ServiceWrapper};
 
     #[action]
     fn add(a: i32, b: i32) -> i32 {

--- a/rust/test_psibase_macros/src/lib.rs
+++ b/rust/test_psibase_macros/src/lib.rs
@@ -4,8 +4,8 @@ mod service {}
 
 #[cfg(test)]
 mod tests {
-    use psibase::account;
     use psibase::services::http_server;
+    use psibase::{account, Push};
     use serde_json::{json, Value};
 
     #[psibase::test_case(packages("PsiMacroTest"))]

--- a/rust/test_subjective/src/lib.rs
+++ b/rust/test_subjective/src/lib.rs
@@ -49,6 +49,7 @@ mod service {
 
 #[psibase::test_case(packages("TestSubjective"))]
 fn test1(chain: psibase::Chain) -> Result<(), psibase::Error> {
+    use psibase::*;
     psibase::services::setcode::Wrapper::push(&chain)
         .setFlags(SERVICE, psibase::CodeRow::IS_PRIVILEGED)
         .get()?;


### PR DESCRIPTION
This makes them easier to use in a generic context and also easier to extend.