### PR TITLE
recollateralize relay shortfall from enable-billing over time

### DIFF
--- a/packages/system/VirtualServer/plugin/src/lib.rs
+++ b/packages/system/VirtualServer/plugin/src/lib.rs
@@ -82,11 +82,10 @@ impl Admin for VirtualServerPlugin {
         Ok(())
     }
 
-    fn enable_billing(enabled: bool, payer: Option<String>) -> Result<(), Error> {
+    fn enable_billing(enabled: bool) -> Result<(), Error> {
         assert_caller(&["config"], "enable_billing");
 
-        let payer = payer.map(|p| p.as_str().parse().unwrap());
-        VirtualServer::add_to_tx().enable_billing(enabled, payer);
+        VirtualServer::add_to_tx().enable_billing(enabled);
         Ok(())
     }
 

--- a/packages/system/VirtualServer/plugin/src/lib.rs
+++ b/packages/system/VirtualServer/plugin/src/lib.rs
@@ -82,10 +82,10 @@ impl Admin for VirtualServerPlugin {
         Ok(())
     }
 
-    fn enable_billing(enabled: bool) -> Result<(), Error> {
+    fn enable_billing() -> Result<(), Error> {
         assert_caller(&["config"], "enable_billing");
 
-        VirtualServer::add_to_tx().enable_billing(enabled);
+        VirtualServer::add_to_tx().enable_billing();
         Ok(())
     }
 

--- a/packages/system/VirtualServer/plugin/wit/world.wit
+++ b/packages/system/VirtualServer/plugin/wit/world.wit
@@ -85,15 +85,9 @@ interface admin {
     /// This must be called after the billing system has been initialized and the
     /// system token has been set.
     ///
-    /// `payer` is required only when `enabled = true`: that account must have
-    /// previously credited sufficient system tokens to this service to cover the
-    /// settlement cost of any net disk consumption that occurred while billing
-    /// was disabled.
-    ///
     /// Parameters:
     /// * `enabled` - Whether to enable the billing system
-    /// * `payer` - The account that will pay the settlement cost (required when enabling)
-    enable-billing: func(enabled: bool, payer: option<string>) -> result<_, error>;
+    enable-billing: func(enabled: bool) -> result<_, error>;
 
     /// Set virtual server specs
     /// It is from these specs that the pricing for network resources is derived.

--- a/packages/system/VirtualServer/plugin/wit/world.wit
+++ b/packages/system/VirtualServer/plugin/wit/world.wit
@@ -81,13 +81,10 @@ interface admin {
     /// * `variables` - The network variables
     set-network-variables: func(variables: network-variables) -> result<_, error>;
 
-    /// Enable the billing system
+    /// Enable the billing system.
     /// This must be called after the billing system has been initialized and the
     /// system token has been set.
-    ///
-    /// Parameters:
-    /// * `enabled` - Whether to enable the billing system
-    enable-billing: func(enabled: bool) -> result<_, error>;
+    enable-billing: func() -> result<_, error>;
 
     /// Set virtual server specs
     /// It is from these specs that the pricing for network resources is derived.

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -94,7 +94,7 @@ namespace SystemService
    /// 2 - Call `init_billing`: Initializes the billing system. To call this, the system token
    ///     must have already been set in the `Tokens` service. The specified `fee_receiver` will
    ///     receive all of the system token fees paid for resources by users.
-   /// 3 - Call `enable_billing(true)`: When ready, calling this action enables the
+   /// 3 - Call `enable_billing`: When ready, calling this action enables the
    ///     billing system. The caller must have already filled their resource buffer because
    ///     this action is itself billed.
    ///
@@ -198,12 +198,8 @@ namespace SystemService
       /// functionality.
       void set_network_variables(NetworkVariables variables);
 
-      /// Enable or disable the billing system
-      ///
-      /// If billing is disabled, resource consumption will still be tracked, but the resources will
-      /// not be automatically metered by the network. This is insecure and allows users to abuse
-      /// the network by consuming all of the network's resources.
-      void enable_billing(bool enabled);
+      /// Enable the billing system
+      void enable_billing();
 
       /// Returns whether the billing system has been enabled
       bool is_billing_enabled();
@@ -422,7 +418,7 @@ namespace SystemService
                 method(get_fee_receiver),
                 method(set_specs, specs),
                 method(set_network_variables, variables),
-                method(enable_billing, enabled),
+                method(enable_billing),
                 method(is_billing_enabled),
                 method(buy_res_for, amount, for_user, memo),
                 method(buy_res_sub, amount, sub_account),

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -66,11 +66,9 @@ namespace SystemService
    /// 2 - Call `init_billing`: Initializes the billing system. To call this, the system token
    ///     must have already been set in the `Tokens` service. The specified `fee_receiver` will
    ///     receive all of the system token fees paid for resources by users.
-   /// 3 - Call `enable_billing(true, Some(payer))`: When ready, calling this action enables the
-   ///     billing system. Two requirements: (a) the caller must have already filled their resource
-   ///     buffer because this action is itself billed, and (b) `payer` must have credited sufficient
-   ///     system tokens to this service to settle any net disk consumption that accumulated while
-   ///     billing was disabled (see the `enableBillingCost` GraphQL query for the required amount).
+   /// 3 - Call `enable_billing(true)`: When ready, calling this action enables the
+   ///     billing system. The caller must have already filled their resource buffer because
+   ///     this action is itself billed.
    ///
    /// > Note: typically, step 1 should be called at system boot, and therefore the network should
    /// >       always at least have some server specs and derived network specs.
@@ -116,11 +114,7 @@ namespace SystemService
       /// If billing is disabled, resource consumption will still be tracked, but the resources will
       /// not be automatically metered by the network. This is insecure and allows users to abuse
       /// the network by consuming all of the network's resources.
-      ///
-      /// `payer` is required only when `enabled = true`: that account must have previously credited
-      /// sufficient system tokens to this service to cover the settlement cost of any net disk
-      /// consumption that occurred while billing was disabled.
-      void enable_billing(bool enabled, std::optional<psibase::AccountNumber> payer);
+      void enable_billing(bool enabled);
 
       /// Returns whether the billing system has been enabled
       bool is_billing_enabled();
@@ -339,7 +333,7 @@ namespace SystemService
                 method(get_fee_receiver),
                 method(set_specs, specs),
                 method(set_network_variables, variables),
-                method(enable_billing, enabled, payer),
+                method(enable_billing, enabled),
                 method(is_billing_enabled),
                 method(buy_res_for, amount, for_user, memo),
                 method(buy_res_sub, amount, sub_account),

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -36,19 +36,47 @@ namespace SystemService
 
    /// Virtual Server Service
    ///
-   /// This service defines a "virtual server" that represents the "server" with which
-   /// a user interacts when they connect to any full node on the network.
+   /// This service defines a "virtual server" that represents the subset of a real server that
+   /// a node operator dedicates to running their network node. A user then interacts with one
+   /// or more virtual servers that are peered together to form a network. The network has
+   /// effective specifications that are derived from (and necessarily lower than) the virtual
+   /// server specs. The difference in specs comes from various overhead costs incurred by the
+   /// management of the network.
    ///
-   /// This service distinguishes between the specs of the network itself, and
-   /// the specs of an individual node that runs the virtual server. The actual node
-   /// specs must meet or exceed the specs defined for the virtual server. And the
-   /// derived network specs will always be less than the virtual server specs to account
-   /// for various overheads (e.g. from running a distributed network, desired replay
-   /// speed, etc).
+   /// Example diagram:
    ///
-   /// This service also defines a billing system that allows for the network to meter
-   /// the consumption of resources by users. A user must send system tokens to this service,
-   /// which are then held in reserve for the user.
+   /// .------------------------.  .------------------------.  .------------------------.
+   /// |     Actual Server 1    |  |     Actual Server 2    |  |     Actual Server 3    |
+   /// |                        |  |                        |  |                        |
+   /// |    100 Gbps network    |  |    50 Gbps network     |  |    100 Gbps network    |
+   /// |       2 TB disk        |  |       1 TB disk        |  |      300 GB disk       |
+   /// |                        |  |                        |  |                        |
+   /// | .--------------------. |  | .--------------------. |  | .--------------------. |
+   /// | |  Virtual Server 1  | |  | |  Virtual Server 2  | |  | |  Virtual Server 3  | |
+   /// | |  10 Gbps network   | |  | |  10 Gbps network   | |  | |  10 Gbps network   | |
+   /// | |    100 GB disk     | |  | |    100 GB disk     | |  | |    100 GB disk     | |
+   /// | '---------+----------' |  | '---------+----------' |  | '---------+----------' |
+   /// '-----------|------------'  '-----------|------------'  '-----------|------------'
+   ///             |                           |                           |
+   ///             |                           V                           |
+   ///             |        .--------------------------------------.       |
+   ///             |        |               Network                |       |
+   ///             +------->|  .--------------------------------.  |<------+
+   ///                      |  |            1 Gbps              |  |
+   ///                      |  |    50 GB replicated storage    |  |
+   ///                      |  |    50 GB node-local storage    |  |
+   ///                      |  '-------------------------------'   |
+   ///                      '-------------------^------------------'
+   ///                                          |
+   ///                                          v
+   ///                                    .-----------.
+   ///                                    |   User    |
+   ///                                    '-----------'
+   ///
+   /// This service also manages monitoring all of the network's resource consumption, and exposes
+   /// an interface that can be used to tune a billing system for rate-limiting per-account resource
+   /// consumption. Users can send system tokens into a "reserve" that can be subsequently redeemed for
+   /// resource consumption.
    ///
    /// As physical resources (CPU, disk space, network bandwidth, etc.) are consumed, the
    /// real-time price of the resource is billed to the user's reserved balance. Reserved system
@@ -76,6 +104,67 @@ namespace SystemService
    /// After each of the above steps, the billing service will be enabled, and users will be
    /// required to buy resources to transact with the network. Use the other actions in this
    /// service to manage server specs, network variables, and billing parameters, as needed.
+   ///
+   /// ## Curve under-collateralization
+   ///
+   /// Capacity limited resources are managed via a constant-product curve that reports the quantity
+   /// of reserve tokens required to be held as collateral for the current utilization levels of the
+   /// resource.
+   ///
+   /// This service attempts to balance the required collateral as reported by the state of the curve
+   /// with the actual collateral as measured by the relay subaccount token balance. The curve for a
+   /// capacity-limited resource can be undercollateralized in certain well-defined scenarios (e.g.
+   /// consumption before billing is enabled).
+   ///
+   /// An undercollateralized curve is recollateralized over time using the fees that would otherwise
+   /// be sent to the fee receiver.
+   ///
+   /// Example disk recollateralization flow diagram (simplified for clarity) for a transaction that
+   /// frees bytes:
+   ///
+   /// ```text
+   ///             .---------------.
+   ///            (   free bytes    )
+   ///             '-------+-------'
+   ///                     |
+   ///                     v
+   ///          +--------------------------+
+   ///          | Reduces curve shortfall  |
+   ///          +-----------+--------------+
+   ///                      |
+   ///                      v
+   ///                 .----------.
+   ///                /            \
+   ///       No      /   curve has  \     Yes
+   ///     .--------(   collateral?  )--------.
+   ///     |         \              /          |
+   ///     |          \            /           |
+   ///     v           '----------'            v
+   ///  .-----.                      +--------------------+
+   /// (  End  )                     |  Calc user refund  |
+   ///  '-----'                      +---------+----------+
+   ///                                         |
+   ///                                         v
+   ///                               +----------------------+
+   ///                               | Take fee from refund |
+   ///                               +---------+------------+
+   ///                                         |
+   ///                                         v
+   ///                               +--------------------+
+   ///                               |  Send user refund  |
+   ///                               +---------+----------+
+   ///                                         |
+   ///                                         v
+   ///                                .-----------------.
+   ///                               /                   \
+   ///                   yes        /    Curve under-     \        no
+   ///                 .-----------(   collateralized?     )-----------.
+   ///                 |            \                     /            |
+   ///                 v             '-------------------'             v
+   ///       +--------------------+                        +--------------------------+
+   ///       |  Add fee to relay  |                        | Send fee to fee receiver |
+   ///       +--------------------+                        +--------------------------+
+   /// ```
    struct VirtualServer : public psibase::Service
    {
       static constexpr auto service = psibase::AccountNumber("vserver");

--- a/packages/system/VirtualServer/service/src/billing.rs
+++ b/packages/system/VirtualServer/service/src/billing.rs
@@ -1,9 +1,9 @@
 use crate::resource_type::ResourceType;
 use crate::tables::tables::{BillingConfig, CapacityPricing, CapacityPricingTable, UserSettings};
 use crate::tx_cache::{accrual, balance_cache};
-use psibase::services::tokens::{Decimal, Quantity, Wrapper as Tokens};
+use psibase::services::tokens::{Quantity, Wrapper as Tokens};
 use psibase::services::transact::Wrapper as Transact;
-use psibase::{abort_message, get_service, AccountNumber, Table};
+use psibase::{AccountNumber, Table};
 use std::collections::HashMap;
 
 /// Upper bound on the bytes written when crediting the fee receiver during
@@ -87,35 +87,4 @@ pub fn reconcile() {
 
     // 5. Credit the fee receiver
     credit_fee_receiver(to_fee_receiver);
-}
-
-/// Used when enabling billing to capitalize any relay shortfall
-/// The specified payer is simply paying for it out of pocket
-/// Todo: consider constructing a new curve when billing is enabled for the first time to
-///       avoid requiring some particular payer to subsidize everyone else's prior writes.
-pub fn settle_relay_balance(resource: ResourceType, payer: AccountNumber) {
-    let net = CapacityPricing::get_assert(resource).relay_net();
-    if net == 0 {
-        return;
-    }
-    let config = BillingConfig::get_assert();
-    let sys = config.sys;
-    if net > 0 {
-        let amt = Quantity::new(net as u64);
-        let shared = Tokens::call().getSharedBal(sys, payer, get_service());
-        if shared < amt {
-            let precision = BillingConfig::get_sys_token().precision;
-            let paid = Decimal::new(shared, precision);
-            let required = Decimal::new(amt, precision);
-            abort_message(&format!(
-                "Account {payer} has paid {paid} tokens, but enabling billing requires {required} tokens"
-            ));
-        }
-        Tokens::call().debit(sys, payer, amt, "".into());
-        CapacityPricing::settle_relay(resource, net);
-        Tokens::call().reject(sys, payer, "Change".into());
-    } else {
-        CapacityPricing::settle_relay(resource, net);
-        credit_fee_receiver((-net) as u64);
-    }
 }

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -380,11 +380,9 @@ mod tx_cache {
 /// 2 - Call `init_billing`: Initializes the billing system. To call this, the system token
 ///     must have already been set in the `Tokens` service. The specified `fee_receiver` will
 ///     receive all of the system token fees paid for resources by users.
-/// 3 - Call `enable_billing(true, Some(payer))`: When ready, calling this action enables the
-///     billing system. Two requirements: (a) the caller must have already filled their resource
-///     buffer because this action is itself billed, and (b) `payer` must have credited sufficient
-///     system tokens to this service to settle any net disk consumption that accumulated while
-///     billing was disabled (see the `enableBillingCost` GraphQL query for the required amount).
+/// 3 - Call `enable_billing(true)`: When ready, calling this action enables the
+///     billing system. The caller must have already filled their resource buffer because
+///     this action is itself billed.
 ///
 /// > Note: typically, step 1 should be called at system boot, and therefore the network should
 /// >       always at least have some server specs and derived network specs.
@@ -563,18 +561,9 @@ mod service {
     /// If billing is disabled, resource consumption will still be tracked, but the resources will
     /// not be automatically metered by the network. This is insecure and allows users to abuse
     /// the network by consuming all of the network's resources.
-    ///
-    /// `payer` is required only when `enabled = true`: that account must have previously credited
-    /// sufficient system tokens to this service to cover the settlement cost of any net disk
-    /// consumption that occurred while billing was disabled.
     #[action]
-    fn enable_billing(enabled: bool, payer: Option<AccountNumber>) {
+    fn enable_billing(enabled: bool) {
         check(get_sender() == get_service(), "Unauthorized");
-
-        if enabled {
-            let payer = check_some(payer, "payer is required when enabling billing");
-            billing::settle_relay_balance(Disk, payer);
-        }
 
         BillingConfig::enable(enabled);
     }

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -1130,6 +1130,8 @@ mod service {
 
         tx_cache::set_billable_account(account);
 
+        warm_billable_account_caches();
+
         CpuLimit::rpc().setCpuLimit(get_cpu_limit(account, None));
     }
 

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -240,6 +240,7 @@ mod tx_cache {
             use super::is_system_user;
             use crate::resource_type::ResourceType;
             use crate::tables::capacity_limit_pricing::relay_sub_account;
+            use crate::tables::tables::CapacityPricing;
             use crate::tx_cache::{balance_cache, drain_cache, with_cache};
             use crate::Wrapper;
             use psibase::AccountNumber;
@@ -294,12 +295,14 @@ mod tx_cache {
                 }
                 let collateral = get_collateral(resource);
                 let refund = user_refund.min(collateral);
-                let clamped_fee = fee.min(collateral.saturating_sub(refund));
-                let gross = refund + clamped_fee;
+
+                // Fee only comes from collateral beyond the refund and what the curve must keep.
+                let required_reserve = CapacityPricing::get_assert(resource).required_reserve();
+                let fee = fee.min(collateral.saturating_sub(refund + required_reserve));
 
                 with(resource, |a| {
-                    a.relay_delta -= gross as i128;
-                    a.fee += clamped_fee;
+                    a.relay_delta -= (refund + fee) as i128;
+                    a.fee += fee;
                 });
                 if refund > 0 {
                     balance_cache::refund(user, sub, refund);
@@ -396,32 +399,33 @@ mod tx_cache {
 /// capacity-limited resource can be undercollateralized in certain well-defined scenarios (e.g.
 /// consumption before billing is enabled).
 ///
-/// An undercollateralized curve is recollateralized over time using the fees that would otherwise
-/// be sent to the fee receiver.
+/// An undercollateralized curve recollateralizes as users free bytes: a free sells bytes
+/// back to the relay, reducing the required reserve. The user's refund is still paid (if
+/// collateral allows), but the fee portion is retained in the curve rather than paid out.
+/// The fee receiver is paid only once the curve is fully collateralized.
 ///
 /// Example disk recollateralization flow diagram (simplified for clarity) for a transaction that
 /// frees bytes:
 ///
 /// ```text
+///                                                                 Example values:
+///                                                                 Total collateral: $15
+///                                                                 Required reserve: $100
+///
 ///            .---------------.
-///           (   free bytes    )
-///            '-------+-------'
+///           (   free bytes    )                                   Total free: $20
+///            '-------+-------'                                    Required reserve: $80
 ///                    |
 ///                    v
 ///      +--------------------------+
-///      | Reduce curve shortfall   |
-///      +------------+-------------+
-///                   |
-///                   v
-///      +--------------------------+
-///      |  Split gross-refund into |
-///      |  refund + fee            |
+///      |  Split gross-refund into |                               Refund: $10
+///      |  refund + fee            |                               Fee: $10
 ///      +----+----------------+----+
 ///           |                |
 ///           |                v
 ///           |     +-------------------------------+
-///           |     | Calculate final refund:       |
-///           |     | min(refund, collateral)       |
+///           |     | Calculate final refund:       |               Final refund:
+///           |     | min(refund, collateral)       |               min(10, 15) = $10
 ///           |     +-----+-------------+-----------+
 ///           |           |             |
 ///           |           |             v
@@ -429,24 +433,16 @@ mod tx_cache {
 ///           |           |      | Send final refund to user |
 ///           |           |      +---------------------------+
 ///           v           v
-///      +-------------------------------------------+
-///      | Calculate final fee:                      |
-///      | min(fee, collateral - final refund)       |
-///      +-----------------+-------------------------+
+///      +----------------------------------------------------+
+///      | Calculate final fee:                               |     Final fee:
+///      | Final fee can only come from collateral left over  |     min(fee, max(collateral - final refund - required reserve, 0))
+///      | after the refund and the curve's required reserve. |     min(10, max(15 - 10 - 80, 0)) = $0
+///      +-----------------+----------------------------------+
 ///                        |
 ///                        v
-///               .-----------------.
-///              /                   \
-///      yes    /  Is curve under-    \     no
-///    .-------(   collateralized?     )-------.
-///    |        \                     /        |
-///    |         \                   /         |
-///    v          '-----------------'          v
-/// +----------------------+     +----------------------+
-/// | Fee covers shortfall |     | Send full fee to fee |
-/// | (remainder sent to   |     | receiver             |
-/// | fee receiver)        |     +----------------------+
-/// +----------------------+
+///        +--------------------------------+
+///        | Send final fee to fee receiver |
+///        +--------------------------------+          
 /// ```
 ///
 #[psibase::service(name = "vserver", recursive = "true", tables = "tables::tables")]
@@ -1096,7 +1092,7 @@ mod service {
         };
 
         // Avoiding a flood of events for writing individual records. Accumulate in the tx_cache and emit
-        // one event at the end of the tx (using `finishTx` as the tx end hook)
+        // one event at the end of the tx (`finishTx`).
         tx_cache::add_disk_usage(user, amount_bytes, cost);
     }
 

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -320,7 +320,7 @@ mod tx_cache {
     }
 }
 
-/// Virtual Server Service
+/// # Virtual Server Service
 ///
 /// This service defines a "virtual server" that represents the subset of a real server that
 /// a node operator dedicates to running their network node. A user then interacts with one
@@ -390,6 +390,68 @@ mod tx_cache {
 /// After each of the above steps, the billing service will be enabled, and users will be
 /// required to buy resources to transact with the network. Use the other actions in this
 /// service to manage server specs, network variables, and billing parameters, as needed.
+///
+/// ## Curve under-collateralization
+///
+/// Capacity limited resources are managed via a constant-product curve that reports the quantity
+/// of reserve tokens required to be held as collateral for the current utilization levels of the
+/// resource.
+///
+/// This service attempts to balance the required collateral as reported by the state of the curve
+/// with the actual collateral as measured by the relay subaccount token balance. The curve for a
+/// capacity-limited resource can be undercollateralized in certain well-defined scenarios (e.g.
+/// consumption before billing is enabled).
+///
+/// An undercollateralized curve is recollateralized over time using the fees that would otherwise
+/// be sent to the fee receiver.
+///
+/// Example disk recollateralization flow diagram (simplified for clarity) for a transaction that
+/// frees bytes:
+///
+/// ```text
+///             .---------------.
+///            (   free bytes    )
+///             '-------+-------'
+///                     |
+///                     v
+///          +--------------------------+
+///          | Reduces curve shortfall  |
+///          +-----------+--------------+
+///                      |
+///                      v
+///                 .----------.
+///                /            \
+///       No      /   curve has  \     Yes
+///     .--------(   collateral?  )--------.
+///     |         \              /          |
+///     |          \            /           |
+///     v           '----------'            v
+///  .-----.                      +--------------------+
+/// (  End  )                     |  Calc user refund  |
+///  '-----'                      +---------+----------+
+///                                         |
+///                                         v
+///                               +----------------------+
+///                               | Take fee from refund |
+///                               +---------+------------+
+///                                         |
+///                                         v
+///                               +--------------------+
+///                               |  Send user refund  |
+///                               +---------+----------+
+///                                         |
+///                                         v
+///                                .-----------------.
+///                               /                   \
+///                   yes        /    Curve under-     \        no
+///                 .-----------(   collateralized?     )-----------.
+///                 |            \                     /            |
+///                 v             '-------------------'             v
+///       +--------------------+                        +--------------------------+
+///       |  Add fee to relay  |                        | Send fee to fee receiver |
+///       +--------------------+                        +--------------------------+
+/// ```
+///
 #[psibase::service(name = "vserver", recursive = "true", tables = "tables::tables")]
 mod service {
     use crate::billing;

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -380,7 +380,7 @@ mod tx_cache {
 /// 2 - Call `init_billing`: Initializes the billing system. To call this, the system token
 ///     must have already been set in the `Tokens` service. The specified `fee_receiver` will
 ///     receive all of the system token fees paid for resources by users.
-/// 3 - Call `enable_billing(true)`: When ready, calling this action enables the
+/// 3 - Call `enable_billing`: When ready, calling this action enables the
 ///     billing system. The caller must have already filled their resource buffer because
 ///     this action is itself billed.
 ///
@@ -618,16 +618,12 @@ mod service {
             .set_capacity(NetworkSpecs::get_assert().obj_storage_bytes);
     }
 
-    /// Enable or disable the billing system
-    ///
-    /// If billing is disabled, resource consumption will still be tracked, but the resources will
-    /// not be automatically metered by the network. This is insecure and allows users to abuse
-    /// the network by consuming all of the network's resources.
+    /// Enable the billing system
     #[action]
-    fn enable_billing(enabled: bool) {
+    fn enable_billing() {
         check(get_sender() == get_service(), "Unauthorized");
 
-        BillingConfig::enable(enabled);
+        BillingConfig::enable();
     }
 
     /// Returns whether the billing system has been enabled

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -528,13 +528,13 @@ mod service {
 
         // `InitRow`, `NetworkSpecs`, and `CapacityPricing` are necessarily written
         // after the db scan, and before resMonitoring is enabled. Therefore we must
-        // explicitly add their exact footprints to the baseline.
-        let used_bytes = get_prealloc()
+        // explicitly add their exact footprints into the prealloc.
+        let prealloc = get_prealloc()
             + row_size(&InitTable::new(), &InitRow::default())
             + row_size(&NetworkSpecsTable::new(), &NetworkSpecs::default())
             + row_size(&CapacityPricingTable::new(), &CapacityPricing::default());
 
-        InitRow::init(used_bytes);
+        InitRow::init(prealloc);
 
         // Must run after `InitRow::init` because it transitively depends on `InitRow::used_bytes()`
         NetworkSpecs::update();
@@ -555,6 +555,14 @@ mod service {
         events::Wrapper::call().addIndex(DbId::HistoryEvent, SERVICE, method!("consumed"), 0);
         events::Wrapper::call().addIndex(DbId::HistoryEvent, SERVICE, method!("subsidized"), 0);
         events::Wrapper::call().addIndex(DbId::HistoryEvent, SERVICE, method!("subsidized"), 1);
+
+        CapacityPricing::get_assert(Disk).consume(prealloc);
+        Wrapper::emit().history().consumed(
+            AccountNumber::new(0),
+            Disk.as_id(),
+            to_i64(prealloc, "preallocated disk space"),
+            0,
+        );
     }
 
     #[pre_action(exclude(init))]

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -1190,8 +1190,6 @@ mod service {
 
         tx_cache::set_billable_account(account);
 
-        warm_billable_account_caches();
-
         CpuLimit::rpc().setCpuLimit(get_cpu_limit(account, None));
     }
 

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -287,18 +287,30 @@ mod tx_cache {
                 sub: Option<String>,
                 user_refund: u64,
                 fee: u64,
-            ) {
-                let gross = user_refund + fee;
-                if is_system_user(user) || gross == 0 {
-                    return;
+            ) -> u64 {
+                let total_out = user_refund + fee;
+                if is_system_user(user) || total_out == 0 {
+                    return 0;
                 }
+                let collateral = get_collateral(resource);
+
+                let (gross, clamped_fee, refund) = if total_out > collateral {
+                    // Clamp the fee and the refund (keeping fee_ppm ratio)
+                    // if the payout exceeds available collateral.
+                    let clamped_fee = (fee as u128 * collateral as u128 / total_out as u128) as u64;
+                    (collateral, clamped_fee, collateral - clamped_fee)
+                } else {
+                    (total_out, fee, user_refund)
+                };
+
                 with(resource, |a| {
                     a.relay_delta -= gross as i128;
-                    a.fee += fee;
+                    a.fee += clamped_fee;
                 });
-                if user_refund > 0 {
-                    balance_cache::refund(user, sub, user_refund);
+                if refund > 0 {
+                    balance_cache::refund(user, sub, refund);
                 }
+                refund
             }
 
             pub fn drain() -> Vec<(ResourceType, Accrual)> {
@@ -1009,8 +1021,9 @@ mod service {
                     let (user_refund, fee) =
                         CapacityPricing::get_assert(Disk).free((-amount_bytes) as u64);
                     if billing {
-                        accrual::capacity_limited::free(Disk, user, sub, user_refund, fee);
-                        -(to_i64(user_refund, "Disk refund"))
+                        let refund =
+                            accrual::capacity_limited::free(Disk, user, sub, user_refund, fee);
+                        -(to_i64(refund, "Disk refund"))
                     } else {
                         0
                     }

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -293,15 +293,9 @@ mod tx_cache {
                     return 0;
                 }
                 let collateral = get_collateral(resource);
-
-                let (gross, clamped_fee, refund) = if total_out > collateral {
-                    // Clamp the fee and the refund (keeping fee_ppm ratio)
-                    // if the payout exceeds available collateral.
-                    let clamped_fee = (fee as u128 * collateral as u128 / total_out as u128) as u64;
-                    (collateral, clamped_fee, collateral - clamped_fee)
-                } else {
-                    (total_out, fee, user_refund)
-                };
+                let refund = user_refund.min(collateral);
+                let clamped_fee = fee.min(collateral.saturating_sub(refund));
+                let gross = refund + clamped_fee;
 
                 with(resource, |a| {
                     a.relay_delta -= gross as i128;
@@ -409,47 +403,50 @@ mod tx_cache {
 /// frees bytes:
 ///
 /// ```text
-///             .---------------.
-///            (   free bytes    )
-///             '-------+-------'
-///                     |
-///                     v
-///          +--------------------------+
-///          | Reduces curve shortfall  |
-///          +-----------+--------------+
-///                      |
-///                      v
-///                 .----------.
-///                /            \
-///       No      /   curve has  \     Yes
-///     .--------(   collateral?  )--------.
-///     |         \              /          |
-///     |          \            /           |
-///     v           '----------'            v
-///  .-----.                      +--------------------+
-/// (  End  )                     |  Calc user refund  |
-///  '-----'                      +---------+----------+
-///                                         |
-///                                         v
-///                               +----------------------+
-///                               | Take fee from refund |
-///                               +---------+------------+
-///                                         |
-///                                         v
-///                               +--------------------+
-///                               |  Send user refund  |
-///                               +---------+----------+
-///                                         |
-///                                         v
-///                                .-----------------.
-///                               /                   \
-///                   yes        /    Curve under-     \        no
-///                 .-----------(   collateralized?     )-----------.
-///                 |            \                     /            |
-///                 v             '-------------------'             v
-///       +--------------------+                        +--------------------------+
-///       |  Add fee to relay  |                        | Send fee to fee receiver |
-///       +--------------------+                        +--------------------------+
+///            .---------------.
+///           (   free bytes    )
+///            '-------+-------'
+///                    |
+///                    v
+///      +--------------------------+
+///      | Reduce curve shortfall   |
+///      +------------+-------------+
+///                   |
+///                   v
+///      +--------------------------+
+///      |  Split gross-refund into |
+///      |  refund + fee            |
+///      +----+----------------+----+
+///           |                |
+///           |                v
+///           |     +-------------------------------+
+///           |     | Calculate final refund:       |
+///           |     | min(refund, collateral)       |
+///           |     +-----+-------------+-----------+
+///           |           |             |
+///           |           |             v
+///           |           |      +---------------------------+
+///           |           |      | Send final refund to user |
+///           |           |      +---------------------------+
+///           v           v
+///      +-------------------------------------------+
+///      | Calculate final fee:                      |
+///      | min(fee, collateral - final refund)       |
+///      +-----------------+-------------------------+
+///                        |
+///                        v
+///               .-----------------.
+///              /                   \
+///      yes    /  Is curve under-    \     no
+///    .-------(   collateralized?     )-------.
+///    |        \                     /        |
+///    |         \                   /         |
+///    v          '-----------------'          v
+/// +----------------------+     +----------------------+
+/// | Fee covers shortfall |     | Send full fee to fee |
+/// | (remainder sent to   |     | receiver             |
+/// | fee receiver)        |     +----------------------+
+/// +----------------------+
 /// ```
 ///
 #[psibase::service(name = "vserver", recursive = "true", tables = "tables::tables")]

--- a/packages/system/VirtualServer/service/src/rpc.rs
+++ b/packages/system/VirtualServer/service/src/rpc.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use async_graphql::*;
 use psibase::{
-    check, is_auth,
+    is_auth,
     services::{
         tokens::{Decimal, Quantity, Wrapper as Tokens},
         transact::ServiceMethod,
@@ -271,27 +271,6 @@ impl Query {
             .unwrap_or(Quantity::new(0));
         let token = BillingConfig::get_sys_token();
         Decimal::new(refund, token.precision)
-    }
-
-    /// Returns the token cost that must be paid to enable billing.
-    ///
-    /// This is the amount of system tokens that the payer must credit to VirtualServer
-    /// before `enable_billing(true, payer)` can succeed.
-    ///
-    /// A 5% buffer is added to the cost to account for any minor variations in the cost
-    /// between query time and the time billing is enabled.
-    async fn enable_billing_cost(&self) -> Decimal {
-        let balance = CapacityPricing::get(ResourceType::Disk)
-            .map(|p| p.relay_net())
-            .unwrap_or(0);
-        let cost: u128 = balance.max(0) as u128;
-        let cost = cost
-            .checked_mul(105)
-            .expect("enable_billing_cost: overflow")
-            / 100;
-        check(cost <= u64::MAX as u128, "settlement cost exceeds u64");
-        let token = BillingConfig::get_sys_token();
-        Decimal::new(Quantity::new(cost as u64), token.precision)
     }
 
     /// Returns information related to the account's resource buffer.

--- a/packages/system/VirtualServer/service/src/tables.rs
+++ b/packages/system/VirtualServer/service/src/tables.rs
@@ -217,8 +217,6 @@ pub mod tables {
         pub curve_d: u64,
         /// Fee on refunds, parts per million
         pub fee_ppm: u32,
-        /// Prealloc bytes that were freed; later writes refill them for free.
-        pub prealloc_deficit: u64,
     }
 }
 

--- a/packages/system/VirtualServer/service/src/tables/billing_config.rs
+++ b/packages/system/VirtualServer/service/src/tables/billing_config.rs
@@ -38,10 +38,13 @@ impl BillingConfig {
         BillingConfigTable::read().get_index_pk().get(&()).is_some()
     }
 
-    pub fn enable(enabled: bool) {
+    pub fn enable() {
         let table = BillingConfigTable::read_write();
         let mut config = check_some(table.get_index_pk().get(&()), "Billing not yet initialized");
-        config.enabled = enabled;
+        if config.enabled {
+            return;
+        }
+        config.enabled = true;
         table.put(&config).unwrap();
     }
 

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -309,7 +309,6 @@ impl CapacityPricing {
                 max_capacity,
                 curve_d,
                 fee_ppm,
-                prealloc_deficit: 0,
             })
             .unwrap();
     }
@@ -363,20 +362,15 @@ impl CapacityPricing {
         let resource = self.resource();
         let mut cost = 0u64;
         Self::update(resource, |p| {
-            // Refilling a prealloc deficit is free; only the remainder is billed.
-            let restored = amount_consumed.min(p.prealloc_deficit);
-            p.prealloc_deficit -= restored;
-            let billable = amount_consumed - restored;
-
             check(
-                billable <= p.remaining_capacity,
+                amount_consumed <= p.remaining_capacity,
                 &format!("Insufficient {} capacity", resource.name()),
             );
             cost = p
                 .curve()
                 .pos_from_remaining_capacity(p.remaining_capacity)
-                .cost_of(billable);
-            p.remaining_capacity -= billable;
+                .cost_of(amount_consumed);
+            p.remaining_capacity -= amount_consumed;
         });
         cost
     }
@@ -388,16 +382,18 @@ impl CapacityPricing {
         Self::update(resource, |p| {
             let consumed = p.max_capacity - p.remaining_capacity;
 
-            // Freeing past `consumed` dips into prealloc: unrefundable, tracked as
-            // a deficit that later writes refill for free.
-            let refundable = amount_freed.min(consumed);
-            p.prealloc_deficit += amount_freed - refundable;
+            // This should not be possible since preallocated bytes are "consumed"
+            // in `init`, every byte should be accounted for on the curve.
+            check(
+                amount_freed <= consumed,
+                "freed more disk than was consumed",
+            );
 
             gross_refund = p
                 .curve()
                 .pos_from_remaining_capacity(p.remaining_capacity)
-                .refund_of(refundable);
-            p.remaining_capacity += refundable;
+                .refund_of(amount_freed);
+            p.remaining_capacity += amount_freed;
             fee_ppm_val = p.fee_ppm;
         });
 

--- a/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/capacity_limit_pricing.rs
@@ -47,6 +47,11 @@
 //! - As the resource is consumed, $x$ increases and $y$ decreases.
 //! - Full consumption corresponds to $(x, y) = (x_{\max}, 0)$.
 //!
+//! ## Collateralization
+//!
+//! The curve math in this module calculates a quantity of reserve tokens that would be necessary
+//! collateral for the current utilization of the resource. Whether the curve is in fact actually
+//! collateralized is outside of this module's scope.
 
 use crate::math_utils::PPM;
 use crate::resource_type::ResourceType;

--- a/packages/system/VirtualServer/service/src/tables/network_specs.rs
+++ b/packages/system/VirtualServer/service/src/tables/network_specs.rs
@@ -5,15 +5,10 @@ use psibase::*;
 impl NetworkSpecs {
     /// Bytes of objective server storage that are not available to the network
     ///
-    /// Reductions here reduce the max billable storage, which is better than treating
-    /// the offsets like a normal "consumption" because then whoever enables billing
-    ///  would be required to settle a much larger virtual balance.
+    /// Reductions here reduce the max billable storage.
     pub(crate) fn obj_storage_offset() -> u64 {
-        // Bytes already in db at boot (`Native` + `Service`)
-        InitRow::used_bytes()
-
         // One misc gigabyte
-        + 1_000_000_000
+        1_000_000_000
     }
 
     fn derive_net(vars: &NetworkVariables, specs: &ServerSpecs) -> u64 {

--- a/packages/system/VirtualServer/service/src/tests/chain.rs
+++ b/packages/system/VirtualServer/service/src/tests/chain.rs
@@ -8,8 +8,6 @@ use psibase::{
         credentials,
         invite::{self, InvPayload},
         nft::Wrapper as Nft,
-        sites::Wrapper as Sites,
-        staged_tx::Wrapper as StagedTx,
         tokens::{self, Decimal, Precision, Quantity, Wrapper as Tokens},
         verify_sig,
     },
@@ -25,9 +23,8 @@ use super::utils::{fmt_mb, fmt_num, fmt_sys};
 
 use super::helpers::{assert_error, check_balance, enable_billing as setup_enable_billing};
 use super::query::{
-    get_billing_config, get_db_prealloc, get_disk_state, get_invite_cost, get_network_vars,
-    get_server_specs, get_site_paths, get_sub_balance, get_total_consumed_disk, get_user_resources,
-    DiskPricingState,
+    get_billing_config, get_disk_state, get_invite_cost, get_network_vars, get_server_specs,
+    get_total_consumed_disk, get_user_resources, DiskPricingState,
 };
 
 fn consumption_details(
@@ -436,23 +433,17 @@ fn check_disk_invariant(label: &str, chain: &psibase::Chain) -> bool {
 
     let scanned_bytes = native + service - status;
 
-    let svc_prealloc = get_db_prealloc(chain);
     let svc_consumed = disk_consumed(chain);
-    let svc_deficit = get_disk_state(chain).prealloc_deficit;
-    let svc_accounting = svc_prealloc - svc_deficit + svc_consumed;
 
-    let delta = scanned_bytes as i128 - svc_accounting as i128;
+    let delta = scanned_bytes as i128 - svc_consumed as i128;
     if delta != 0 {
         println!(
-            "[{label}] total={} (native={} + service={} - status={}) == prealloc={} - deficit={} + consumed={} ({}), delta={}",
+            "[{label}] scanned={} (native={} + service={} - status={}) == consumed={}, delta={}",
             fmt_num(scanned_bytes),
             fmt_num(native),
             fmt_num(service),
             fmt_num(status),
-            fmt_num(svc_prealloc),
-            fmt_num(svc_deficit),
             fmt_num(svc_consumed),
-            fmt_num(svc_accounting),
             delta,
         );
     }
@@ -600,223 +591,6 @@ fn invites(chain: psibase::Chain) -> Result<(), psibase::Error> {
         check_disk_invariant("end of invites", &chain),
         "disk accounting invariant violated"
     );
-
-    Ok(())
-}
-
-fn scanned_bytes(chain: &psibase::Chain) -> u64 {
-    chain.database_usage(DbId::Native) + chain.database_usage(DbId::Service)
-        - status_row_bytes(chain)
-}
-fn disk_consumed_now(chain: &psibase::Chain) -> u64 {
-    let d = get_disk_state(chain);
-    d.max_capacity - d.remaining_capacity
-}
-
-// Stores `total` bytes of site content at `/blob{tag}`
-fn write(chain: &psibase::Chain, tag: u8, total: usize) -> Result<(), psibase::Error> {
-    Sites::push_from(chain, PRODUCER_ACCOUNT)
-        .storeSys(
-            format!("/blob{tag}"),
-            "application/octet-stream".to_string(),
-            None,
-            Hex(vec![tag; total]),
-        )
-        .get()?;
-    chain.finish_block();
-    Ok(())
-}
-
-fn free(chain: &psibase::Chain, tag: u8) -> Result<(), psibase::Error> {
-    Sites::push_from(chain, PRODUCER_ACCOUNT)
-        .remove(format!("/blob{tag}"))
-        .get()?;
-    chain.finish_block();
-    Ok(())
-}
-
-// Frees all site content uploaded at boot, freeing far more than has been
-// consumed since init and so dipping into the prealloc baseline. Returns the
-// resulting prealloc deficit.
-fn free_boot_content(chain: &psibase::Chain) -> Result<u64, psibase::Error> {
-    let consumed_before = disk_consumed_now(chain);
-    let scanned_before = scanned_bytes(chain);
-
-    let accounts = [
-        account!("common-api"),
-        account!("supervisor"),
-        account!("accounts"),
-        account!("perms"),
-        account!("clientdata"),
-        account!("aes"),
-        account!("kdf"),
-        account!("base64"),
-        account!("transact"),
-        account!("sites"),
-        account!("auth-sig"),
-        account!("nft"),
-        account!("tokens"),
-        account!("symbol"),
-        account!("invite"),
-        account!("producers"),
-    ];
-    let actions: Vec<Action> = accounts
-        .into_iter()
-        .flat_map(|acct| {
-            get_site_paths(chain, acct)
-                .into_iter()
-                .map(move |path| Sites::pack_from(acct).remove(path))
-        })
-        .collect();
-    StagedTx::push_from(chain, PRODUCER_ACCOUNT)
-        .propose(actions, true)
-        .get()?;
-    chain.finish_block();
-
-    let physically_freed = scanned_before as i128 - scanned_bytes(chain) as i128;
-    assert!(
-        physically_freed > consumed_before as i128,
-        "expected to free more than consumed: freed={physically_freed} consumed={consumed_before}",
-    );
-
-    let dipped = get_disk_state(chain);
-    assert!(
-        dipped.prealloc_deficit > 0,
-        "expected freeing past consumed to record a deficit"
-    );
-    assert!(
-        check_disk_invariant("after freeing prealloc bytes", chain),
-        "invariant violated after freeing prealloc bytes"
-    );
-
-    println!(
-        "freed {} MB > consumed {} MB; remaining {} / max {} MB; deficit {} MB",
-        fmt_mb(physically_freed as u64),
-        fmt_mb(consumed_before),
-        fmt_mb(dipped.remaining_capacity),
-        fmt_mb(dipped.max_capacity),
-        fmt_mb(dipped.prealloc_deficit),
-    );
-    Ok(dipped.prealloc_deficit)
-}
-
-// Exercises the prealloc-deficit accounting
-#[psibase::test_case(packages("VirtualServer", "StagedTx"))]
-fn free_into_prealloc(chain: psibase::Chain) -> Result<(), psibase::Error> {
-    initial_setup(&chain)?;
-    setup_enable_billing(&chain)?;
-    chain.finish_block();
-
-    let sys: tokens::TID = 1;
-    let vserver = Wrapper::SERVICE;
-    let vserver_token = chain.login(vserver, tokens::Wrapper::SERVICE)?;
-
-    // Reserve tokens backing the disk pool live in this relay sub-account; refunds
-    // are paid out of it and consumption charges flow into it.
-    let relay_sub = format!("{vserver}.disk:relay");
-    let relay_balance = |chain: &psibase::Chain| {
-        get_sub_balance(chain, vserver, &relay_sub, sys, &vserver_token).unwrap()
-    };
-
-    let deficit = free_boot_content(&chain)?;
-
-    {
-        // a write within the deficit is free: no reserve tokens move
-        let consumed_pre_write = disk_consumed_now(&chain);
-        let relay_pre_write = relay_balance(&chain);
-
-        write(&chain, 1, (deficit / 4) as usize)?;
-
-        let after_write = get_disk_state(&chain);
-        let consumed_after_write = after_write.max_capacity - after_write.remaining_capacity;
-        assert_eq!(
-            consumed_after_write, consumed_pre_write,
-            "a write within the deficit must not change consumed",
-        );
-
-        assert!(
-            after_write.prealloc_deficit < deficit,
-            "the write should shrink the deficit"
-        );
-        assert_eq!(
-            relay_balance(&chain),
-            relay_pre_write,
-            "an in-deficit write must not move reserve tokens into the relay",
-        );
-        assert!(
-            check_disk_invariant("after in-deficit write", &chain),
-            "invariant violated after in-deficit write"
-        );
-    }
-
-    {
-        // freeing into the prealloc pays no refund: no reserve tokens move
-        let deficit_pre_free = get_disk_state(&chain).prealloc_deficit;
-        let relay_pre_free = relay_balance(&chain);
-
-        free(&chain, 1)?;
-
-        let after_free = get_disk_state(&chain);
-        let consumed_after_free = after_free.max_capacity - after_free.remaining_capacity;
-        assert_eq!(
-            consumed_after_free, 0,
-            "a free within the deficit must not change consumed",
-        );
-        assert!(
-            after_free.prealloc_deficit > deficit_pre_free,
-            "the free should grow the deficit"
-        );
-        assert_eq!(
-            relay_balance(&chain),
-            relay_pre_free,
-            "a free within the deficit must not refund reserve tokens",
-        );
-        assert!(
-            check_disk_invariant("after in-deficit free", &chain),
-            "invariant violated after in-deficit free"
-        );
-    }
-
-    // Buy extra resources to comfortably cover the large writes below
-    let extra_resources: u64 = 200_000_000;
-    tokens::Wrapper::push_from(&chain, PRODUCER_ACCOUNT)
-        .credit(sys, vserver, extra_resources.into(), "".into())
-        .get()?;
-    Wrapper::push_from(&chain, PRODUCER_ACCOUNT)
-        .buy_res(extra_resources.into())
-        .get()?;
-
-    {
-        // a write crossing the deficit boundary bills the excess into the relay
-        let deficit_pre_cross = get_disk_state(&chain).prealloc_deficit;
-        let consumed_pre_cross = disk_consumed_now(&chain);
-        let scanned_pre_cross = scanned_bytes(&chain);
-        let relay_pre_cross = relay_balance(&chain);
-
-        write(&chain, 2, deficit_pre_cross as usize + 64 * 1024)?;
-
-        let after_cross = get_disk_state(&chain);
-        let consumed_after_cross = after_cross.max_capacity - after_cross.remaining_capacity;
-        let scanned_after_cross = scanned_bytes(&chain);
-
-        assert_eq!(
-            after_cross.prealloc_deficit, 0,
-            "crossing the boundary should drain the deficit"
-        );
-        assert_eq!(
-            consumed_after_cross - consumed_pre_cross,
-            scanned_after_cross - (scanned_pre_cross + deficit_pre_cross),
-            "billed amount must equal bytes written above the prealloc",
-        );
-        assert!(
-            relay_balance(&chain) > relay_pre_cross,
-            "more reserve tokens should be in the relay",
-        );
-        assert!(
-            check_disk_invariant("after writing past the prealloc deficit boundary", &chain),
-            "invariant violated after writing past the prealloc deficit boundary"
-        );
-    }
 
     Ok(())
 }

--- a/packages/system/VirtualServer/service/src/tests/chain.rs
+++ b/packages/system/VirtualServer/service/src/tests/chain.rs
@@ -321,7 +321,7 @@ fn metering(chain: psibase::Chain) -> Result<(), psibase::Error> {
     // Verify enable billing
     chain
         .propose::<Wrapper>(PRODUCER_ACCOUNT, Wrapper::SERVICE)
-        .enable_billing(true)
+        .enable_billing()
         .get()?;
 
     // Verify alice out of resources

--- a/packages/system/VirtualServer/service/src/tests/chain.rs
+++ b/packages/system/VirtualServer/service/src/tests/chain.rs
@@ -777,6 +777,15 @@ fn free_into_prealloc(chain: psibase::Chain) -> Result<(), psibase::Error> {
         );
     }
 
+    // Buy extra resources to comfortably cover the large writes below
+    let extra_resources: u64 = 200_000_000;
+    tokens::Wrapper::push_from(&chain, PRODUCER_ACCOUNT)
+        .credit(sys, vserver, extra_resources.into(), "".into())
+        .get()?;
+    Wrapper::push_from(&chain, PRODUCER_ACCOUNT)
+        .buy_res(extra_resources.into())
+        .get()?;
+
     {
         // a write crossing the deficit boundary bills the excess into the relay
         let deficit_pre_cross = get_disk_state(&chain).prealloc_deficit;

--- a/packages/system/VirtualServer/service/src/tests/chain.rs
+++ b/packages/system/VirtualServer/service/src/tests/chain.rs
@@ -25,9 +25,9 @@ use super::utils::{fmt_mb, fmt_num, fmt_sys};
 
 use super::helpers::{assert_error, check_balance, enable_billing as setup_enable_billing};
 use super::query::{
-    get_billing_config, get_db_prealloc, get_disk_state, get_enable_billing_cost, get_invite_cost,
-    get_network_vars, get_server_specs, get_site_paths, get_sub_balance, get_total_consumed_disk,
-    get_user_resources, DiskPricingState,
+    get_billing_config, get_db_prealloc, get_disk_state, get_invite_cost, get_network_vars,
+    get_server_specs, get_site_paths, get_sub_balance, get_total_consumed_disk, get_user_resources,
+    DiskPricingState,
 };
 
 fn consumption_details(
@@ -318,18 +318,10 @@ fn metering(chain: psibase::Chain) -> Result<(), psibase::Error> {
         .credit(sys, PRODUCER_ACCOUNT, 50_000_0000.into(), "".into())
         .get()?;
 
-    // Credit the settlement cost to VirtualServer before enabling billing
-    let billing_cost = get_enable_billing_cost(&chain)?;
-    if billing_cost > 0 {
-        tokens::Wrapper::push_from(&chain, PRODUCER_ACCOUNT)
-            .credit(sys, vserver, billing_cost.into(), "".into())
-            .get()?;
-    }
-
     // Verify enable billing
     chain
         .propose::<Wrapper>(PRODUCER_ACCOUNT, Wrapper::SERVICE)
-        .enable_billing(true, Some(PRODUCER_ACCOUNT))
+        .enable_billing(true)
         .get()?;
 
     // Verify alice out of resources

--- a/packages/system/VirtualServer/service/src/tests/helpers.rs
+++ b/packages/system/VirtualServer/service/src/tests/helpers.rs
@@ -6,7 +6,7 @@ use psibase::{
     AccountNumber, ChainEmptyResult,
 };
 
-use super::query::{get_enable_billing_cost, get_user_resources};
+use super::query::get_user_resources;
 
 pub(super) fn assert_error(result: ChainEmptyResult, message: &str) {
     let err = result.trace.error.unwrap();
@@ -46,7 +46,8 @@ pub(super) fn enable_billing(chain: &psibase::Chain) -> Result<(), psibase::Erro
         .get()?;
     chain.finish_block();
 
-    chain.propose::<Wrapper>(PRODUCER_ACCOUNT, Wrapper::SERVICE)
+    chain
+        .propose::<Wrapper>(PRODUCER_ACCOUNT, Wrapper::SERVICE)
         .init_billing(tokens)
         .get()?;
 
@@ -66,23 +67,14 @@ pub(super) fn enable_billing(chain: &psibase::Chain) -> Result<(), psibase::Erro
         .buy_res(min_resource_buffer.into())
         .get()?;
 
-    let billing_cost = get_enable_billing_cost(&chain)?;
-    if billing_cost > 0 {
-        tokens::Wrapper::push_from(&chain, alice)
-            .credit(sys, PRODUCER_ACCOUNT, billing_cost.into(), "".into())
-            .get()?;
-        tokens::Wrapper::push_from(&chain, PRODUCER_ACCOUNT)
-            .credit(sys, vserver, billing_cost.into(), "".into())
-            .get()?;
-    }
-
     // Give producer account some more tokens for general use
     tokens::Wrapper::push_from(&chain, alice)
         .credit(sys, PRODUCER_ACCOUNT, 50_000_0000.into(), "".into())
         .get()?;
 
-    chain.propose::<Wrapper>(PRODUCER_ACCOUNT, Wrapper::SERVICE)
-        .enable_billing(true, Some(PRODUCER_ACCOUNT))
+    chain
+        .propose::<Wrapper>(PRODUCER_ACCOUNT, Wrapper::SERVICE)
+        .enable_billing(true)
         .get()?;
 
     Ok(())

--- a/packages/system/VirtualServer/service/src/tests/helpers.rs
+++ b/packages/system/VirtualServer/service/src/tests/helpers.rs
@@ -74,7 +74,7 @@ pub(super) fn enable_billing(chain: &psibase::Chain) -> Result<(), psibase::Erro
 
     chain
         .propose::<Wrapper>(PRODUCER_ACCOUNT, Wrapper::SERVICE)
-        .enable_billing(true)
+        .enable_billing()
         .get()?;
 
     Ok(())

--- a/packages/system/VirtualServer/service/src/tests/query.rs
+++ b/packages/system/VirtualServer/service/src/tests/query.rs
@@ -1,7 +1,4 @@
-use psibase::{
-    services::tokens::{self, Decimal, TID},
-    AccountNumber,
-};
+use psibase::{services::tokens::Decimal, AccountNumber};
 use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::tables::tables::{NetworkVariables, ServerSpecs};
@@ -52,7 +49,6 @@ pub(super) struct DiskPricingState {
     pub curve_d: u64,
     pub relay_shortfall: Decimal,
     pub relay_excess: Decimal,
-    pub prealloc_deficit: u64,
 }
 
 pub(super) fn get_billing_config(chain: &psibase::Chain) -> Result<BillingConfig, psibase::Error> {
@@ -134,43 +130,11 @@ const DISK_PRICING_QUERY: &str = r#"query {
         utilizationPct
         relayShortfall
         relayExcess
-        preallocDeficit
     }
 }"#;
 
 pub(super) fn get_disk_state(chain: &psibase::Chain) -> DiskPricingState {
     query(chain, Wrapper::SERVICE, "diskPricing", DISK_PRICING_QUERY).unwrap()
-}
-
-pub(super) fn get_db_prealloc(chain: &psibase::Chain) -> u64 {
-    query(
-        chain,
-        Wrapper::SERVICE,
-        "dbPrealloc",
-        r#"query { dbPrealloc }"#,
-    )
-    .unwrap()
-}
-
-/// Lists every path of `sites`-hosted content owned by `account`.
-pub(super) fn get_site_paths(chain: &psibase::Chain, account: AccountNumber) -> Vec<String> {
-    let result: serde_json::Value = chain
-        .graphql(
-            psibase::services::sites::SERVICE,
-            &format!(
-                r#"query {{ getContent(account: "{account}", first: 100000) {{ edges {{ node {{ path }} }} }} }}"#
-            ),
-        )
-        .unwrap();
-    result["data"]["getContent"]["edges"]
-        .as_array()
-        .map(|edges| {
-            edges
-                .iter()
-                .filter_map(|e| e["node"]["path"].as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default()
 }
 
 pub(super) fn get_total_consumed_disk(
@@ -208,24 +172,6 @@ pub(super) fn get_total_consumed_disk(
                 .sum()
         })
         .unwrap_or(0)
-}
-
-pub(super) fn get_sub_balance(
-    chain: &psibase::Chain,
-    holder: AccountNumber,
-    sub_account: &str,
-    token_id: TID,
-    auth_token: &str,
-) -> Result<u64, psibase::Error> {
-    #[derive(Deserialize)]
-    struct SubBal {
-        balance: Decimal,
-    }
-    let q = format!(
-        r#"query {{ subaccountBalance(user: "{holder}", subAccount: "{sub_account}", tokenId: {token_id}) {{ balance }} }}"#
-    );
-    let b: SubBal = query_auth(chain, tokens::SERVICE, "subaccountBalance", &q, auth_token)?;
-    Ok(b.balance.quantity.value)
 }
 
 pub(super) fn get_invite_cost(

--- a/packages/system/VirtualServer/service/src/tests/query.rs
+++ b/packages/system/VirtualServer/service/src/tests/query.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use psibase::{
     services::tokens::{self, Decimal, TID},
     AccountNumber,
@@ -228,17 +226,6 @@ pub(super) fn get_sub_balance(
     );
     let b: SubBal = query_auth(chain, tokens::SERVICE, "subaccountBalance", &q, auth_token)?;
     Ok(b.balance.quantity.value)
-}
-
-pub(super) fn get_enable_billing_cost(chain: &psibase::Chain) -> Result<u64, psibase::Error> {
-    let s: String = query(
-        chain,
-        Wrapper::SERVICE,
-        "enableBillingCost",
-        r#"query { enableBillingCost }"#,
-    )?;
-    let decimal = Decimal::from_str(&s).map_err(psibase::Error::new)?;
-    Ok(decimal.quantity.value)
 }
 
 pub(super) fn get_invite_cost(

--- a/packages/user/Config/plugin/src/lib.rs
+++ b/packages/user/Config/plugin/src/lib.rs
@@ -202,13 +202,11 @@ impl VirtualServer for ConfigPlugin {
         virtual_server::plugin::admin::set_network_variables(variables)
     }
 
-    fn enable_billing(enabled: bool) -> Result<(), Error> {
-        if enabled {
-            virtual_server::plugin::billing::fill_gas_tank()?;
-        }
+    fn enable_billing() -> Result<(), Error> {
+        virtual_server::plugin::billing::fill_gas_tank()?;
 
         set_propose_latch(Some(VIRTUAL_SERVER))?;
-        virtual_server::plugin::admin::enable_billing(enabled)
+        virtual_server::plugin::admin::enable_billing()
     }
 
     fn set_cpu_pricing_params(params: CpuPricingParams) -> Result<(), Error> {

--- a/packages/user/Config/plugin/src/lib.rs
+++ b/packages/user/Config/plugin/src/lib.rs
@@ -17,11 +17,6 @@ use virtual_server::plugin::types::{
     NetworkVariables as DestNetworkVariables, ServerSpecs as DestServerSpecs,
 };
 
-use accounts::plugin::api::get_current_user;
-
-use psibase::services::tokens::{Decimal, Quantity};
-use std::str::FromStr;
-
 use transact::plugin::intf::set_propose_latch;
 
 const VIRTUAL_SERVER: &'static str = "vserver";
@@ -210,37 +205,10 @@ impl VirtualServer for ConfigPlugin {
     fn enable_billing(enabled: bool) -> Result<(), Error> {
         if enabled {
             virtual_server::plugin::billing::fill_gas_tank()?;
-
-            let cost_json =
-                virtual_server::plugin::authorized::graphql("query { enableBillingCost }")?;
-            let parsed: serde_json::Value =
-                serde_json::from_str(&cost_json).expect("Failed to parse billing cost");
-            let cost_str = parsed["data"]["enableBillingCost"]
-                .as_str()
-                .expect("enableBillingCost missing or not a string");
-
-            let cost = Decimal::from_str(cost_str)
-                .unwrap_or_else(|_| panic!("Invalid enableBillingCost '{cost_str}'"));
-
-            if cost.quantity != Quantity::new(0) {
-                let sys_id = tokens::plugin::helpers::fetch_network_token()?
-                    .expect("Network token not found");
-                tokens::plugin::user::credit(
-                    sys_id,
-                    VIRTUAL_SERVER,
-                    &cost_str.to_string(),
-                    "Settle disk consumption that occurred while billing was disabled",
-                )?;
-            }
         }
 
         set_propose_latch(Some(VIRTUAL_SERVER))?;
-        let payer = if enabled {
-            Some(get_current_user().unwrap())
-        } else {
-            None
-        };
-        virtual_server::plugin::admin::enable_billing(enabled, payer.as_deref())
+        virtual_server::plugin::admin::enable_billing(enabled)
     }
 
     fn set_cpu_pricing_params(params: CpuPricingParams) -> Result<(), Error> {

--- a/packages/user/Config/plugin/wit/world.wit
+++ b/packages/user/Config/plugin/wit/world.wit
@@ -99,13 +99,10 @@ interface virtual-server {
     /// * `variables` - The network variables
     set-network-variables: func(variables: network-variables) -> result<_, error>;
 
-    /// Enable the billing system
+    /// Enable the billing system.
     /// This must be called after the billing system has been initialized and the
     /// system token has been set.
-    ///
-    /// Parameters:
-    /// * `enabled` - Whether to enable the billing system
-    enable-billing: func(enabled: bool) -> result<_, error>;
+    enable-billing: func() -> result<_, error>;
 
     /// Set the virtual server specs
     /// It is from these specs that the pricing for network resources is derived.

--- a/packages/user/Config/ui/src/components/billing.tsx
+++ b/packages/user/Config/ui/src/components/billing.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { useSetEnableBilling } from "@/hooks/use-set-enable-billing";
 import { useSetFeeReceiverAccount } from "@/hooks/use-set-fee-receiver-account";
@@ -16,7 +16,6 @@ interface SystemTokenInfo {
 }
 
 interface BillingFormData {
-    enableBilling: boolean;
     tokenFeeReceiverAccount: { account: string };
 }
 
@@ -41,32 +40,17 @@ export const Billing = ({ systemToken, systemTokenLoading }: BillingProps) => {
     const { data: billingConfig, isLoading: billingConfigLoading } =
         useBillingConfig();
 
-    // Track the submitted/initial value of enableBilling for comparison
-    const [submittedEnableBilling, setSubmittedEnableBilling] = useState<
-        boolean | null
-    >(null);
-
     const computedInitialValues = useMemo<BillingFormData>(() => {
         if (billingConfig) {
             return {
-                enableBilling: billingConfig.enabled,
                 tokenFeeReceiverAccount: {
                     account: billingConfig.feeReceiver || "",
                 },
             };
         }
         return {
-            enableBilling: false,
             tokenFeeReceiverAccount: { account: "" },
         };
-    }, [billingConfig]);
-
-    useEffect(() => {
-        if (billingConfig) {
-            setSubmittedEnableBilling(billingConfig.enabled);
-        } else {
-            setSubmittedEnableBilling(false);
-        }
     }, [billingConfig]);
 
     const billingForm = useAppForm({
@@ -96,11 +80,9 @@ export const Billing = ({ systemToken, systemTokenLoading }: BillingProps) => {
         );
     }, [billingConfig?.feeReceiver]);
 
-    const handleApplyEnableBilling = async () => {
+    const handleEnableBilling = async () => {
         resetEnableBilling();
-        await setEnableBilling([billingForm.state.values.enableBilling]);
-        setSubmittedEnableBilling(billingForm.state.values.enableBilling);
-        billingForm.reset(billingForm.state.values);
+        await setEnableBilling([]);
     };
 
     if (billingConfigLoading) {
@@ -190,55 +172,27 @@ export const Billing = ({ systemToken, systemTokenLoading }: BillingProps) => {
                     </div>
                 </form>
 
-                <form
-                    onSubmit={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        handleApplyEnableBilling();
-                    }}
-                >
-                    <billingForm.AppField name="enableBilling">
-                        {(field) => (
-                            <>
-                                <field.CheckboxField
-                                    label="Enable billing"
-                                    disabled={!hasFeeReceiverAccount}
-                                />
-                                <billingForm.Subscribe
-                                    selector={(state) =>
-                                        state.values.enableBilling
-                                    }
-                                >
-                                    {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                                    {(enableBilling: any) => {
-                                        const isApplyEnabled =
-                                            submittedEnableBilling !== null &&
-                                            enableBilling !==
-                                                submittedEnableBilling;
-                                        return (
-                                            <div className="mt-2">
-                                                {enableBillingTxError && (
-                                                    <p className="text-destructive mb-2 text-sm">
-                                                        {enableBillingTxError}
-                                                    </p>
-                                                )}
-                                                <Button
-                                                    type="submit"
-                                                    disabled={
-                                                        !hasFeeReceiverAccount ||
-                                                        !isApplyEnabled
-                                                    }
-                                                >
-                                                    Apply
-                                                </Button>
-                                            </div>
-                                        );
-                                    }}
-                                </billingForm.Subscribe>
-                            </>
+                {billingConfig?.enabled ? (
+                    <div>
+                        <Label>Billing</Label>
+                        <p className="mt-1 text-sm">Enabled</p>
+                    </div>
+                ) : (
+                    <div>
+                        {enableBillingTxError && (
+                            <p className="text-destructive mb-2 text-sm">
+                                {enableBillingTxError}
+                            </p>
                         )}
-                    </billingForm.AppField>
-                </form>
+                        <Button
+                            type="button"
+                            disabled={!hasFeeReceiverAccount}
+                            onClick={handleEnableBilling}
+                        >
+                            Enable billing
+                        </Button>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/packages/user/Config/ui/src/hooks/use-set-enable-billing.tsx
+++ b/packages/user/Config/ui/src/hooks/use-set-enable-billing.tsx
@@ -6,7 +6,7 @@ import { queryClient } from "@shared/lib/query-client";
 import { usePluginMutation } from "./use-plugin-mutation";
 
 export const useSetEnableBilling = () =>
-    usePluginMutation<[boolean]>(
+    usePluginMutation<[]>(
         {
             service: CONFIG,
             method: "enableBilling",
@@ -17,21 +17,19 @@ export const useSetEnableBilling = () =>
             loading: "Setting enable billing.",
             success: "Set enable billing",
             isStagable: true,
-            onSuccess: (params, _status) => {
-                const enabled = params[0];
+            onSuccess: () => {
                 const updater = (
                     old:
                         | { feeReceiver: string | null; enabled: boolean }
                         | undefined,
                 ) => {
-                    if (!old) return { feeReceiver: null, enabled };
-                    return { ...old, enabled };
+                    if (!old) return { feeReceiver: null, enabled: true };
+                    return { ...old, enabled: true };
                 };
                 queryClient.setQueryData(
                     [...QueryKey.virtualServer(), "billingConfig"],
                     updater,
                 );
-                // useBillingConfig (shared) uses key ["billingConfig"]; keep cache in sync
                 queryClient.setQueryData(["billingConfig"], updater);
             },
         },

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -100,11 +100,9 @@ pub struct BufferConfig {
 /// 2 - Call `init_billing`: Initializes the billing system. To call this, the system token
 ///     must have already been set in the `Tokens` service. The specified `fee_receiver` will
 ///     receive all of the system token fees paid for resources by users.
-/// 3 - Call `enable_billing(true, Some(payer))`: When ready, calling this action enables the
-///     billing system. Two requirements: (a) the caller must have already filled their resource
-///     buffer because this action is itself billed, and (b) `payer` must have credited sufficient
-///     system tokens to this service to settle any net disk consumption that accumulated while
-///     billing was disabled (see the `enableBillingCost` GraphQL query for the required amount).
+/// 3 - Call `enable_billing(true)`: When ready, calling this action enables the
+///     billing system. The caller must have already filled their resource buffer because
+///     this action is itself billed.
 ///
 /// > Note: typically, step 1 should be called at system boot, and therefore the network should
 /// >       always at least have some server specs and derived network specs.
@@ -173,12 +171,8 @@ mod service {
     /// If billing is disabled, resource consumption will still be tracked, but the resources will
     /// not be automatically metered by the network. This is insecure and allows users to abuse
     /// the network by consuming all of the network's resources.
-    ///
-    /// `payer` is required only when `enabled = true`: that account must have previously credited
-    /// sufficient system tokens to this service to cover the settlement cost of any net disk
-    /// consumption that occurred while billing was disabled.
     #[action]
-    fn enable_billing(enabled: bool, payer: Option<AccountNumber>) {
+    fn enable_billing(enabled: bool) {
         unimplemented!()
     }
 

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -100,7 +100,7 @@ pub struct BufferConfig {
 /// 2 - Call `init_billing`: Initializes the billing system. To call this, the system token
 ///     must have already been set in the `Tokens` service. The specified `fee_receiver` will
 ///     receive all of the system token fees paid for resources by users.
-/// 3 - Call `enable_billing(true)`: When ready, calling this action enables the
+/// 3 - Call `enable_billing`: When ready, calling this action enables the
 ///     billing system. The caller must have already filled their resource buffer because
 ///     this action is itself billed.
 ///
@@ -227,13 +227,9 @@ mod service {
         unimplemented!()
     }
 
-    /// Enable or disable the billing system
-    ///
-    /// If billing is disabled, resource consumption will still be tracked, but the resources will
-    /// not be automatically metered by the network. This is insecure and allows users to abuse
-    /// the network by consuming all of the network's resources.
+    /// Enable the billing system
     #[action]
-    fn enable_billing(enabled: bool) {
+    fn enable_billing() {
         unimplemented!()
     }
 

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -40,7 +40,7 @@ pub struct BufferConfig {
     pub capacity: u64,
 }
 
-/// Virtual Server Service
+/// # Virtual Server Service
 ///
 /// This service defines a "virtual server" that represents the subset of a real server that
 /// a node operator dedicates to running their network node. A user then interacts with one
@@ -61,8 +61,8 @@ pub struct BufferConfig {
 /// | |  Virtual Server 1  | |  | |  Virtual Server 2  | |  | |  Virtual Server 3  | |
 /// | |  10 Gbps network   | |  | |  10 Gbps network   | |  | |  10 Gbps network   | |
 /// | |    100 GB disk     | |  | |    100 GB disk     | |  | |    100 GB disk     | |
-/// | '---------+----------' |  | '---------+----------' |  | '--------------------' |
-/// '-----------|------------'  '-----------|------------'  '-----------+------------'
+/// | '---------+----------' |  | '---------+----------' |  | '---------+----------' |
+/// '-----------|------------'  '-----------|------------'  '-----------|------------'
 ///             |                           |                           |
 ///             |                           V                           |
 ///             |        .--------------------------------------.       |
@@ -110,6 +110,67 @@ pub struct BufferConfig {
 /// After each of the above steps, the billing service will be enabled, and users will be
 /// required to buy resources to transact with the network. Use the other actions in this
 /// service to manage server specs, network variables, and billing parameters, as needed.
+///
+/// ## Curve under-collateralization
+///
+/// Capacity limited resources are managed via a constant-product curve that reports the quantity
+/// of reserve tokens required to be held as collateral for the current utilization levels of the
+/// resource.
+///
+/// This service attempts to balance the required collateral as reported by the state of the curve
+/// with the actual collateral as measured by the relay subaccount token balance. The curve for a
+/// capacity-limited resource can be undercollateralized in certain well-defined scenarios (e.g.
+/// consumption before billing is enabled).
+///
+/// An undercollateralized curve is recollateralized over time using the fees that would otherwise
+/// be sent to the fee receiver.
+///
+/// Example disk recollateralization flow diagram (simplified for clarity) for a transaction that
+/// frees bytes:
+///
+/// ```text
+///             .---------------.
+///            (   free bytes    )
+///             '-------+-------'
+///                     |
+///                     v
+///          +--------------------------+
+///          | Reduces curve shortfall  |
+///          +-----------+--------------+
+///                      |
+///                      v
+///                 .----------.
+///                /            \
+///       No      /   curve has  \     Yes
+///     .--------(   collateral?  )--------.
+///     |         \              /          |
+///     |          \            /           |
+///     v           '----------'            v
+///  .-----.                      +--------------------+
+/// (  End  )                     |  Calc user refund  |
+///  '-----'                      +---------+----------+
+///                                         |
+///                                         v
+///                               +----------------------+
+///                               | Take fee from refund |
+///                               +---------+------------+
+///                                         |
+///                                         v
+///                               +--------------------+
+///                               |  Send user refund  |
+///                               +---------+----------+
+///                                         |
+///                                         v
+///                                .-----------------.
+///                               /                   \
+///                   yes        /    Curve under-     \        no
+///                 .-----------(   collateralized?     )-----------.
+///                 |            \                     /            |
+///                 v             '-------------------'             v
+///       +--------------------+                        +--------------------------+
+///       |  Add fee to relay  |                        | Send fee to fee receiver |
+///       +--------------------+                        +--------------------------+
+/// ```
 #[crate::service(name = "vserver", dispatch = false, psibase_mod = "crate")]
 #[allow(non_snake_case, unused_variables)]
 mod service {


### PR DESCRIPTION
Before this PR, any disk curve shortfall that accumulated due to system billing was recollateralized over time by taking the fees that would otherwise be sent to the fee receiver, with one exception:

When billing was first enabled, there would be a large undercollateralization due to the initial byte allocations that happened before billing was enabled. Historically this has been handled by requiring the caller of enable-billing to pay for the cost of settling this shortfall atomically with the enabling of billing.

This PR unifies this exception with the normal recollateralization strategy.

To do so, we must do the following:
* After measuring the preallocated bytes, we immediately update the curve to acknowledge the consumption.
* When billing is enabled, we "do nothing" (remove the code that required a payment and instantaneously settled). 

With these changes, the consumed capacity on the curve already represents the full tally of bytes that have been written. The curve reports a large shortfall, and will slowly recollateralize over time from fee-receiver fees.