### PR TITLE
Vserver cleanups

### DIFF
--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -753,16 +753,17 @@ namespace SystemService
          {
             std::chrono::nanoseconds cpuUsage = cpuLimit.getCpuTime();
             to<VirtualServer>().useCpuSys(trx.actions()[0].sender(), cpuUsage.count());
+            to<VirtualServer>().finishTx();
          }
       }
 
       if (auto eventIndexer = tables.open<EventIndexerTable>().get({}))
       {
          // Events were already indexed before useCpuSys, which is intentional because we want to bill CPU time for event
-         // indexing. However, if indexing is done before useCpuSys, then the event emitted by useCpuSys that reports
-         // the used CPU doesn't get indexed (or billed).
+         // indexing. However, if indexing is done before useCpuSys, then the event(s) emitted by useCpuSys and finishTx
+         // don't get indexed (or billed).
          //
-         // Therefore, we do one more event indexer sync after useCpuSys, which will only index the new event (and uses
+         // Therefore, we do one more event indexer sync, which will only index the new events (and uses
          // cached service schemas so isn't as expensive).
          to<EventIndexerInterface>(eventIndexer->service).sync();
       }

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -281,6 +281,10 @@ namespace SystemService
       /// this resource.
       void useCpuSys(psibase::AccountNumber user, uint64_t amount_ns);
 
+      /// A notification called at the end of a transaction in which to do any final
+      /// per-tx accounting or cleanup.
+      void finishTx();
+
       /// Called by the system when `user` causes a write to any database.
       ///
       /// `amount_bytes` is positive for consumption and negative for a free
@@ -355,6 +359,7 @@ namespace SystemService
                 method(disk_ref_quote, bytes),
                 method(useNetSys, user, amount_bytes),
                 method(useCpuSys, user, amount_ns),
+                method(finishTx),
                 method(useDiskSys, user, db_id, amount_bytes),
                 method(get_resources, user),
                 method(notifyBlock, block_num),

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -156,12 +156,6 @@ namespace SystemService
       /// resource balance.
       void del_res_sub(std::string sub_account);
 
-      /// Gets the amount of resources available for the caller
-      UserService::Quantity res_balance();
-
-      /// Gets the amount of resources available for the caller's specified sub-account
-      UserService::Quantity res_balance_sub(std::string sub_account);
-
       /// Reserves system tokens for future resource consumption by the sender
       ///
       /// The reserve is consumed when interacting with metered network functionality.
@@ -342,8 +336,6 @@ namespace SystemService
                 method(buy_res_for, amount, for_user, memo),
                 method(buy_res_sub, amount, sub_account),
                 method(del_res_sub, sub_account),
-                method(res_balance),
-                method(res_balance_sub, sub_account),
                 method(buy_res, amount),
                 method(bill_to_sub, sub_account),
                 method(conf_buffer, config),

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -924,9 +924,14 @@ mod service {
         Wrapper::emit()
             .history()
             .consumed(user, Cpu.as_id(), amount, cost);
+    }
 
