### PR TITLE
Homogenizing/Correcting DiffAdjust's use of `activity`

### DIFF
--- a/packages/user/DiffAdjust/service/src/lib.rs
+++ b/packages/user/DiffAdjust/service/src/lib.rs
@@ -18,7 +18,7 @@ pub mod tables {
         #[primary_key]
         pub nft_id: u32,
         pub window_seconds: u32,
-        pub counter: u32,
+        pub activity_count: u32,
         pub target_min: u32,
         pub target_max: u32,
         pub floor_difficulty: u64,
@@ -45,7 +45,7 @@ pub mod tables {
             Self {
                 nft_id,
                 active_difficulty: initial_difficulty,
-                counter: 0,
+                activity_count: 0,
                 floor_difficulty,
                 target_min,
                 target_max,
@@ -190,9 +190,9 @@ pub mod tables {
             let seconds_elapsed = (now.seconds - self.last_update.seconds).max(0) as u32;
             let windows_elapsed = seconds_elapsed / self.window_seconds;
             if windows_elapsed > 0 {
-                let below_target = self.counter < self.target_min;
+                let below_target = self.activity_count < self.target_min;
                 let seconds_remainder = seconds_elapsed % self.window_seconds;
-                self.counter = 0;
+                self.activity_count = 0;
                 self.last_update = TimePointSec::from(now.seconds - seconds_remainder as i64);
                 if below_target {
                     let factor = 1.0 - self.ratio_decrease();
@@ -208,30 +208,30 @@ pub mod tables {
         }
 
         fn check_difficulty_increase(&mut self, clamp_increase: bool) -> u64 {
-            if self.counter > self.target_max {
+            if self.activity_count > self.target_max {
                 let factor = 1.0 + self.ratio_increase();
-                // `target_max` events accumulate with no adjustment; the next event triggers
-                //   one. So one adjustment is applied per `target_max + 1` events, and the
-                //   cumulative adjustments for `events` in a window is
-                //   floor(events / (target_max + 1)).
-                // The remainder is carried in `counter` so a batched
+                // `target_max` activity accumulates with no adjustment; the next unit triggers
+                //   one. So one adjustment is applied per `target_max + 1` activity, and the
+                //   cumulative adjustments for `activity_count` in a window is
+                //   floor(activity_count / (target_max + 1)).
+                // The remainder is carried in `activity_count` so a batched
                 //   increment produces the same result as the equivalent single increments.
                 // (u64 math avoids overflow when target_max == u32::MAX.)
-                let events_per_adjustment = self.target_max as u64 + 1;
-                let mut adjustments = (self.counter as u64 / events_per_adjustment) as u32;
+                let activity_per_adjustment = self.target_max as u64 + 1;
+                let mut adjustments = (self.activity_count as u64 / activity_per_adjustment) as u32;
                 if clamp_increase {
                     adjustments = adjustments.min(1);
                 }
                 self.active_difficulty =
                     Self::apply_increase(self.active_difficulty, factor, adjustments);
-                self.counter = if clamp_increase {
+                self.activity_count = if clamp_increase {
                     0
                 } else {
-                    (self.counter as u64 % events_per_adjustment) as u32
+                    (self.activity_count as u64 % activity_per_adjustment) as u32
                 };
                 // The update is happening "mid block", so we round up to the next second. In other words,
                 // updates happens at the "end" of the block. Without this, a one-second block window would
-                // cause a decrease every block, because an increase zeroes out the counter, so each block
+                // cause a decrease every block, because an increase zeroes out the activity_count, so each block
                 // would consider a window to have elapsed.
                 self.last_update =
                     TransactSvc::call().currentBlock().time.seconds() + psibase::Seconds::new(1);
@@ -251,10 +251,10 @@ pub mod tables {
             check(self.consumer == get_sender(), "must be consumer");
         }
 
-        pub fn increment(&mut self, increment_amount: u32) -> u64 {
+        pub fn increment(&mut self, activity: u32) -> u64 {
             self.check_sender_is_consumer();
             let difficulty = self.check_difficulty_decrease();
-            self.counter = self.counter.saturating_add(increment_amount);
+            self.activity_count = self.activity_count.saturating_add(activity);
             self.check_difficulty_increase(false);
             self.save();
             difficulty
@@ -376,10 +376,10 @@ pub mod service {
 
     /// Increment RateLimit instance, potentially increasing the difficulty.
     ///
-    /// `target_max` events accumulate with no adjustment, and the next event triggers one,
-    ///   so the number of adjustments for `events` accumulated in the window is
-    ///   `floor(events / (target_max + 1))`. Adjustments therefore land every
-    ///   `target_max + 1` events (and `target_max == 0` means every event adjusts). A single
+    /// `target_max` activity accumulates with no adjustment, and the next unit triggers one,
+    ///   so the number of adjustments for `activity_count` accumulated in the window is
+    ///   `floor(activity_count / (target_max + 1))`. Adjustments therefore land every
+    ///   `target_max + 1` activity (and `target_max == 0` means every unit adjusts). A single
     ///   large increment may apply multiple adjustments at once, matching the equivalent
     ///   sequence of single increments (the remainder is carried across calls).
     ///
@@ -389,7 +389,7 @@ pub mod service {
     ///
     /// # Arguments
     /// * `nft_id` - RateLimit / NFT ID
-    /// * `amount` - Amount to increment the counter by
+    /// * `amount` - Amount to increment the activity_count by
     #[action]
     fn increment(nft_id: u32, amount: u32) -> u64 {
         RateLimit::get_assert(nft_id).increment(amount)
@@ -401,8 +401,8 @@ pub mod service {
     ///
     /// # Arguments
     /// * `nft_id` - RateLimit / NFT ID
-    /// * `target_min` - Minimum target difficulty
-    /// * `target_max` - Maximum target difficulty
+    /// * `target_min` - Minimum target activity
+    /// * `target_max` - Maximum target activity
     #[action]
     fn set_targets(nft_id: u32, target_min: u32, target_max: u32) {
         RateLimit::get_assert(nft_id).set_targets(target_min, target_max);

--- a/packages/user/DiffAdjust/service/src/tests/adjustment.rs
+++ b/packages/user/DiffAdjust/service/src/tests/adjustment.rs
@@ -34,7 +34,7 @@ fn test_diff_adjust_basic(mut chain: psibase::Chain) -> Result<(), psibase::Erro
     // 7 sales increases the Difficulty by 5%
     assert_eq!(Wrapper::push(&chain).get_diff(nft_id).get()?, 2992);
 
-    // Adjustments = floor(events / (target_max + 1)). The 7 sales above left no remainder
+    // Adjustments = floor(activity_count / (target_max + 1)). The 7 sales above left no remainder
     // (7 % 7 == 0), so these 18 sales give floor(18 / 7) = 2 steps (5% x 2 on top of 2992).
     chain.start_block_after(Seconds::new(5).into());
 
@@ -72,15 +72,15 @@ fn test_asymmetric_ppm(mut chain: psibase::Chain) -> Result<(), psibase::Error> 
     Ok(())
 }
 
-/// Verifies the core rule across targets: `target` events accumulate with no adjustment and
-/// the next event triggers one, so the number of difficulty steps for `events` accumulated in
-/// a window is `floor(events / (target + 1))` (which makes `target == 0` adjust every event).
+/// Verifies the core rule across targets: `target` activity accumulates with no adjustment and
+/// the next unit triggers one, so the number of difficulty steps for `activity_count` accumulated in
+/// a window is `floor(activity_count / (target + 1))` (which makes `target == 0` adjust every unit).
 ///
 /// This reproduces the NameMarket / Symbol usage pattern (`increment(nft, 1)` once per
-/// purchase). For example with `target = 3` the steps land on events 4, 8, 12, ... :
-///   events 1-3 -> 0 steps, events 4-7 -> 1, events 8-11 -> 2, event 12 -> 3.
+/// purchase). For example with `target = 3` the steps land on activity 4, 8, 12, ... :
+///   activity 1-3 -> 0 steps, activity 4-7 -> 1, activity 8-11 -> 2, activity 12 -> 3.
 #[psibase::test_case(packages("DiffAdjust"))]
-fn test_adjustment_count_matches_floor_events_over_target_plus_one(
+fn test_adjustment_count_matches_floor_activity_over_target_plus_one(
     mut chain: psibase::Chain,
 ) -> Result<(), psibase::Error> {
     chain.set_auto_block_start(false);
@@ -103,7 +103,7 @@ fn test_adjustment_count_matches_floor_events_over_target_plus_one(
         }
         d
     };
-    let expected_steps = |target: u32, events: u32| -> u32 { events / (target + 1) };
+    let expected_steps = |target: u32, activity: u32| -> u32 { activity / (target + 1) };
 
     for target in [0u32, 1, 2, 3, 5] {
         let nft_id = Wrapper::push_from(&chain, alice)
@@ -111,16 +111,16 @@ fn test_adjustment_count_matches_floor_events_over_target_plus_one(
             .get()?;
         chain.start_block();
 
-        let total_events = target.max(1) * 3 + 1;
-        for events in 1..=total_events {
+        let total_activity = target.max(1) * 3 + 1;
+        for activity in 1..=total_activity {
             Wrapper::push_from(&chain, alice)
                 .increment(nft_id, 1)
                 .get()?;
             chain.start_block();
             assert_eq!(
                 Wrapper::push(&chain).get_diff(nft_id).get()?,
-                diff_after_steps(expected_steps(target, events)),
-                "target={target}: wrong difficulty after {events} events"
+                diff_after_steps(expected_steps(target, activity)),
+                "target={target}: wrong difficulty after {activity} activity"
             );
         }
     }
@@ -156,13 +156,13 @@ fn test_target_zero_increase_every_event(mut chain: psibase::Chain) -> Result<()
     Ok(())
 }
 
-/// The counter remainder must be CARRIED across increments (not reset to 0). A series of
+/// The activity_count remainder must be CARRIED across increments (not reset to 0). A series of
 /// individually-below-threshold batches must still earn the adjustments that their
-/// cumulative event count deserves, and a batched increment must match the same events fed
+/// cumulative activity count deserves, and a batched increment must match the same activity fed
 /// one at a time.
 ///
-/// With `target = 3` (one adjustment per `target + 1 = 4` events), four increments of 3
-/// (12 events) trace the counter as: 3 (no step) -> 6 (1 step, carry 2) -> 5 (1 step,
+/// With `target = 3` (one adjustment per `target + 1 = 4` activity), four increments of 3
+/// (12 activity) trace the activity_count as: 3 (no step) -> 6 (1 step, carry 2) -> 5 (1 step,
 /// carry 1) -> 4 (1 step, carry 0), i.e. 3 steps. A reset-to-0 implementation would instead
 /// fire only on the 2nd and 4th batch (2 steps) and silently drop the carried remainder.
 #[psibase::test_case(packages("DiffAdjust"))]
@@ -199,7 +199,7 @@ fn test_remainder_carries_across_batches(mut chain: psibase::Chain) -> Result<()
         assert_eq!(Wrapper::push(&chain).get_diff(batched).get()?, expected);
     }
 
-    // The same 12 events, one at a time, must land on the identical difficulty (11_576).
+    // The same 12 activity, one at a time, must land on the identical difficulty (11_576).
     let mut individual_diff = INITIAL;
     for _ in 0..12 {
         Wrapper::push_from(&chain, alice)
@@ -210,7 +210,7 @@ fn test_remainder_carries_across_batches(mut chain: psibase::Chain) -> Result<()
     }
     assert_eq!(
         individual_diff, 11_576,
-        "batched increments must equal the same events fed one at a time"
+        "batched increments must equal the same activity fed one at a time"
     );
 
     Ok(())

--- a/packages/user/DiffAdjust/service/src/tests/limits.rs
+++ b/packages/user/DiffAdjust/service/src/tests/limits.rs
@@ -80,7 +80,9 @@ fn test_decrease_ppm_rejected_above_100_percent(
 }
 
 #[psibase::test_case(packages("DiffAdjust"))]
-fn test_saturated_difficulty_and_counter(mut chain: psibase::Chain) -> Result<(), psibase::Error> {
+fn test_saturated_difficulty_and_activity_count(
+    mut chain: psibase::Chain,
+) -> Result<(), psibase::Error> {
     chain.set_auto_block_start(false);
 
     let alice = account!("alice");
@@ -102,7 +104,7 @@ fn test_saturated_difficulty_and_counter(mut chain: psibase::Chain) -> Result<()
     chain.start_block();
     assert_eq!(Wrapper::push(&chain).get_diff(nft_id).get()?, u64::MAX);
 
-    // Counter saturates at u32::MAX instead of wrapping; difficulty still caps at u64::MAX.
+    // activity_count saturates at u32::MAX instead of wrapping; difficulty still caps at u64::MAX.
     let nft_id = Wrapper::push_from(&chain, alice)
         .create(1000, 60, 5, 5, 1, u32::MAX, 50_000)
         .get()?;

--- a/packages/user/DiffAdjust/service/src/tests/windows.rs
+++ b/packages/user/DiffAdjust/service/src/tests/windows.rs
@@ -50,7 +50,7 @@ fn test_one_second_window(mut chain: psibase::Chain) -> Result<(), psibase::Erro
     // Blocks: [0] [1] [2] [3] [4] [5] [6] [7] [8]
     //                      ^current_block
     //                          ^last_update
-    assert_eq!(get_diff_2(nft_id)?, 300); // It increments immediately since counter exceeded target, which also
+    assert_eq!(get_diff_2(nft_id)?, 300); // It increments immediately since activity_count exceeded target, which also
                                           // sets the last_update (window reset)
     chain.start_block();
     // Blocks: [0] [1] [2] [3] [4] [5] [6] [7] [8]
@@ -79,14 +79,14 @@ fn test_one_second_window(mut chain: psibase::Chain) -> Result<(), psibase::Erro
     //                                      ^current_block
     //                                      ^last_update
 
-    // The 6 + 7 = 13 events above gave floor(13 / (5 + 1)) = 2 steps and leave a carried
-    // counter of 1 (13 % 6 == 1), so a single extra event keeps the counter below the next
+    // The 6 + 7 = 13 activity above gave floor(13 / (5 + 1)) = 2 steps and leave a carried
+    // activity_count of 1 (13 % 6 == 1), so a single extra unit keeps the activity_count below the next
     // step threshold (target_max + 1 = 6).
     Wrapper::push_from(&chain, alice).increment(nft_id, 1);
     // Blocks: [0] [1] [2] [3] [4] [5] [6] [7] [8]
     //                                      ^current_block
-    //                                      ^last_update - window not reset because the counter stayed below target
-    assert_eq!(get_diff(nft_id)?, 108); // difficulty also not changed: counter (2) did not exceed target_max
+    //                                      ^last_update - window not reset because the activity_count stayed below target
+    assert_eq!(get_diff(nft_id)?, 108); // difficulty also not changed: activity_count (2) did not exceed target_max
     chain.start_block();
     // Blocks: [0] [1] [2] [3] [4] [5] [6] [7] [8]
     //                                          ^current_block

--- a/rust/psibase/src/services/diff_adjust.rs
+++ b/rust/psibase/src/services/diff_adjust.rs
@@ -8,18 +8,18 @@
 //!
 //! # Mechanics
 //!
-//! The service operates on a time-windowed counter system:
+//! The service operates on a time-windowed activity count:
 //!
-//! 1. **Activity Tracking**: A consumer account increments a counter each time an action occurs.
-//!    The counter accumulates activity within a configurable time window.
+//! 1. **Activity Tracking**: A consumer account increments `activity_count` each time an action
+//!    occurs. `activity_count` accumulates within a configurable time window.
 //!
 //! 2. **Difficulty Adjustment**:
-//!    - **Below Target**: If the counter is below `target_min` when a window elapses, the
+//!    - **Below Target**: If `activity_count` is below `target_min` when a window elapses, the
 //!      difficulty decreases by a configured percentage (subject to a floor value).
-//!    - **Above Target**: If the counter exceeds `target_max` at any point, the difficulty
-//!      immediately increases by a configured percentage, the counter resets, and a new window
-//!      begins. If one increment pushes the counter past `target_max` by one or more whole multiples
-//!      of `target_max`, the difficulty is increased by the configured percentage once per multiple.
+//!    - **Above Target**: If `activity_count` exceeds `target_max` at any point, the difficulty
+//!      immediately increases by a configured percentage, `activity_count` resets, and a new window
+//!      begins. If one increment pushes `activity_count` past `target_max` by one or more whole
+//!      multiples of `target_max`, the difficulty is increased by the configured percentage once per multiple.
 //!
 //! 3. **Window-Based Decay**: After each window period (`window_seconds`), if activity was below
 //!    the minimum target, difficulty decays proportionally for each complete window that elapsed.
@@ -32,7 +32,7 @@
 //! - **Admin**: The NFT owner can configure all parameters (targets, window, percentages, floor).
 //!   The NFT is initially minted to the account that creates the rate limiter, but can be
 //!   transferred to change administration.
-//! - **Consumer**: The account designated at creation time can increment the counter and query
+//! - **Consumer**: The account designated at creation time can increment the activity_count and query
 //!   difficulty. The consumer is automatically set to the account that calls `create()` and cannot
 //!   be changed after creation. Initially, the creator is both admin and consumer, but the admin
 //!   role can be transferred via NFT ownership while the consumer remains fixed.
@@ -52,7 +52,7 @@ pub mod Service {
         #[primary_key]
         pub nft_id: u32,
         pub window_seconds: u32,
-        pub counter: u32,
+        pub activity_count: u32,
         pub target_min: u32,
         pub target_max: u32,
         pub floor_difficulty: u64,
@@ -100,7 +100,7 @@ pub mod Service {
 
     /// Increment RateLimit instance, potentially increasing the difficulty.
     ///
-    /// The difficulty may increase multiple times if the counter exceeds `target_max`
+    /// The difficulty may increase multiple times if `activity_count` exceeds `target_max`
     ///   by more than one multiple of `target_max`.
     ///
     /// Returns the difficulty before any difficulty adjustment due to the increment.
@@ -109,7 +109,7 @@ pub mod Service {
     ///
     /// # Arguments
     /// * `nft_id` - RateLimit / NFT ID
-    /// * `amount` - Amount to increment the counter by
+    /// * `amount` - Amount to increment the activity_count by
     #[action]
     fn increment(nft_id: u32, amount: u32) -> u64 {
         unimplemented!()
@@ -121,8 +121,8 @@ pub mod Service {
     ///
     /// # Arguments
     /// * `nft_id` - RateLimit / NFT ID
-    /// * `target_min` - Minimum target difficulty
-    /// * `target_max` - Maximum target difficulty
+    /// * `target_min` - Minimum target activity
+    /// * `target_max` - Maximum target activity
     #[action]
     fn set_targets(nft_id: u32, target_min: u32, target_max: u32) {
         unimplemented!()


### PR DESCRIPTION
`activity` now uniformly replaces `difficulty` (where used wrong), `events` (in the branch this is built on), and `counter`.