### PR TITLE
proposed restructuring supervisor message queuing 

### DIFF
--- a/packages/user/CommonApi/common/packages/common-lib/src/messaging/errors.ts
+++ b/packages/user/CommonApi/common/packages/common-lib/src/messaging/errors.ts
@@ -55,6 +55,7 @@ export class GenericErrorObject {
 export const isGenericError = (error: any): error is Error => {
     return (
         typeof error === "object" &&
+        error !== null &&
         "message" in error &&
         typeof error.message === "string" &&
         "name" in error &&
@@ -71,6 +72,7 @@ export const isGenericErrorObject = (
 ): error is GenericErrorObject => {
     return (
         typeof error === "object" &&
+        error !== null &&
         "message" in error &&
         typeof error.message === "string" &&
         "name" in error &&

--- a/packages/user/Supervisor/ui/src/serialize.ts
+++ b/packages/user/Supervisor/ui/src/serialize.ts
@@ -3,7 +3,7 @@
 let queue: Promise<unknown> = Promise.resolve();
 
 export function serialize<T>(fn: () => Promise<T>): Promise<T> {
-    const res = queue.then(() => fn());
+    const res = queue.catch(() => {}).then(() => fn());
     queue = res.catch(() => {});
     return res;
 }

--- a/packages/user/Supervisor/ui/src/serialize.ts
+++ b/packages/user/Supervisor/ui/src/serialize.ts
@@ -1,0 +1,9 @@
+// Async serializer pattern:
+// https://advancedweb.hu/how-to-serialize-calls-to-an-async-function/
+let queue: Promise<unknown> = Promise.resolve();
+
+export function serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const res = queue.then(() => fn());
+    queue = res.catch(() => {});
+    return res;
+}

--- a/packages/user/Supervisor/ui/src/serialize.ts
+++ b/packages/user/Supervisor/ui/src/serialize.ts
@@ -1,9 +1,12 @@
 // Async serializer pattern:
 // https://advancedweb.hu/how-to-serialize-calls-to-an-async-function/
-let queue: Promise<unknown> = Promise.resolve();
+let queue: Promise<void> = Promise.resolve();
 
 export function serialize<T>(fn: () => Promise<T>): Promise<T> {
     const res = queue.catch(() => {}).then(() => fn());
-    queue = res.catch(() => {});
+    queue = res.then(
+        () => {},
+        () => {},
+    );
     return res;
 }

--- a/packages/user/Supervisor/ui/src/supervisor-concurrent-entry.test.ts
+++ b/packages/user/Supervisor/ui/src/supervisor-concurrent-entry.test.ts
@@ -1,14 +1,15 @@
-import { isPluginErrorObject } from "@psibase/common-lib/messaging";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import { CALL_SENTINEL } from "@/test/test-plugin";
+import { serialize } from "@/serialize";
 import {
+    TEST_ORIGIN,
     createTestSupervisor,
     mockAppCallArgs,
     mockAppPluginId,
     mockParentReplies,
-    TEST_ORIGIN,
 } from "@/test/supervisor-test-harness";
+import { CALL_SENTINEL } from "@/test/test-plugin";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isPluginErrorObject } from "@psibase/common-lib/messaging";
 
 vi.mock("./plugin/plugin-loader", () => ({
     PluginLoader: class {
@@ -50,8 +51,8 @@ describe("Supervisor concurrent entry", () => {
         const supervisor = createTestSupervisor();
         const args = mockAppCallArgs();
 
-        await supervisor.entry(TEST_ORIGIN, "id-1", args);
-        await supervisor.entry(TEST_ORIGIN, "id-2", args);
+        await serialize(() => supervisor.entry(TEST_ORIGIN, "id-1", args));
+        await serialize(() => supervisor.entry(TEST_ORIGIN, "id-2", args));
 
         expect(replies.get("id-1")).toBe(CALL_SENTINEL);
         expect(replies.get("id-2")).toBe(CALL_SENTINEL);
@@ -63,8 +64,8 @@ describe("Supervisor concurrent entry", () => {
         const args = mockAppCallArgs();
 
         await Promise.all([
-            supervisor.entry(TEST_ORIGIN, "id-a", args),
-            supervisor.entry(TEST_ORIGIN, "id-b", args),
+            serialize(() => supervisor.entry(TEST_ORIGIN, "id-a", args)),
+            serialize(() => supervisor.entry(TEST_ORIGIN, "id-b", args)),
         ]);
 
         expect(replies.get("id-a")).toBe(CALL_SENTINEL);
@@ -79,8 +80,10 @@ describe("Supervisor concurrent entry", () => {
         const args = mockAppCallArgs();
 
         await Promise.all([
-            supervisor.preloadPlugins(TEST_ORIGIN, [mockAppPluginId()]),
-            supervisor.entry(TEST_ORIGIN, "id-entry", args),
+            serialize(() =>
+                supervisor.preloadPlugins(TEST_ORIGIN, [mockAppPluginId()]),
+            ),
+            serialize(() => supervisor.entry(TEST_ORIGIN, "id-entry", args)),
         ]);
 
         expect(replies.get("id-entry")).toBe(CALL_SENTINEL);

--- a/packages/user/Supervisor/ui/src/supervisor.ts
+++ b/packages/user/Supervisor/ui/src/supervisor.ts
@@ -98,19 +98,6 @@ export class Supervisor implements AppInterface {
         }
     }
 
-    private sessionLock: Promise<void> = Promise.resolve();
-
-    private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
-        const session = this.sessionLock
-            .catch(() => {})
-            .then(() => fn());
-        this.sessionLock = session.then(
-            () => {},
-            () => {},
-        );
-        return session;
-    }
-
     // This step loads the full plugin tree (downloading + parsing + JCO transpiling)
     //
     // This does not instantiate wasms, with the exception of core system plugin wasms,
@@ -364,39 +351,35 @@ export class Supervisor implements AppInterface {
 
     // This is an entrypoint that returns the JSON interface for a plugin.
     async getJson(callerOrigin: string, id: string, plugin: QualifiedPluginId) {
-        return this.runExclusive(async () => {
-            try {
-                await networkNamePromise;
-                this.setParentOrigination(callerOrigin);
-                await this.preload([plugin]);
-                const json = this.plugins.getPlugin(plugin).plugin.getJson();
-                this.replyToParent(id, json);
-            } catch (e) {
-                this.replyToParent(id, e);
-            } finally {
-                this.plugins.disposeAll();
-                this.cleanupSessionState();
-            }
-        });
+        try {
+            await networkNamePromise;
+            this.setParentOrigination(callerOrigin);
+            await this.preload([plugin]);
+            const json = this.plugins.getPlugin(plugin).plugin.getJson();
+            this.replyToParent(id, json);
+        } catch (e) {
+            this.replyToParent(id, e);
+        } finally {
+            this.plugins.disposeAll();
+            this.cleanupSessionState();
+        }
     }
 
     // This is an entrypoint for apps to preload plugins.
     // Intended to be used on pageload to prepare the plugins that an app requires,
     //   which accelerates the responsiveness of the plugins for subsequent calls.
     async preloadPlugins(callerOrigin: string, plugins: QualifiedPluginId[]) {
-        return this.runExclusive(async () => {
-            try {
-                await networkNamePromise;
-                this.setParentOrigination(callerOrigin);
-                await this.preload(plugins);
-            } catch (e) {
-                console.error("TODO: Return an error to the caller.");
-                console.error(e);
-            } finally {
-                this.plugins.disposeAll();
-                this.cleanupSessionState();
-            }
-        });
+        try {
+            await networkNamePromise;
+            this.setParentOrigination(callerOrigin);
+            await this.preload(plugins);
+        } catch (e) {
+            console.error("TODO: Return an error to the caller.");
+            console.error(e);
+        } finally {
+            this.plugins.disposeAll();
+            this.cleanupSessionState();
+        }
     }
 
     // This is an entrypoint for apps to call into plugins.
@@ -405,67 +388,62 @@ export class Supervisor implements AppInterface {
         id: string,
         args: QualifiedFunctionCallArgs,
     ): Promise<any> {
-        return this.runExclusive(async () => {
-            try {
-                await networkNamePromise;
-                this.setParentOrigination(callerOrigin);
+        try {
+            await networkNamePromise;
+            this.setParentOrigination(callerOrigin);
 
-                // This is the time-intensive step. It includes: downloading, parsing, and transpiling the
-                //   each plugin component. Everything needed to prepare for instantiation and execution.
-                // UIs can use `preloadPlugins` to decouple this task from the actual call to the plugin.
-                await this.preload([
-                    {
-                        service: args.service,
-                        plugin: args.plugin,
-                    },
-                ]);
+            // This is the time-intensive step. It includes: downloading, parsing, and transpiling the
+            //   each plugin component. Everything needed to prepare for instantiation and execution.
+            // UIs can use `preloadPlugins` to decouple this task from the actual call to the plugin.
+            await this.preload([
+                {
+                    service: args.service,
+                    plugin: args.plugin,
+                },
+            ]);
 
-                await this.plugins.instantiateAll();
+            await this.plugins.instantiateAll();
 
-                this.context = this.getCallContext();
+            this.context = this.getCallContext();
 
-                // Starts the tx context.
-                this.supervisorCall(
-                    getCallArgs("transact", "plugin", "admin", "start-tx", []),
-                );
+            // Starts the tx context.
+            this.supervisorCall(
+                getCallArgs("transact", "plugin", "admin", "start-tx", []),
+            );
 
-                // Make a *synchronous* call into the plugin. It can be fully synchronous since everything was
-                //   preloaded.
-                const result = this.call(args);
+            // Make a *synchronous* call into the plugin. It can be fully synchronous since everything was
+            //   preloaded.
+            const result = this.call(args);
 
-                // Closes the current tx context. If actions were added, tx is submitted.
-                const txResult = this.supervisorCall(
-                    getCallArgs("transact", "plugin", "admin", "finish-tx", []),
-                );
-                if (txResult !== null && txResult !== undefined) {
-                    console.warn(txResult);
-                }
-
-                // Send plugin result to parent window
-                this.replyToParent(id, result);
-            } catch (e) {
-                const err = getRecoverableError(e);
-                if (err) {
-                    let newError;
-                    if (err.code === REDIRECT_ERROR_CODE) {
-                        newError = new RedirectErrorObject(
-                            err.producer,
-                            err.message,
-                        );
-                    } else {
-                        newError = new PluginErrorObject(
-                            err.producer,
-                            err.message,
-                        );
-                    }
-                    this.replyToParent(id, newError);
-                } else {
-                    this.replyToParent(id, e);
-                }
-            } finally {
-                this.plugins.disposeAll();
-                this.cleanupSessionState();
+            // Closes the current tx context. If actions were added, tx is submitted.
+            const txResult = this.supervisorCall(
+                getCallArgs("transact", "plugin", "admin", "finish-tx", []),
+            );
+            if (txResult !== null && txResult !== undefined) {
+                console.warn(txResult);
             }
-        });
+
+            // Send plugin result to parent window
+            this.replyToParent(id, result);
+        } catch (e) {
+            const err = getRecoverableError(e);
+            if (err) {
+                let newError;
+                if (err.code === REDIRECT_ERROR_CODE) {
+                    newError = new RedirectErrorObject(
+                        err.producer,
+                        err.message,
+                    );
+                } else {
+                    newError = new PluginErrorObject(err.producer, err.message);
+                }
+                this.replyToParent(id, newError);
+            } else {
+                this.replyToParent(id, e);
+            }
+        } finally {
+            this.plugins.disposeAll();
+            this.cleanupSessionState();
+        }
     }
 }

--- a/packages/user/Supervisor/ui/src/window-messaging.ts
+++ b/packages/user/Supervisor/ui/src/window-messaging.ts
@@ -1,3 +1,5 @@
+import { serialize } from "./serialize";
+
 export interface CallHandler {
     checkType: (param: any) => boolean;
     dispatch: (param: MessageEvent<any>) => void;
@@ -6,9 +8,16 @@ export interface CallHandler {
 export const addCallHandler = (
     handlers: CallHandler[],
     checkType: (param: any) => boolean,
-    dispatch: (param: MessageEvent<any>) => void,
+    dispatch: (param: MessageEvent<any>) => Promise<void> | void,
 ) => {
-    handlers.push({ checkType, dispatch });
+    handlers.push({
+        checkType,
+        dispatch: (param) => {
+            void serialize(async () => {
+                await dispatch(param);
+            });
+        },
+    });
 };
 
 export const registerCallHandlers = (


### PR DESCRIPTION
Extracts the message serialization up into the supervisor ingress layer instead of adding it inside the supervisor lib itself.

Also, I propose renaming away from "session lock" because "session" in this context can be confused with a browser session and this is not a browser-session-based lock.