-        // useCpuSys runs once at the end of a billed transaction, so this is where we
-        // emit the per-tx aggregated disk `consumed` events that useDiskSys accumulated.
+    /// A notification called at the end of a transaction in which to do any final
+    /// per-tx accounting or cleanup.
+    #[action]
+    fn finishTx() {
+        check(get_sender() == Transact::SERVICE, "[finishTx] Unauthorized");
+
         for (disk_user, disk_amount, disk_cost) in tx_cache::drain_disk_usage() {
             if disk_amount == 0 && disk_cost == 0 {
                 continue;
@@ -997,7 +1002,7 @@ mod service {
         };
 
         // Avoiding a flood of events for writing individual records. Accumulate in the tx_cache and emit
-        // one event at the end of the tx (using `useCpuSys` as the tx end hook)
+        // one event at the end of the tx (using `finishTx` as the tx end hook)
         tx_cache::add_disk_usage(user, amount_bytes, cost);
     }
 

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -648,18 +648,6 @@ mod service {
         }
     }
 
-    /// Gets the amount of resources available for the caller
-    #[action]
-    fn res_balance() -> Quantity {
-        balance_cache::get_available(get_sender(), None)
-    }
-
-    /// Gets the amount of resources available for the caller's specified sub-account
-    #[action]
-    fn res_balance_sub(sub_account: String) -> Quantity {
-        balance_cache::get_available(get_sender(), Some(sub_account))
-    }
-
     /// Reserves system tokens for future resource consumption by the sender
     ///
     /// The reserve is consumed when interacting with metered network functionality.

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -19,17 +19,17 @@ mod tx_cache {
         cache: &'static LocalKey<RefCell<Option<T>>>,
         f: impl FnOnce(&mut T) -> R,
     ) -> R {
-        cache.with_borrow_mut(|m| {
-            f(m.as_mut()
-                .expect("resource billing attempted during end-of-tx settlement"))
+        cache.with_borrow_mut(|m| match m.as_mut() {
+            Some(inner) => f(inner),
+            None => abort_message("resource billing attempted during end-of-tx settlement"),
         })
     }
 
     /// Drain a billing cache, subsequent access panics.
     fn drain_cache<T: 'static>(cache: &'static LocalKey<RefCell<Option<T>>>) -> T {
-        cache.with_borrow_mut(|m| {
-            m.take()
-                .expect("resource billing attempted during end-of-tx settlement")
+        cache.with_borrow_mut(|m| match m.take() {
+            Some(inner) => inner,
+            None => abort_message("resource billing attempted during end-of-tx settlement"),
         })
     }
 

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -1,13 +1,13 @@
 //! # Capacity-limit pricing
 //!
 //! Resources in this category are limited by **total consumed capacity** relative to a maximum
-//! (e.g. objective storage bytes). This module implements that pricing with a constant-product curve between
-//!
+//! (e.g. objective storage bytes). This module implements that pricing with a constant-product curve
+//! between:
 //! - a **reserve token** (the unit used to pay for access to the resource), and
-//! - a **resource share token** (representing a claim on remaining resource capacity).
+//! - a **remaining resource capacity**
 //!
 //! The relay is configured so that the entire resource capacity can be consumed (i.e. the pool can
-//! reach 0 available resources) when a fixed budget of reserve tokens is sold into the pool.
+//! reach 0 remaining capacity) when a fixed budget of reserve tokens is sold into the pool.
 //!
 //! Offsets to the normal hyperbola are used in this design to avoid the price->infinity
 //! behavior of the vanilla $x y = k$ curve.
@@ -35,11 +35,11 @@
 //! Let:
 //!
 //! - $x$: pool reserve of **real** reserve tokens
-//! - $y$: pool reserve of **real** resource-share tokens (remaining capacity)
+//! - $y$: pool reserve of **real** remaining capacity
 //! - $x_{\max}$: total reserve-token budget that may be sold into the relay
 //! - $y_{\max}$: total resource capacity
 //! - $x_0$: an offset of **virtual** reserve tokens that cannot be withdrawn
-//! - $y_0$: an offset of **virtual** resource-share tokens that cannot be withdrawn
+//! - $y_0$: an offset of **virtual** resource capacity that cannot be withdrawn
 //!
 //! Interpretation:
 //!
@@ -140,7 +140,7 @@ impl Curve {
 }
 
 impl CurvePosition {
-    // Cost of consuming `amount` units of resource.
+    // Cost of consuming `amount` units of capacity.
     // delta_x = ceil(k / (Y - delta_y)) - X
     pub(crate) fn cost_of(&self, amount_consumed: u64) -> u64 {
         if amount_consumed == 0 {
@@ -163,7 +163,7 @@ impl CurvePosition {
         u64::try_from(dx).expect("cost exceeds u64")
     }
 
-    // Gross refund for freeing `amount` units of resource.
+    // Gross refund for freeing `amount` units of capacity.
     // delta_x = X - ceil(k / (Y + delta_y))
     pub(crate) fn refund_of(&self, amount_freed: u64) -> u64 {
         if amount_freed == 0 {

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -64,6 +64,18 @@ fn relay_sub(resource: ResourceType) -> String {
     )
 }
 
+/// This is a constant product curve, where the fundamental equation is XY = k. In this case,
+/// we derive X = (x+x0) and Y = (y+y0) where x0 and y0 are virtual offsets.
+///
+/// Evaluating k = XY at each endpoint and equating yields:
+/// x0(y_max+y0) = y0(x_max + x0)
+///
+/// Algebraically simplifying yields:
+/// x_max / x0 = y_max / y0
+///
+/// We refer to this single constant as the "shape parameter", or `D`. D controls how "aggressive"
+/// pricing is near the endpoints. Smaller D means larger offsets (flatter), larger D means
+/// smaller offsets (steeper).
 pub(crate) struct Curve {
     pub(crate) x0: u64,
     pub(crate) y0: u64,
@@ -81,18 +93,6 @@ pub(crate) struct CurvePosition {
     max_reserve: u64,
 }
 
-/// This is a constant product curve, where the fundamental equation is XY = k. In this case,
-/// we derive X = (x+x0) and Y = (y+y0) where x0 and y0 are virtual offsets.
-///
-/// Evaluating k = XY at each endpoint and equating yields:
-/// x0(y_max+y0) = y0(x_max + x0)
-///
-/// Algebraically simplifying yields:
-/// x_max / x0 = y_max / y0
-///
-/// We refer to this single constant as the "shape parameter", or `D`. D controls how "aggressive"
-/// pricing is near the endpoints. Smaller D means larger offsets (flatter), larger D means
-/// smaller offsets (steeper).
 impl Curve {
     /// All parameters can be expressed in terms of x_max, y_max, and D.
     /// x0 = x_max / D

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -101,9 +101,9 @@ impl Curve {
     ///
     /// Substituting yields:
     /// k = (x_max * y_max)(D+1) / D^2
-    pub(crate) fn new(max_reserves: u64, max_resources: u64, curve_d: u64) -> Self {
-        let xm = max_reserves as u128;
-        let ym = max_resources as u128;
+    pub(crate) fn new(max_reserve: u64, max_capacity: u64, curve_d: u64) -> Self {
+        let xm = max_reserve as u128;
+        let ym = max_capacity as u128;
         let d = curve_d as u128;
 
         // `xm * ym * (d + 1)` stays within u128 because `check_curve_params`
@@ -113,10 +113,10 @@ impl Curve {
         // Flooring x0/y0 and ceiling k all bias `pos_from_resources`'
         // `ceil(k / (resources + y0)) - x0` upward, keeping the pool capitalized.
         Curve {
-            x0: (max_reserves / curve_d),
-            y0: (max_resources / curve_d),
+            x0: (max_reserve / curve_d),
+            y0: (max_capacity / curve_d),
             k: (xm * ym * (d + 1)).div_ceil(d * d),
-            max_reserve: max_reserves,
+            max_reserve,
         }
     }
 

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -424,7 +424,7 @@ impl CapacityPricing {
 
             check(
                 p.required_reserve() <= old_reserve,
-                "Reserves drop after capacity increase",
+                "required reserve rose after capacity increase",
             );
         });
     }
@@ -450,7 +450,7 @@ impl CapacityPricing {
         let consumed = self.max_capacity - self.remaining_capacity;
         check(
             consumed == 0 || to_remove > 0,
-            "Reserves drop after reserve budget decrease",
+            "reserve budget decrease freed no reserves",
         );
     }
 

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -106,9 +106,9 @@ impl Curve {
         let ym = max_capacity as u128;
         let d = curve_d as u128;
 
-        // `xm * ym * (d + 1)` stays within u128 because `check_curve_params`
-        // bounds `max_reserve * max_capacity * (curve_d + 1)` whenever those
-        // inputs are set.
+        // For `xm * ym * (d + 1)` to stay within u128: callers must construct `Curve`
+        // only from params that were passed through `check_curve_params`, which bounds
+        // `max_reserve * max_capacity * (curve_d + 1)`.
         //
         // Flooring x0/y0 and ceiling k all bias `pos_from_remaining_capacity`'s
         // `ceil(k / (remaining_capacity + y0)) - x0` upward, keeping the pool capitalized.

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -160,7 +160,7 @@ impl CurvePosition {
         let dx = dx.min((self.max_reserve - self.reserves) as u128);
 
         // `dx <= max_reserve <= u64::MAX` after the cap so this cannot fail
-        check_some(u64::try_from(dx).ok(), "Insufficient capacity")
+        u64::try_from(dx).expect("cost exceeds u64")
     }
 
     // Gross refund for freeing `amount` units of resource.

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -182,7 +182,7 @@ impl CurvePosition {
 
     // Spot price: X / Y
     pub(crate) fn spot_price(&self) -> u64 {
-        (self.X / self.Y) as u64
+        (self.X / self.Y).min(u64::MAX as u128) as u64
     }
 }
 

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -110,8 +110,8 @@ impl Curve {
         // bounds `max_reserve * max_capacity * (curve_d + 1)` whenever those
         // inputs are set.
         //
-        // Flooring x0/y0 and ceiling k all bias `pos_from_resources`'
-        // `ceil(k / (resources + y0)) - x0` upward, keeping the pool capitalized.
+        // Flooring x0/y0 and ceiling k all bias `pos_from_remaining_capacity`'s
+        // `ceil(k / (remaining_capacity + y0)) - x0` upward, keeping the pool capitalized.
         Curve {
             x0: (max_reserve / curve_d),
             y0: (max_capacity / curve_d),
@@ -120,12 +120,12 @@ impl Curve {
         }
     }
 
-    /// Positions the curve by solving for reserves from resources.
-    /// reserves = ceil(k / (resources + y0)) - x0
+    /// Positions the curve by solving for reserves from remaining capacity.
+    /// reserves = ceil(k / (remaining_capacity + y0)) - x0
     ///
     /// Rounds the required reserves up, keeping the pool fully capitalized.
-    pub(crate) fn pos_from_resources(&self, resources: u64) -> CurvePosition {
-        let Y = resources as u128 + self.y0 as u128;
+    pub(crate) fn pos_from_remaining_capacity(&self, remaining_capacity: u64) -> CurvePosition {
+        let Y = remaining_capacity as u128 + self.y0 as u128;
         // True reserves never exceed `max_reserve`; clamp so the upward rounding
         // bias can't push past it and wrap the `as u64` cast.
         let reserves = (self.k.div_ceil(Y) - self.x0 as u128).min(self.max_reserve as u128) as u64;
@@ -254,7 +254,7 @@ impl CapacityPricing {
     /// Reserve token backing required in the relay for the current curve position.
     pub(crate) fn required_reserve(&self) -> u64 {
         self.curve()
-            .pos_from_resources(self.remaining_capacity)
+            .pos_from_remaining_capacity(self.remaining_capacity)
             .reserves
     }
 
@@ -264,14 +264,14 @@ impl CapacityPricing {
         }
 
         self.curve()
-            .pos_from_resources(self.remaining_capacity)
+            .pos_from_remaining_capacity(self.remaining_capacity)
             .cost_of(amount_consumed)
     }
 
     fn refund_of(&self, amount_freed: u64) -> u64 {
         let gross = self
             .curve()
-            .pos_from_resources(self.remaining_capacity)
+            .pos_from_remaining_capacity(self.remaining_capacity)
             .refund_of(amount_freed);
         let fee = (gross as u128 * self.fee_ppm as u128 / PPM) as u64;
         gross - fee
@@ -369,7 +369,7 @@ impl CapacityPricing {
             );
             cost = p
                 .curve()
-                .pos_from_resources(p.remaining_capacity)
+                .pos_from_remaining_capacity(p.remaining_capacity)
                 .cost_of(billable);
             p.remaining_capacity -= billable;
         });
@@ -390,7 +390,7 @@ impl CapacityPricing {
 
             gross_refund = p
                 .curve()
-                .pos_from_resources(p.remaining_capacity)
+                .pos_from_remaining_capacity(p.remaining_capacity)
                 .refund_of(refundable);
             p.remaining_capacity += refundable;
             fee_ppm_val = p.fee_ppm;
@@ -519,7 +519,7 @@ impl CapacityPricing {
     pub async fn spot_price(&self) -> Decimal {
         let price = self
             .curve()
-            .pos_from_resources(self.remaining_capacity)
+            .pos_from_remaining_capacity(self.remaining_capacity)
             .spot_price();
         sys_decimal(price)
     }

--- a/packages/system/VirtualServer/service/src/tests/chain.rs
+++ b/packages/system/VirtualServer/service/src/tests/chain.rs
@@ -136,7 +136,7 @@ fn relay_balance_basics(chain: psibase::Chain) -> Result<(), psibase::Error> {
         initial_disk_state.max_capacity,
         initial_disk_state.curve_d,
     )
-    .pos_from_resources(initial_disk_state.remaining_capacity)
+    .pos_from_remaining_capacity(initial_disk_state.remaining_capacity)
     .cost_of(cap_consumed);
     let new_shortfall = new_disk_state.relay_shortfall.quantity.value;
     assert_eq!(new_shortfall, initial_shortfall + cost, "invalid increase");

--- a/packages/system/VirtualServer/service/src/tests/curve_math.rs
+++ b/packages/system/VirtualServer/service/src/tests/curve_math.rs
@@ -17,13 +17,13 @@ fn endpoints() {
     for (max_reserves, max_resources, d) in test_curves() {
         let c = Curve::new(max_reserves, max_resources, d);
 
-        assert_eq!(c.pos_from_resources(0).reserves, max_reserves);
+        assert_eq!(c.pos_from_remaining_capacity(0).reserves, max_reserves);
 
         // When nothing has been consumed yet, the ideal reserve is 0, but
         // conservative rounding (ceil `k`, floor `x0`/`y0`) can push it higher, so
         // assert only that it's the minimal reserve keeping the pool capitalized
         // (`X * Y >= k`).
-        let pos = c.pos_from_resources(max_resources);
+        let pos = c.pos_from_remaining_capacity(max_resources);
         let big_y = max_resources as u128 + c.y0 as u128;
         let x = pos.reserves as u128 + c.x0 as u128;
         assert!(
@@ -55,8 +55,8 @@ fn cost_increases() {
         let c = Curve::new(max_reserves, max_resources, d);
         let amount = (max_resources / 10).max(1);
 
-        let cost_low = c.pos_from_resources(remaining_low).cost_of(amount);
-        let cost_high = c.pos_from_resources(remaining_high).cost_of(amount);
+        let cost_low = c.pos_from_remaining_capacity(remaining_low).cost_of(amount);
+        let cost_high = c.pos_from_remaining_capacity(remaining_high).cost_of(amount);
 
         assert!(
             cost_high > cost_low,
@@ -87,7 +87,7 @@ fn pool_capitalization() {
         }
 
         for resources in resource_checkpoints {
-            let pos = c.pos_from_resources(resources);
+            let pos = c.pos_from_remaining_capacity(resources);
             let xy = (pos.reserves as u128 + c.x0 as u128) * (resources as u128 + c.y0 as u128);
             // `X*Y >= k` holds except where reserves is capped at the budget, in
             // which case `X*Y` dips below `k`, which is harmless. Curve is still
@@ -111,9 +111,9 @@ fn no_arbitrage() {
         let c = Curve::new(max_reserves, max_resources, d);
 
         let partial_amount = (max_resources / 2).max(1);
-        let full = c.pos_from_resources(max_resources);
-        let partial = c.pos_from_resources(max_resources - partial_amount);
-        let empty = c.pos_from_resources(0);
+        let full = c.pos_from_remaining_capacity(max_resources);
+        let partial = c.pos_from_remaining_capacity(max_resources - partial_amount);
+        let empty = c.pos_from_remaining_capacity(0);
 
         // No-arbitrage: a buy then sell of the same amount round-trips exactly.
         let cost_all = full.cost_of(max_resources);
@@ -131,11 +131,11 @@ fn no_arbitrage() {
 fn cost_refund_of_zero() {
     for (max_reserves, max_resources, d) in test_curves() {
         let c = Curve::new(max_reserves, max_resources, d);
-        let full = c.pos_from_resources(max_resources);
+        let full = c.pos_from_remaining_capacity(max_resources);
         assert_eq!(full.cost_of(0), 0);
         assert_eq!(full.refund_of(0), 0);
 
-        let empty = c.pos_from_resources(0);
+        let empty = c.pos_from_remaining_capacity(0);
         assert_eq!(empty.cost_of(0), 0);
         assert_eq!(empty.refund_of(0), 0);
     }

--- a/packages/system/VirtualServer/service/src/tests/curve_math.rs
+++ b/packages/system/VirtualServer/service/src/tests/curve_math.rs
@@ -6,7 +6,7 @@ fn test_curves() -> [(u64, u64, u64); 7] {
         (1, 1, 1),                               // The minimal curve
         (1_000_000, 1_000_000, 1),               // D = 1
         (u64::MAX, 1_000_000, 1),                // D = 1, max reserves
-        (1_000_000, u64::MAX, 1),                // D = 1, max resources
+        (1_000_000, u64::MAX, 1),                // D = 1, max capacity
         (67_280_421_310_721, u64::MAX, 274_176), // A maximal curve
         (u64::MAX, 67_280_421_310_721, 274_176), // A maximal curve
     ]
@@ -14,17 +14,17 @@ fn test_curves() -> [(u64, u64, u64); 7] {
 
 #[test]
 fn endpoints() {
-    for (max_reserves, max_resources, d) in test_curves() {
-        let c = Curve::new(max_reserves, max_resources, d);
+    for (max_reserve, max_capacity, d) in test_curves() {
+        let c = Curve::new(max_reserve, max_capacity, d);
 
-        assert_eq!(c.pos_from_remaining_capacity(0).reserves, max_reserves);
+        assert_eq!(c.pos_from_remaining_capacity(0).reserves, max_reserve);
 
         // When nothing has been consumed yet, the ideal reserve is 0, but
         // conservative rounding (ceil `k`, floor `x0`/`y0`) can push it higher, so
         // assert only that it's the minimal reserve keeping the pool capitalized
         // (`X * Y >= k`).
-        let pos = c.pos_from_remaining_capacity(max_resources);
-        let big_y = max_resources as u128 + c.y0 as u128;
+        let pos = c.pos_from_remaining_capacity(max_capacity);
+        let big_y = max_capacity as u128 + c.y0 as u128;
         let x = pos.reserves as u128 + c.x0 as u128;
         assert!(
             x * big_y >= c.k,
@@ -42,9 +42,9 @@ fn endpoints() {
 
 #[test]
 fn cost_increases() {
-    for (max_reserves, max_resources, d) in test_curves() {
-        let remaining_low = max_resources * 8 / 10;
-        let remaining_high = max_resources * 2 / 10;
+    for (max_reserve, max_capacity, d) in test_curves() {
+        let remaining_low = max_capacity * 8 / 10;
+        let remaining_high = max_capacity * 2 / 10;
 
         if remaining_low <= remaining_high {
             // Not really a valid test for the minimal (1,1,1) curve.
@@ -52,8 +52,8 @@ fn cost_increases() {
             continue;
         }
 
-        let c = Curve::new(max_reserves, max_resources, d);
-        let amount = (max_resources / 10).max(1);
+        let c = Curve::new(max_reserve, max_capacity, d);
+        let amount = (max_capacity / 10).max(1);
 
         let cost_low = c.pos_from_remaining_capacity(remaining_low).cost_of(amount);
         let cost_high = c.pos_from_remaining_capacity(remaining_high).cost_of(amount);
@@ -69,37 +69,37 @@ fn cost_increases() {
 
 #[test]
 fn pool_capitalization() {
-    for (max_reserves, max_resources, d) in test_curves() {
-        let c = Curve::new(max_reserves, max_resources, d);
+    for (max_reserve, max_capacity, d) in test_curves() {
+        let c = Curve::new(max_reserve, max_capacity, d);
 
-        let mut resource_checkpoints = Vec::new();
-        for resources in [
+        let mut capacity_checkpoints = Vec::new();
+        for remaining_capacity in [
             0,
-            1.min(max_resources),
-            max_resources / 4,
-            max_resources / 2,
-            max_resources.saturating_sub(1),
-            max_resources,
+            1.min(max_capacity),
+            max_capacity / 4,
+            max_capacity / 2,
+            max_capacity.saturating_sub(1),
+            max_capacity,
         ] {
-            if !resource_checkpoints.contains(&resources) {
-                resource_checkpoints.push(resources);
+            if !capacity_checkpoints.contains(&remaining_capacity) {
+                capacity_checkpoints.push(remaining_capacity);
             }
         }
 
-        for resources in resource_checkpoints {
-            let pos = c.pos_from_remaining_capacity(resources);
-            let xy = (pos.reserves as u128 + c.x0 as u128) * (resources as u128 + c.y0 as u128);
+        for remaining_capacity in capacity_checkpoints {
+            let pos = c.pos_from_remaining_capacity(remaining_capacity);
+            let xy = (pos.reserves as u128 + c.x0 as u128) * (remaining_capacity as u128 + c.y0 as u128);
             // `X*Y >= k` holds except where reserves is capped at the budget, in
             // which case `X*Y` dips below `k`, which is harmless. Curve is still
             // economically safe.
             assert!(
-                xy >= c.k || pos.reserves == max_reserves,
-                "undercapitalized at resources={}: x*y={} < k={} (reserves={}, max_reserve={})",
-                resources,
+                xy >= c.k || pos.reserves == max_reserve,
+                "undercapitalized at remaining_capacity={}: x*y={} < k={} (reserves={}, max_reserve={})",
+                remaining_capacity,
                 xy,
                 c.k,
                 pos.reserves,
-                max_reserves,
+                max_reserve,
             );
         }
     }
@@ -107,18 +107,18 @@ fn pool_capitalization() {
 
 #[test]
 fn no_arbitrage() {
-    for (max_reserves, max_resources, d) in test_curves() {
-        let c = Curve::new(max_reserves, max_resources, d);
+    for (max_reserve, max_capacity, d) in test_curves() {
+        let c = Curve::new(max_reserve, max_capacity, d);
 
-        let partial_amount = (max_resources / 2).max(1);
-        let full = c.pos_from_remaining_capacity(max_resources);
-        let partial = c.pos_from_remaining_capacity(max_resources - partial_amount);
+        let partial_amount = (max_capacity / 2).max(1);
+        let full = c.pos_from_remaining_capacity(max_capacity);
+        let partial = c.pos_from_remaining_capacity(max_capacity - partial_amount);
         let empty = c.pos_from_remaining_capacity(0);
 
         // No-arbitrage: a buy then sell of the same amount round-trips exactly.
-        let cost_all = full.cost_of(max_resources);
+        let cost_all = full.cost_of(max_capacity);
         let cost_partial = full.cost_of(partial_amount);
-        let refund_all = empty.refund_of(max_resources);
+        let refund_all = empty.refund_of(max_capacity);
         let refund_partial = partial.refund_of(partial_amount);
         assert!(cost_all > 0);
         assert!(cost_partial > 0);
@@ -129,9 +129,9 @@ fn no_arbitrage() {
 
 #[test]
 fn cost_refund_of_zero() {
-    for (max_reserves, max_resources, d) in test_curves() {
-        let c = Curve::new(max_reserves, max_resources, d);
-        let full = c.pos_from_remaining_capacity(max_resources);
+    for (max_reserve, max_capacity, d) in test_curves() {
+        let c = Curve::new(max_reserve, max_capacity, d);
+        let full = c.pos_from_remaining_capacity(max_capacity);
         assert_eq!(full.cost_of(0), 0);
         assert_eq!(full.refund_of(0), 0);
 
@@ -141,16 +141,16 @@ fn cost_refund_of_zero() {
     }
 }
 
-fn ok(max_reserve: u64, max_resources: u64, curve_d: u64) {
+fn ok(max_reserve: u64, max_capacity: u64, curve_d: u64) {
     assert_eq!(
-        validate_curve_params(max_reserve, max_resources, curve_d),
+        validate_curve_params(max_reserve, max_capacity, curve_d),
         Ok(())
     );
 }
 
-fn err(max_reserve: u64, max_resources: u64, curve_d: u64, expected: &str) {
+fn err(max_reserve: u64, max_capacity: u64, curve_d: u64, expected: &str) {
     assert_eq!(
-        validate_curve_params(max_reserve, max_resources, curve_d),
+        validate_curve_params(max_reserve, max_capacity, curve_d),
         Err(expected)
     );
 }
@@ -179,34 +179,34 @@ fn boundary_construction() {
 
     // (D + 1) * MAX_RES == 2^64 + 1
     {
-        let (max_reserves, max_resources, d) = (u64::MAX, 67_280_421_310_721, 274_176);
-        ok(max_reserves, max_resources, d);
+        let (max_reserve, max_capacity, d) = (u64::MAX, 67_280_421_310_721, 274_176);
+        ok(max_reserve, max_capacity, d);
         err(
-            max_reserves,
-            max_resources + 1,
+            max_reserve,
+            max_capacity + 1,
             d,
             "curve parameters too large: pricing math would overflow",
         );
         err(
-            max_reserves,
-            max_resources,
+            max_reserve,
+            max_capacity,
             d + 1,
             "curve parameters too large: pricing math would overflow",
         );
     }
 
     {
-        let (max_reserves, max_resources, d) = (67_280_421_310_721, u64::MAX, 274_176);
-        ok(max_reserves, max_resources, d);
+        let (max_reserve, max_capacity, d) = (67_280_421_310_721, u64::MAX, 274_176);
+        ok(max_reserve, max_capacity, d);
         err(
-            max_reserves + 1,
-            max_resources,
+            max_reserve + 1,
+            max_capacity,
             d,
             "curve parameters too large: pricing math would overflow",
         );
         err(
-            max_reserves,
-            max_resources,
+            max_reserve,
+            max_capacity,
             d + 1,
             "curve parameters too large: pricing math would overflow",
         );

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -226,18 +226,6 @@ mod service {
         unimplemented!()
     }
 
-    /// Gets the amount of resources available for the caller
-    #[action]
-    fn res_balance() -> Quantity {
-        unimplemented!()
-    }
-
-    /// Gets the amount of resources available for the caller's specified sub-account
-    #[action]
-    fn res_balance_sub(sub_account: String) -> Quantity {
-        unimplemented!()
-    }
-
     /// Reserves system tokens for future resource consumption by the sender
     ///
     /// The reserve is consumed when interacting with metered network functionality.

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -408,6 +408,13 @@ mod service {
         unimplemented!()
     }
 
+    /// A notification called at the end of a transaction in which to do any final
+    /// per-tx accounting or cleanup.
+    #[action]
+    fn finishTx() {
+        unimplemented!()
+    }
+
     /// Called by the system when `user` causes a write to any database.
     ///
     /// `amount_bytes` is positive for consumption and negative for a free


### PR DESCRIPTION
* improve errors
* remove unused vserver actions `res_balance` and `res_balance_sub`
* improve parameter and function naming
  * standardizes on referring to the Y axis of capacity limited resources as capacity. It was previously inconsistent, with some places referring to it as "resources", which I don't like because it can easily be confused with resource backing tokens (the x axis/reserve).
* improve comments
* separate finish-tx from use-cpu-sys