### PR TITLE
Vserver resource balance caching and db-writes during reconciliation

### DIFF
--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -633,9 +633,8 @@ namespace SystemService
       check(trx.actions().size() > 0, "transaction has no actions");
       auto _           = recurse();
       bool enforceAuth = checkTapos(id, trx.tapos(), true, false);
-      if (enforceAuth) {
+      if (enforceAuth)
          checkAuth(trx.actions().front(), trx.claims(), true, true);
-      }
       return enforceAuth;
    }
 
@@ -705,9 +704,8 @@ namespace SystemService
       if (enforceAuth && isResMonitoring())
       {
          auto actors = std::vector<AccountNumber>();
-         actors.reserve(trx.actions().size());
-         for (auto act : trx.actions())
-            actors.push_back(act.sender().unpack());
+         actors.reserve(1);
+         actors.push_back(trxSender.value());
          to<VirtualServer>().prestartTx(actors);
       }
 

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -633,8 +633,15 @@ namespace SystemService
       check(trx.actions().size() > 0, "transaction has no actions");
       auto _           = recurse();
       bool enforceAuth = checkTapos(id, trx.tapos(), true, false);
-      if (enforceAuth)
+      if (enforceAuth) {
+         auto actors = std::vector<AccountNumber>();
+         actors.reserve(trx.actions().size());
+         for (auto act : trx.actions()) {
+            actors.push_back(act.sender().unpack());
+         }
+         to<VirtualServer>().prestartTx(actors);
          checkAuth(trx.actions().front(), trx.claims(), true, true);
+      }
       return enforceAuth;
    }
 

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -634,12 +634,6 @@ namespace SystemService
       auto _           = recurse();
       bool enforceAuth = checkTapos(id, trx.tapos(), true, false);
       if (enforceAuth) {
-         auto actors = std::vector<AccountNumber>();
-         actors.reserve(trx.actions().size());
-         for (auto act : trx.actions()) {
-            actors.push_back(act.sender().unpack());
-         }
-         to<VirtualServer>().prestartTx(actors);
          checkAuth(trx.actions().front(), trx.claims(), true, true);
       }
       return enforceAuth;
@@ -707,6 +701,15 @@ namespace SystemService
 
       Actor<CpuLimit> cpuLimit(Transact::service, CpuLimit::service, CallFlags::runModeRpc);
       Actor<Accounts> accounts(Transact::service, Accounts::service);
+
+      if (enforceAuth && isResMonitoring())
+      {
+         auto actors = std::vector<AccountNumber>();
+         actors.reserve(trx.actions().size());
+         for (auto act : trx.actions())
+            actors.push_back(act.sender().unpack());
+         to<VirtualServer>().prestartTx(actors);
+      }
 
       for (auto act : trx.actions())
       {

--- a/packages/system/Transact/src/Transact.cpp
+++ b/packages/system/Transact/src/Transact.cpp
@@ -703,10 +703,7 @@ namespace SystemService
 
       if (enforceAuth && isResMonitoring())
       {
-         auto actors = std::vector<AccountNumber>();
-         actors.reserve(1);
-         actors.push_back(trxSender.value());
-         to<VirtualServer>().prestartTx(actors);
+         to<VirtualServer>().prestartTx(trxSender.value());
       }
 
       for (auto act : trx.actions())

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -298,8 +298,8 @@ namespace SystemService
 
       void notifyBlock(psibase::BlockNum block_num);
 
-      /// A notification called before the start of a transaction with the specified top-level
-      /// action senders. Used for any pre-tx initialization.
+      /// A notification called before the start of a transaction that specifies any actors
+      /// responsible for activity within a tx. Used for any pre-tx initialization.
       void prestartTx(std::vector<psibase::AccountNumber> actors);
 
       /// This action specifies which account is primarily responsible for

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -298,6 +298,10 @@ namespace SystemService
 
       void notifyBlock(psibase::BlockNum block_num);
 
+      /// A notification called before the start of a transaction with the specified top-level
+      /// action senders. Used for any pre-tx initialization.
+      void prestartTx(std::vector<psibase::AccountNumber> actors);
+
       /// This action specifies which account is primarily responsible for
       /// paying the bill for any consumed resources.
       ///
@@ -363,6 +367,7 @@ namespace SystemService
                 method(useDiskSys, user, db_id, amount_bytes),
                 method(get_resources, user),
                 method(notifyBlock, block_num),
+                method(prestartTx, actors),
                 method(setBillableAcc, account),
                 method(serveSys, request, socket, user))
 

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -298,9 +298,9 @@ namespace SystemService
 
       void notifyBlock(psibase::BlockNum block_num);
 
