### PR TITLE
Fix shutdown leak

### DIFF
--- a/libraries/psibase/native/include/psibase/Socket.hpp
+++ b/libraries/psibase/native/include/psibase/Socket.hpp
@@ -39,6 +39,11 @@ namespace psibase
       virtual bool       supportsP2P() const;
       virtual SocketInfo info() const = 0;
 
+      /// Called on shutdown after the io_context is stopped, but
+      /// before it is destroyed. This should destroy all callbacks
+      /// held by the socket.
+      virtual void abandon() noexcept;
+
       void remove(Writer& writer);
       void writeInfo(Writer& writer);
 

--- a/libraries/psibase/native/src/Socket.cpp
+++ b/libraries/psibase/native/src/Socket.cpp
@@ -79,6 +79,8 @@ bool Socket::supportsP2P() const
    return false;
 }
 
+void Socket::abandon() noexcept {}
+
 void AutoCloseSocket::replace(Writer& writer, std::shared_ptr<AutoCloseSocket>&& other)
 {
    if (auto sockets = weak_sockets.lock())
@@ -250,6 +252,10 @@ void Sockets::shutdown()
    stopped         = true;
    auto tmpsockets = std::move(sockets);
    l.unlock();
+   for (const auto& sock : tmpsockets)
+   {
+      sock->abandon();
+   }
    tmpsockets.clear();
 }
 

--- a/libraries/psibase/native/src/Socket.cpp
+++ b/libraries/psibase/native/src/Socket.cpp
@@ -254,7 +254,8 @@ void Sockets::shutdown()
    l.unlock();
    for (const auto& sock : tmpsockets)
    {
-      sock->abandon();
+      if (sock)
+         sock->abandon();
    }
    tmpsockets.clear();
 }

--- a/libraries/psibase_http/http.cpp
+++ b/libraries/psibase_http/http.cpp
@@ -121,12 +121,17 @@ namespace psibase::http
       impl->shutdown_connections(restart);
    }
 
-   void server_service::shutdown() noexcept
+   void server_service::stop() noexcept
    {
       if (impl)
       {
          impl->stop();
       }
+   }
+
+   void server_service::shutdown() noexcept
+   {
+      stop();
    }
 
    // Accepts incoming connections and launches the sessions

--- a/libraries/psibase_http/include/psibase/http.hpp
+++ b/libraries/psibase_http/include/psibase/http.hpp
@@ -255,6 +255,7 @@ namespace psibase::http
                      const std::shared_ptr<const http_config>& http_config,
                      const std::shared_ptr<SharedState>&       sharedState);
       void start();
+      void stop() noexcept;
       void async_close(bool restart, std::function<void()>);
 
       // The result must not be used after the server_service is

--- a/libraries/psibase_http/websocket.hpp
+++ b/libraries/psibase_http/websocket.hpp
@@ -75,6 +75,7 @@ namespace psibase::http
             self->impl  = std::move(impl);
             hasMessages = !self->outbox.empty();
          }
+         self->server.register_connection(self);
          if (hasMessages)
             ptr->writeLoop(std::shared_ptr{self});
          ptr->readLoop(std::move(self));
@@ -247,6 +248,17 @@ namespace psibase::http
             // TODO: propagate code
             server.sharedState->sockets()->asyncClose(*this);
          }
+      }
+
+      static void close(std::shared_ptr<WebSocket>&& self, bool restart)
+      {
+         self->close(restart ? close_code::restart : close_code::shutdown);
+      }
+
+      void abandon() noexcept override
+      {
+         outbox.clear();
+         readCallback = nullptr;
       }
 
       using ChannelAttr = boost::log::attributes::mutable_constant<std::string>;

--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -242,12 +242,12 @@ void from_json(Timeout& obj, auto& stream)
 
 std::filesystem::path option_path;
 ConfigFileOptions     config_options{.expandValue =
-                                     [](std::string_view key)
-                                 {
+                                         [](std::string_view key)
+                                     {
                                     // shell commands are processed by the shell. They should not go
                                     // through another round of expansion.
                                     return !key.ends_with(".command");
-                                 },
+                                     },
                                      .allowUnregistered = true};
 std::filesystem::path parse_path(std::string_view             s,
                                  const std::filesystem::path& context = option_path)
