### PR TITLE
Fix null dereference

### DIFF
--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -705,7 +705,7 @@ void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> 
    {
       auto          table   = open<BlockSizeTable>();
       auto          sizeRow = table.get({}).value_or(BlockSizeRecord{0});
-      std::uint32_t txSize;
+      std::uint32_t txSize  = 0;
       PSIBASE_SUBJECTIVE_TX
       {
          if (auto tx = open<TransactionDataTable>().getView(id))

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -708,7 +708,10 @@ void RTransact::onTrx(const Checksum256& id, psio::view<const TransactionTrace> 
       std::uint32_t txSize;
       PSIBASE_SUBJECTIVE_TX
       {
-         txSize = open<TransactionDataTable>().getView(id).size();
+         if (auto tx = open<TransactionDataTable>().getView(id))
+         {
+            txSize = tx.size();
+         }
       }
       sizeRow.currentBlockSize += txSize;
       table.put(sizeRow);


### PR DESCRIPTION
This happens when processing a block containing a transaction that isn't in the queue (e.g. syncing the chain). Aborting `onTrx` is mostly harmless in this case, because there can't be any clients waiting on a response for the transaction.