-      /// A notification called before the start of a transaction that specifies any actors
-      /// responsible for activity within a tx. Used for any pre-tx initialization.
-      void prestartTx(std::vector<psibase::AccountNumber> actors);
+      /// A notification called before the start of a transaction that specifies the primary
+      /// actor responsible for the transaction. Used for any pre-tx initialization.
+      void prestartTx(psibase::AccountNumber actor);
 
       /// This action specifies which account is primarily responsible for
       /// paying the bill for any consumed resources.
@@ -367,7 +367,7 @@ namespace SystemService
                 method(useDiskSys, user, db_id, amount_bytes),
                 method(get_resources, user),
                 method(notifyBlock, block_num),
-                method(prestartTx, actors),
+                method(prestartTx, actor),
                 method(setBillableAcc, account),
                 method(serveSys, request, socket, user))
 

--- a/packages/system/VirtualServer/service/src/billing.rs
+++ b/packages/system/VirtualServer/service/src/billing.rs
@@ -16,6 +16,9 @@ const FEE_RECEIVER_CREDIT_MAX_BYTES: u64 = 169;
 /// Pays fees out to the configured `fee_receiver`.
 pub fn credit_fee_receiver(amount: u64) {
     if amount > 0 {
+        // [DB WRITE] Possible allocation - Therefore must be attributed to the system account.
+        // Consider finding a way to guarantee avoiding this allocation, which would avoid the need to
+        // attribute it to the system account.
         Transact::call().systemWrite(FEE_RECEIVER_CREDIT_MAX_BYTES);
         let c = BillingConfig::get_assert();
         Tokens::call().credit(c.sys, c.fee_receiver, amount.into(), "".into());
@@ -27,6 +30,12 @@ pub fn credit_fee_receiver(amount: u64) {
 /// * one per-payer settlement
 /// * one per-relay settlement
 /// * one fee-receiver credit
+///
+/// [DB_WRITE] WARNING:
+/// As of this point in the lifecycle of the transaction, we can no longer service subsequent user billing events.
+/// Therefore, all records that are updated from here on within this transaction must either have already been
+/// created to avoid an allocation, or must be attributed to the system account which will cause its billing to
+/// be handled as drift settlement.
 pub fn reconcile() {
     let payer_accruals = balance_cache::drain_balances();
     let capacity_accruals = accrual::capacity_limited::drain();
@@ -43,6 +52,8 @@ pub fn reconcile() {
     // 1. Charge payers first so the service balance funds the relay/fee payouts below.
     for ((account, sub), net) in &payer_accruals {
         if *net < 0 {
+            // [DB WRITE] No allocation - primary balance record for vserver already exists, it is created
+            // by the first resource purchase, which must be done before billing is enabled.
             Tokens::call().fromSub(sys, key(account, sub), Quantity::new((-net) as u64));
         }
     }
@@ -68,6 +79,8 @@ pub fn reconcile() {
     // 4. Process payer resource refunds
     for ((account, sub), net) in &payer_accruals {
         if *net > 0 {
+            // [DB WRITE] No allocation - primary balance record for vserver already exists, it is created
+            // by the first resource purchase, which must be done before billing is enabled.
             Tokens::call().toSub(sys, key(account, sub), Quantity::new(*net as u64));
         }
     }

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -153,12 +153,16 @@ mod tx_cache {
             with(|m| m.contains_key(&(account, sub)))
         }
 
-        /// The current resource balance for the specified account
+        /// The current resource balance for the specified account.
+        ///
+        /// Caches on cache-miss.
         pub fn get_available(account: AccountNumber, sub: Option<String>) -> Quantity {
-            match with(|m| m.get(&(account, sub.clone())).map(|b| b.available)) {
-                Some(available) => Quantity::new(available.max(0) as u64),
-                None => UserSettings::get_resource_balance(account, sub),
-            }
+            with(|m| {
+                let bal = m
+                    .entry((account, sub))
+                    .or_insert_with_key(Balance::from_live);
+                Quantity::new(bal.available.max(0) as u64)
+            })
         }
 
         /// Handles mid-tx resource purchase/deletion.
@@ -235,7 +239,9 @@ mod tx_cache {
         pub mod capacity_limited {
             use super::is_system_user;
             use crate::resource_type::ResourceType;
+            use crate::tables::capacity_limit_pricing::relay_sub_account;
             use crate::tx_cache::{balance_cache, drain_cache, with_cache};
+            use crate::Wrapper;
             use psibase::AccountNumber;
             use std::cell::RefCell;
             use std::collections::HashMap;
@@ -253,6 +259,13 @@ mod tx_cache {
 
             fn with<R>(resource: ResourceType, f: impl FnOnce(&mut Accrual) -> R) -> R {
                 with_cache(&STATE, |m| f(m.entry(resource).or_default()))
+            }
+
+            pub fn get_collateral(resource: ResourceType) -> u64 {
+                let sub = relay_sub_account(resource);
+                let actual = balance_cache::get_available(Wrapper::SERVICE, sub).value as i128;
+                let pending = with(resource, |a| a.relay_delta);
+                (actual + pending).max(0) as u64
             }
 
             pub fn consume(
@@ -675,6 +688,8 @@ mod service {
 
         let sender = get_sender();
 
+        // Warning: This `get_resource_balance_opt` call calls into the tokens service. Therefore the
+        // tokens service is currently not allowed to use `bill_to_sub`` since it is not re-entrant.
         check(
             UserSettings::get_resource_balance_opt(sender, Some(sub_account.clone())).is_some(),
             "Billable sub-account does not exist",
@@ -953,6 +968,21 @@ mod service {
     ///  amount of bytes consumed/freed.
     #[action]
     fn useDiskSys(user: AccountNumber, db_id: psibase::DbId, amount_bytes: i64) {
+        // [WARNING]
+        //
+        // Unlike `useCpuSys` and `useNetSys`, `useDiskSys` is called in real time during the
+        // execution of the user's transaction. For that reason, any inline action calls that
+        // are made in this action may cause recursion into that foreign service whenever that
+        // service itself updates database records.
+        //
+        // Therefore, we must be very careful if we are introducing inline action calls to other
+        // services in this action.
+        //
+        // Currently, the only potential foreign service call in this action is the call to
+        // `Tokens::getSubBal` on balance_cache cache misses. For that reason, `setBillableAcc`
+        // (which runs outside of the transaction context) is used to warm the balance_cache for
+        // any accounts whose sub-account balances are needed.
+
         check(
             get_sender() == Transact::SERVICE,
             "[useDiskSys] Unauthorized",
@@ -1063,7 +1093,25 @@ mod service {
         Some(limit_ns)
     }
 
-    /// This action specifies which account is primarily responsible for
+    // This function is used to warm the balance_cache for any accounts whose resource token
+    // balances may be queried. This is called outside of the transaction context, allowing
+    // any such queries during the tx to hit the cache instead of triggering an inline action
+    // call.
+    fn warm_billable_account_caches(user_account: AccountNumber) {
+        if !is_billing_enabled() {
+            return;
+        }
+
+        let _ = balance_cache::get_available(user_account, None);
+
+        for pricing in &CapacityPricingTable::read().get_index_pk() {
+            let _ = accrual::capacity_limited::get_collateral(pricing.resource());
+        }
+    }
+
+    /// This action does some per-tx initialization for accounts involved in billing.
+    ///
+    /// The `account` parameter specifies which account is primarily responsible for
     /// paying the bill for any consumed resources.
     ///
     /// A time limit for the execution of the current tx/query will be set based
@@ -1073,6 +1121,8 @@ mod service {
         check(get_sender() == Transact::SERVICE, "Unauthorized");
 
         tx_cache::set_billable_account(account);
+
+        warm_billable_account_caches(account);
 
         CpuLimit::rpc().setCpuLimit(get_cpu_limit(account, None));
     }

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -1096,27 +1096,25 @@ mod service {
     // balances may be queried. This is called outside of the transaction context, allowing
     // any such queries during the tx to hit the cache instead of triggering an inline action
     // call.
-    fn warm_billable_account_caches(user_accounts: Vec<AccountNumber>) {
+    fn warm_billable_account_caches(user_account: AccountNumber) {
         if !is_billing_enabled() {
             return;
         }
 
-        for actor in user_accounts {
-            let _ = balance_cache::get_available(actor, None);
-        }
+        let _ = balance_cache::get_available(user_account, None);
 
         for pricing in &CapacityPricingTable::read().get_index_pk() {
             let _ = accrual::capacity_limited::get_collateral(pricing.resource());
         }
     }
 
-    /// A notification called before the start of a transaction that specifies any actors
-    /// responsible for activity within a tx. Used for any pre-tx initialization.
+    /// A notification called before the start of a transaction that specifies the primary
+    /// actor responsible for the transaction. Used for any pre-tx initialization.
     #[action]
-    fn prestartTx(actors: Vec<AccountNumber>) {
+    fn prestartTx(actor: AccountNumber) {
         check(get_sender() == Transact::SERVICE, "Unauthorized");
 
-        warm_billable_account_caches(actors);
+        warm_billable_account_caches(actor);
     }
 
     /// This action specifies which `account` is primarily responsible for paying the

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -979,9 +979,8 @@ mod service {
         // services in this action.
         //
         // Currently, the only potential foreign service call in this action is the call to
-        // `Tokens::getSubBal` on balance_cache cache misses. For that reason, `setBillableAcc`
-        // (which runs outside of the transaction context) is used to warm the balance_cache for
-        // any accounts whose sub-account balances are needed.
+        // `Tokens::getSubBal` on balance_cache cache misses. For that reason, billable resource
+        // token balances are pre-warmed during the pre-tx initialization.
 
         check(
             get_sender() == Transact::SERVICE,
@@ -1097,22 +1096,31 @@ mod service {
     // balances may be queried. This is called outside of the transaction context, allowing
     // any such queries during the tx to hit the cache instead of triggering an inline action
     // call.
-    fn warm_billable_account_caches(user_account: AccountNumber) {
+    fn warm_billable_account_caches(user_accounts: Vec<AccountNumber>) {
         if !is_billing_enabled() {
             return;
         }
 
-        let _ = balance_cache::get_available(user_account, None);
+        for actor in user_accounts {
+            let _ = balance_cache::get_available(actor, None);
+        }
 
         for pricing in &CapacityPricingTable::read().get_index_pk() {
             let _ = accrual::capacity_limited::get_collateral(pricing.resource());
         }
     }
 
-    /// This action does some per-tx initialization for accounts involved in billing.
-    ///
-    /// The `account` parameter specifies which account is primarily responsible for
-    /// paying the bill for any consumed resources.
+    /// A notification called before the start of a transaction with the specified top-level
+    /// action senders. Used for any pre-tx initialization.
+    #[action]
+    fn prestartTx(actors: Vec<AccountNumber>) {
+        check(get_sender() == Transact::SERVICE, "Unauthorized");
+
+        warm_billable_account_caches(actors);
+    }
+
+    /// This action specifies which `account` is primarily responsible for paying the
+    /// bill for any resources consumed by the current tx.
     ///
     /// A time limit for the execution of the current tx/query will be set based
     /// on the resources available for the specified account.
@@ -1121,8 +1129,6 @@ mod service {
         check(get_sender() == Transact::SERVICE, "Unauthorized");
 
         tx_cache::set_billable_account(account);
-
-        warm_billable_account_caches(account);
 
         CpuLimit::rpc().setCpuLimit(get_cpu_limit(account, None));
     }

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -1110,8 +1110,8 @@ mod service {
         }
     }
 
-    /// A notification called before the start of a transaction with the specified top-level
-    /// action senders. Used for any pre-tx initialization.
+    /// A notification called before the start of a transaction that specifies any actors
+    /// responsible for activity within a tx. Used for any pre-tx initialization.
     #[action]
     fn prestartTx(actors: Vec<AccountNumber>) {
         check(get_sender() == Transact::SERVICE, "Unauthorized");

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -55,13 +55,12 @@ use async_graphql::ComplexObject;
 use psibase::services::tokens::{Decimal, Precision, Quantity, Wrapper as Tokens};
 use psibase::*;
 
-// Note: `pub(crate)` is used so the functions are available for the unit tests
+pub(crate) fn relay_sub_account(resource: ResourceType) -> Option<String> {
+    Some(format!("{}:relay", resource.name().to_lowercase()))
+}
 
 fn relay_sub(resource: ResourceType) -> String {
-    UserSettings::to_sub_account_key(
-        crate::Wrapper::SERVICE,
-        Some(format!("{}:relay", resource.name().to_lowercase())),
-    )
+    UserSettings::to_sub_account_key(crate::Wrapper::SERVICE, relay_sub_account(resource))
 }
 
 /// This is a constant product curve, where the fundamental equation is XY = k. In this case,

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -463,8 +463,9 @@ impl CapacityPricing {
             return;
         }
 
-        // The system's relay balance record is created once.
-        //   Instead of billing the first payer, socialize it as a system write.
+        // [DB WRITE] Possible allocation - Therefore must be attributed to the system account.
+        // Consider finding a way to guarantee avoiding this allocation, which would avoid the need to
+        // attribute it to the system account.
         const RELAY_BALANCE_RECORD_BYTES: u64 = 64;
         Transact::call().systemWrite(RELAY_BALANCE_RECORD_BYTES);
         if delta > 0 {

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -230,6 +230,7 @@ pub(crate) fn check_curve_params(max_reserve: u64, max_capacity: u64, curve_d: u
     }
 }
 
+use psibase::services::transact::Wrapper as Transact;
 impl CapacityPricing {
     pub(crate) fn resource(&self) -> ResourceType {
         ResourceType::from_id(self.resource_id)
@@ -458,11 +459,20 @@ impl CapacityPricing {
     pub(crate) fn settle_relay(resource: ResourceType, delta: i128) {
         let sys = BillingConfig::get_assert().sys;
         let sub = relay_sub(resource);
+        if delta == 0 {
+            return;
+        }
+
+        // The system's relay balance record is created once.
+        //   Instead of billing the first payer, socialize it as a system write.
+        const RELAY_BALANCE_RECORD_BYTES: u64 = 64;
+        Transact::call().systemWrite(RELAY_BALANCE_RECORD_BYTES);
         if delta > 0 {
             Tokens::call().toSub(sys, sub, Quantity::new(delta as u64));
         } else if delta < 0 {
             Tokens::call().fromSub(sys, sub, Quantity::new((-delta) as u64));
         }
+        Transact::call().systemWrite(0);
     }
 
     /// Settles the relay drift using up to `available` tokens, returning the leftover.

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -437,8 +437,8 @@ mod service {
         unimplemented!()
     }
 
-    /// A notification called before the start of a transaction with the specified top-level
-    /// action senders. Used for any pre-tx initialization.
+    /// A notification called before the start of a transaction that specifies any actors
+    /// responsible for activity within a tx. Used for any pre-tx initialization.
     #[action]
     fn prestartTx(actors: Vec<AccountNumber>) {
         unimplemented!()

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -437,6 +437,13 @@ mod service {
         unimplemented!()
     }
 
+    /// A notification called before the start of a transaction with the specified top-level
+    /// action senders. Used for any pre-tx initialization.
+    #[action]
+    fn prestartTx(actors: Vec<AccountNumber>) {
+        unimplemented!()
+    }
+
     /// This action specifies which account is primarily responsible for
     /// paying the bill for any consumed resources.
     ///

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -437,10 +437,10 @@ mod service {
         unimplemented!()
     }
 
-    /// A notification called before the start of a transaction that specifies any actors
-    /// responsible for activity within a tx. Used for any pre-tx initialization.
+    /// A notification called before the start of a transaction that specifies the primary
+    /// actor responsible for the transaction. Used for any pre-tx initialization.
     #[action]
-    fn prestartTx(actors: Vec<AccountNumber>) {
+    fn prestartTx(actor: AccountNumber) {
         unimplemented!()
     }
 


### PR DESCRIPTION
This PR clarifies how resource token balances are cached in `vserver`. It consolidates the warming of the cache for all accounts whose resource balances might be touched during a transaction into a `prestartTx` hook called by transact (symmetric with `finishTx`). The accounts whose resource balances might be touched include both user accounts as the sender of any action in the tx, as well as the relay subaccount for any capacitylimited resources (which may be "billed" when the user frees any corresponding resource and is therefore refunded from the relay).

Furthermore, this PR clarifies the new rule used in `vserver::reconcile` (the settlement of the payments accrued during tx processing): Any records written during reconciliation either need to have been pre-created (particularly if they are user-controlled records), or they must be attributed to the system account. This avoids the reconciliation process itself incurring subsequent disk-write billing, which would violate an invariant.