@@ -858,7 +858,7 @@ Perf get_perf(const SharedState& state)
    result.timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
                           std::chrono::steady_clock::now().time_since_epoch())
                           .count();
-   result.memory = getMemStats(state);
+   result.memory    = getMemStats(state);
    for (const auto& entry : std::filesystem::directory_iterator("/proc/self/task"))
    {
       result.tasks.push_back(getThreadInfo(entry, clk_tck));
@@ -1357,11 +1357,10 @@ void run(const std::string&              db_path,
    // is destroyed.
    auto http_config = std::make_shared<http::http_config>();
 
-   // The runQueue needs to out-live the chainContext, so
-   // that notify is safe.
-   RunQueue runQueue{sharedState};
-
+   RunQueue                runQueue{sharedState};
    boost::asio::io_context chainContext;
+
+   auto shutdown_sockets = psio::finally{[&system] { system->sockets->shutdown(); }};
 
    auto server_work = boost::asio::make_work_guard(chainContext);
 
@@ -1495,6 +1494,15 @@ void run(const std::string&              db_path,
               });
        });
 
+   auto stop_threads =
+       psio::finally{[&chainContext, &tpool]
+                     {
+                        tpool.setNumThreads(0);
+                        auto& ectx = static_cast<boost::asio::execution_context&>(chainContext);
+                        if (boost::asio::has_service<http::server_service>(ectx))
+                           boost::asio::use_service<http::server_service>(ectx).stop();
+                     }};
+
    if (!listen.empty())
    {
       // TODO: command-line options
@@ -1503,7 +1511,7 @@ void run(const std::string&              db_path,
       http_config->idle_timeout_us  = http_timeout.duration.count();
       http_config->listen           = listen;
       http_config->status           = http::http_status{
-                    .slow = system->sharedDatabase.isSlow(), .startup = 1, .needgenesis = 1};
+          .slow = system->sharedDatabase.isSlow(), .startup = 1, .needgenesis = 1};
 
       // TODO: speculative execution on non-producers
       http_config->push_boot_async =
@@ -1813,17 +1821,6 @@ void run(const std::string&              db_path,
    }
 
    tpool.setNumThreads(service_threads);
-
-   auto remove_http_handlers = psio::finally{[&http_config, &system]
-                                             {
-                                                {
-                                                   std::lock_guard l{http_config->mutex};
-                                                   http_config->push_boot_async = nullptr;
-                                                }
-                                                {
-                                                   system->sockets->shutdown();
-                                                }
-                                             }};
 
    node.set_producer_id(producer);
    {

--- a/programs/psinode/tests/psinode.py
+++ b/programs/psinode/tests/psinode.py
@@ -75,6 +75,9 @@ class Cluster(object):
         result = Node(dir=os.path.join(self.dir, hostname), hostname=hostname, producer=name, **kw)
         self.nodes[hostname] = result
         return result
+    def disconnected(self, *names, **kw):
+        '''Create a set of nodes with no connections'''
+        return tuple(self.make_node(name, **kw) for name in names)
     def star(self, *names, **kw):
         '''Create a star graph with the first node in the center'''
         nodes = [self.make_node(name, **kw) for name in names]
@@ -449,7 +452,7 @@ def _init_softhsm(dir, pin):
     return env
 
 class Node(API):
-    def __init__(self, executable='psinode', dir=None, hostname=None, producer=None, p2p=True, listen=[], log_filter=None, log_format=None, database_cache_size=None, start=True, softhsm=None, trustfile=None):
+    def __init__(self, executable='psinode', dir=None, hostname=None, producer=None, p2p=True, listen=[], log_filter=None, log_format=None, database_cache_size=None, start=True, softhsm=None, trustfile=None, env={}):
         '''
         Create a new psinode server
         If dir is not specified, the server will reside in a temporary directory
@@ -464,7 +467,7 @@ class Node(API):
         self.producer = producer
         self.socketpath = os.path.join(self.dir, 'socket')
         self.logpath = os.path.join(self.dir, 'psinode.log')
-        self.env = {}
+        self.env = dict(env)
         session = requests.Session()
         session.mount('http://', _LocalAdapter(self.socketpath))
         super().__init__('http://%s/' % hostname, session)

--- a/programs/psinode/tests/test_exception_exit.py
+++ b/programs/psinode/tests/test_exception_exit.py
@@ -102,13 +102,17 @@ class TestExceptionExit(unittest.TestCase):
                 reply.raise_for_status()
 
             url = websocket_url(a, '/', service='x-proxy')
-            async with websockets.unix_connect(a.socketpath, url, compression=None) as websocket:
-                # Send a round-trip message, to make sure that the connection
-                # is fully established
-                await websocket.send(expected)
-                self.assertEqual(await websocket.recv(), expected)
+            try:
+                async with websockets.unix_connect(a.socketpath, url, compression=None) as websocket:
+                    # Send a round-trip message, to make sure that the connection
+                    # is fully established
+                    await websocket.send(expected)
+                    self.assertEqual(await websocket.recv(), expected)
 
-                self.cause_exception(a)
+                    self.cause_exception(a)
+            except websocket.exceptions.ConnectionClosedError:
+                # the connection is closed abnormally when the node exits
+                pass
 
     @testutil.psinode_test
     def test_incoming_p2p(self, cluster):

--- a/programs/psinode/tests/test_exception_exit.py
+++ b/programs/psinode/tests/test_exception_exit.py
@@ -9,11 +9,14 @@ from psibase import *
 from threading import Thread
 from requests import ConnectionError
 
-# This test is most useful when run with ASAN_OPTIONS=abort_on_error=1
+# Since this test stops psinode with an error, we want
+# sanitizer errors to cause a signal instead to fail the test.
+ENV = {'ASAN_OPTIONS': 'abort_on_error=1'}
+
 class TestExceptionExit(unittest.TestCase):
     @testutil.psinode_test
     def test_socket(self, cluster):
-        (a,) = cluster.complete('a')
+        (a,) = cluster.complete('a', env=ENV)
         a.boot(packages=['Minimal', 'Explorer'])
         a.install(packages=['KeepSocket'], sources=[testutil.test_packages()])
         a.wait(new_block())
@@ -26,13 +29,32 @@ class TestExceptionExit(unittest.TestCase):
 
         t = Thread(target=long_query, args=(a.new_api(),))
         t.start()
-        try:
-            a.push_action('transact', 'setcode', 'setcode', {"service":"transact","vmType":0, "vmVersion":0, "code": "DEADBEEF"})
-        except ConnectionError:
-            pass
+        self.cause_exception(a)
         t.join()
 
-        code = a.child.wait(timeout=10)
+    @testutil.psinode_test
+    def test_incoming_p2p(self, cluster):
+        (a, b) = cluster.disconnected(*testutil.generate_names(2), env=ENV)
+        a.boot(packages=['Minimal', 'Explorer'])
+        b.connect(a)
+        b.wait(new_block())
+        self.cause_exception(a)
+
+    @testutil.psinode_test
+    def test_outgoing_p2p(self, cluster):
+        (a, b) = cluster.disconnected(*testutil.generate_names(2), env=ENV)
+        a.boot(packages=['Minimal', 'Explorer'])
+        a.connect(b)
+        b.wait(new_block())
+        self.cause_exception(a)
+
+    def cause_exception(self, node):
+        try:
+            node.push_action('transact', 'setcode', 'setcode', {"service":"transact","vmType":0, "vmVersion":0, "code": "DEADBEEF"})
+        except ConnectionError:
+            pass
+
+        code = node.child.wait(timeout=10)
         self.assertEqual(code, 1)
 
 if __name__ == '__main__':

--- a/programs/psinode/tests/test_exception_exit.py
+++ b/programs/psinode/tests/test_exception_exit.py
@@ -110,7 +110,7 @@ class TestExceptionExit(unittest.TestCase):
                     self.assertEqual(await websocket.recv(), expected)
 
                     self.cause_exception(a)
-            except websocket.exceptions.ConnectionClosedError:
+            except websockets.exceptions.ConnectionClosedError:
                 # the connection is closed abnormally when the node exits
                 pass
 

--- a/programs/psinode/tests/test_exception_exit.py
+++ b/programs/psinode/tests/test_exception_exit.py
@@ -4,18 +4,22 @@ from predicates import *
 import testutil
 import unittest
 import os
+import time
 from fracpack import *
 from psibase import *
-from threading import Thread
+from threading import Thread, Semaphore
 from requests import ConnectionError
+from http.server import *
 
 # Since this test stops psinode with an error, we want
 # sanitizer errors to cause a signal instead to fail the test.
 ENV = {'ASAN_OPTIONS': 'abort_on_error=1'}
 
+expected = "Lorem ipsum dolor sit amet"
+
 class TestExceptionExit(unittest.TestCase):
     @testutil.psinode_test
-    def test_socket(self, cluster):
+    def test_incoming_request(self, cluster):
         (a,) = cluster.complete('a', env=ENV)
         a.boot(packages=['Minimal', 'Explorer'])
         a.install(packages=['KeepSocket'], sources=[testutil.test_packages()])
@@ -31,6 +35,47 @@ class TestExceptionExit(unittest.TestCase):
         t.start()
         self.cause_exception(a)
         t.join()
+
+    @testutil.psinode_test
+    def test_proxy_request(self, cluster):
+        (a,) = cluster.complete('a', env=ENV)
+        a.boot(packages=['Minimal', 'Explorer'])
+        a.install_local(['XProxy'])
+
+        sem = Semaphore(0)
+        class RequestHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                sem.acquire()
+                body = expected.encode('utf-8')
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/plain')
+                self.send_header('Content-Length', str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        server = HTTPServer(('', 0), RequestHandler)
+        t = Thread(target=server.serve_forever)
+        t.start()
+        try:
+            with a.post('/set_origin_server', service='x-proxy', json={"subdomain":"x-proxy", "host":"localhost:%d" % server.server_address[1]}) as reply:
+                reply.raise_for_status()
+
+            def long_query(api):
+                try:
+                    api.get('/', service='x-proxy')
+                except ConnectionError:
+                    pass
+
+            t2 = Thread(target=long_query, args=(a.new_api(),))
+            t2.start()
+            time.sleep(0.5)
+            self.cause_exception(a)
+            t2.join()
+            sem.release()
+        finally:
+            server.shutdown()
+            t.join()
+            server.server_close()
 
     @testutil.psinode_test
     def test_incoming_p2p(self, cluster):

--- a/programs/psinode/tests/test_exception_exit.py
+++ b/programs/psinode/tests/test_exception_exit.py
@@ -10,12 +10,26 @@ from psibase import *
 from threading import Thread, Semaphore
 from requests import ConnectionError
 from http.server import *
+import urllib3
+import websockets
 
 # Since this test stops psinode with an error, we want
 # sanitizer errors to cause a signal instead to fail the test.
 ENV = {'ASAN_OPTIONS': 'abort_on_error=1'}
 
 expected = "Lorem ipsum dolor sit amet"
+
+def websocket_url(node, path='/', service=None):
+    url = urllib3.util.parse_url(node.url)
+    if service is not None:
+        host = service + '.' + url.host
+    else:
+        host = url.host
+    return urllib3.util.Url('ws', url.auth, host, url.port, path).url
+
+async def echo(connection):
+    async for msg in connection:
+        await connection.send(msg)
 
 class TestExceptionExit(unittest.TestCase):
     @testutil.psinode_test
@@ -76,6 +90,25 @@ class TestExceptionExit(unittest.TestCase):
             server.shutdown()
             t.join()
             server.server_close()
+
+    @testutil.psinode_test
+    async def test_proxy_websocket(self, cluster):
+        (a,) = cluster.complete(*testutil.generate_names(1), env=ENV)
+        a.boot(packages=['Minimal', 'Explorer'])
+        a.install_local(['XProxy'])
+
+        async with websockets.serve(echo, host='127.0.0.1', port=0) as server:
+            with a.post('/set_origin_server', service='x-proxy', json={"subdomain":"x-proxy", "host":"localhost:%d" % server.sockets[0].getsockname()[1]}) as reply:
+                reply.raise_for_status()
+
+            url = websocket_url(a, '/', service='x-proxy')
+            async with websockets.unix_connect(a.socketpath, url, compression=None) as websocket:
+                # Send a round-trip message, to make sure that the connection
+                # is fully established
+                await websocket.send(expected)
+                self.assertEqual(await websocket.recv(), expected)
+
+                self.cause_exception(a)
 
     @testutil.psinode_test
     def test_incoming_p2p(self, cluster):


### PR DESCRIPTION
The WebSocket contains callbacks which often hold a shared_ptr to itself. This `shared_ptr` cycle causes a memory leak at shutdown.

- Add test cases which have each possible kind of socket open at shutdown
- Reorganize shutdown to stop all threads sooner, which makes controlling the order of destruction much easier