### PR TITLE
Limit block size

### DIFF
--- a/libraries/psibase/common/include/psibase/Table.hpp
+++ b/libraries/psibase/common/include/psibase/Table.hpp
@@ -882,7 +882,7 @@ namespace psibase
       ///
       /// This is equivalent to looking an object up by the key, then
       /// calling [remove] if found. The key must be the primary key.
-      template <compatible_key<key_type> Key>
+      template <compatible_key<key_type> Key = key_type>
       void erase(Key&& key)
       {
          if constexpr (sizeof...(Secondary) == 0)

--- a/packages/system/Transact/include/services/system/RTransact.hpp
+++ b/packages/system/Transact/include/services/system/RTransact.hpp
@@ -239,6 +239,15 @@ namespace SystemService
    using TxStatsTable = psibase::Table<TxStatsRecord, psibase::SingletonKey{}>;
    PSIO_REFLECT_TYPENAME(TxStatsTable)
 
+   // This is used to limit the size of blocks before the chain
+   struct BlockSizeRecord
+   {
+      uint32_t currentBlockSize;
+   };
+   PSIO_REFLECT(BlockSizeRecord, currentBlockSize)
+   using BlockSizeTable = psibase::Table<BlockSizeRecord, psibase::SingletonKey{}>;
+   PSIO_REFLECT_TYPENAME(BlockSizeTable)
+
    // Transactions enter this service through the push_transaction endpoint
    // or over p2p (recv). Speculative execution and signature verification
    // are dispatched asynchronously. When they complete, the transaction
@@ -261,7 +270,8 @@ namespace SystemService
       using WriteOnly               = psibase::WriteOnlyTables<UnappliedTransactionTable,
                                                                ReversibleBlocksTable,
                                                                TxSuccessTable,
-                                                               VerifyIdTable>;
+                                                               VerifyIdTable,
+                                                               BlockSizeTable>;
 
       std::optional<psibase::SignedTransaction>                    next();
       std::optional<std::vector<std::optional<psibase::RunToken>>> preverify(

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -6,6 +6,7 @@
 #include <services/system/RTransact.hpp>
 #include <services/system/SetCode.hpp>
 #include <services/system/Transact.hpp>
+#include <services/system/VirtualServer.hpp>
 
 #include <functional>
 #include <psibase/HttpHeaders.hpp>
@@ -60,11 +61,37 @@ namespace
       return to<Transact>().checkFirstAuth(id, *trx.transaction);
    }
 
+   bool isResMonitoring()
+   {
+      auto table  = Transact{}.open<ResMonitoringConfigTable>(KvMode::read);
+      auto config = table.get({});
+      return config && config->enabled;
+   }
 }  // namespace
 
 std::optional<SignedTransaction> SystemService::RTransact::next()
 {
    check(getSender() == AccountNumber{}, "Wrong sender");
+   if (isResMonitoring())
+   {
+      if (!to<VirtualServer>().can_push_tx())
+      {
+         return {};
+      }
+   }
+   else
+   {
+      // Soft limit for boot blocks (hard limit imposed by triedent
+      // is 16 MiB for the packed block)
+      constexpr std::uint32_t blockLimit = 8 * 1024 * 1024;
+      if (auto sizeRow = open<BlockSizeTable>().get({}))
+      {
+         if (sizeRow->currentBlockSize >= blockLimit)
+         {
+            return {};
+         }
+      }
+   }
    auto unapplied    = WriteOnly{}.open<UnappliedTransactionTable>();
    auto reverify     = open<ReverifySignaturesTable>();
    auto nextSequence = unapplied.get({}).value_or(UnappliedTransactionRecord{0}).nextSequence;
@@ -674,6 +701,19 @@ void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> 
       row = clients.get(id);
    }
 
+   if (!isResMonitoring())
+   {
+      auto          table   = open<BlockSizeTable>();
+      auto          sizeRow = table.get({}).value_or(BlockSizeRecord{0});
+      std::uint32_t txSize;
+      PSIBASE_SUBJECTIVE_TX
+      {
+         txSize = open<TransactionDataTable>().getView(id).size();
+      }
+      sizeRow.currentBlockSize += txSize;
+      table.put(sizeRow);
+   }
+
    if (row)
    {
       waitForApplied = std::ranges::any_of(row->clients, WaitFor::isApplied);
@@ -719,6 +759,11 @@ void RTransact::onBlock()
    check(stat && stat->head, "Head block should be set before calling onBlock");
 
    checkReverify(stat->head->blockId);
+
+   if (!isResMonitoring())
+   {
+      open<BlockSizeTable>().erase({});
+   }
 
    auto finalized = finalizeBlocks(stat->head->header);
    if (!finalized)

--- a/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
+++ b/packages/system/VirtualServer/service/cpp/include/services/system/VirtualServer.hpp
@@ -267,6 +267,9 @@ namespace SystemService
 
       UserService::Quantity get_resources(psibase::AccountNumber user);
 
+      /// Whether the current block can hold another transaction
+      bool can_push_tx();
+
       void notifyBlock(psibase::BlockNum block_num);
 
       /// This action specifies which account is primarily responsible for
@@ -328,6 +331,7 @@ namespace SystemService
                 method(useNetSys, user, amount_bytes),
                 method(useCpuSys, user, amount_ns),
                 method(get_resources, user),
+                method(can_push_tx),
                 method(notifyBlock, block_num),
                 method(setBillableAcc, account),
                 method(serveSys, request, socket, user))

--- a/packages/system/VirtualServer/service/src/lib.rs
+++ b/packages/system/VirtualServer/service/src/lib.rs
@@ -552,6 +552,12 @@ mod service {
             .unwrap_or(0.into())
     }
 
+    /// Whether the current block can hold another transaction
+    #[action]
+    fn can_push_tx() -> bool {
+        BandwidthPricing::get(NET).map_or(true, |n| !n.is_full())
+    }
+
     #[action]
     fn notifyBlock(block_num: BlockNum) {
         check(get_sender() == Transact::SERVICE, "Unauthorized");

--- a/packages/system/VirtualServer/service/src/tables/bandwidth_pricing.rs
+++ b/packages/system/VirtualServer/service/src/tables/bandwidth_pricing.rs
@@ -267,6 +267,10 @@ impl BandwidthPricing {
     pub fn get_billable_unit(&self) -> u64 {
         self.billable_unit
     }
+
+    pub fn is_full(&self) -> bool {
+        self.current_usage >= capacity(self.resource_id)
+    }
 }
 
 #[derive(SimpleObject)]

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -369,6 +369,12 @@ mod service {
         unimplemented!()
     }
 
+    /// Whether the current block can hold another transaction
+    #[action]
+    fn can_push_tx() -> bool {
+        unimplemented!()
+    }
+
     #[action]
     fn notifyBlock(block_num: BlockNum) {
         unimplemented!()


### PR DESCRIPTION
With a release build, blocks could become too large for triedent.

Transaction are only applied when the current block size is below the limit. This allows one transaction over the limit, which will trigger price increases in VirtualServer. Before VirtualServer is installed, RTransact imposes a limit of 8MB.