### PR TITLE
Fixing 2 issues

### DIFF
--- a/nix/deploy/README.md
+++ b/nix/deploy/README.md
@@ -52,6 +52,16 @@ Traefik, nginx) in front of the node, passing the authenticated user through:
 services.psibase.environment.PSIBASE_USERNAME_FIELD = "X-Auth-User";
 ```
 
+For that reason, psinode listens on `127.0.0.1` by default. If a remote proxy
+connects directly to psinode, explicitly expose it:
+
+```nix
+services.psibase = {
+  listenAddress = "0.0.0.0";
+  openFirewall = true;
+};
+```
+
 ## SoftHSM / block production
 
 With `softHsm.enable = true` the module writes a SoftHSM config pointing at a persistent token directory, runs a oneshot that initializes the token once from `pinFile`, and starts `psinode` with `--pkcs11-module=…/libsofthsm2.so` and `SOFTHSM2_CONF` set.

--- a/nix/deploy/module.nix
+++ b/nix/deploy/module.nix
@@ -41,6 +41,17 @@ in {
       description = "Hostname for the service HTTP interface (psinode --host).";
     };
 
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = ''
+        IP address on which psinode listens. The loopback default keeps the
+        unauthenticated admin API behind a local reverse proxy. Set this to
+        `0.0.0.0` only when remote access is intentional.
+      '';
+    };
+
     listen = lib.mkOption {
       type = lib.types.port;
       default = 8080;
@@ -54,7 +65,7 @@ in {
       description = ''
         Block producer name (psinode --producer). Null means a non-producing node.
         After the service is up, boot a new chain once with:
-          psibase -a http://HOST:PORT boot -p PRODUCER
+          psibase boot -a http://HOST:PORT -p PRODUCER
         If using SoftHSM for block signing, unlock the token via x-admin after start.
       '';
     };
@@ -101,7 +112,8 @@ in {
       default = false;
       description = ''
         Open the listen port in the firewall. Usually false: psinode does not
-        authenticate `/native/admin/`. Put a reverse proxy in front.
+        authenticate `/native/admin/`. Put a reverse proxy in front. To accept
+        remote connections directly, also set `listenAddress` to `0.0.0.0`.
       '';
     };
 
@@ -170,6 +182,15 @@ in {
         then "${softhsmPkg}/lib/softhsm/libsofthsm2.so"
         else null;
 
+      listenEndpoint =
+        let
+          address =
+            if lib.hasInfix ":" cfg.listenAddress && !lib.hasPrefix "[" cfg.listenAddress
+            then "[${cfg.listenAddress}]"
+            else cfg.listenAddress;
+        in
+        "${address}:${toString cfg.listen}";
+
       psinodeArgs =
         [
           "${cfg.package}/bin/psinode"
@@ -177,7 +198,7 @@ in {
           "--host"
           cfg.host
           "--listen"
-          (toString cfg.listen)
+          listenEndpoint
         ]
         ++ lib.optionals (cfg.producer != null) [
           "--producer"


### PR DESCRIPTION
- `listen` only accepted a port, which psinode interpreted as 0.0.0.0:<port>. The goal is `psinode` only binding to the loopback address. this fix ensures it's only listening on loopback (which allows it to work with the reverse proxy)
- `psibase boot` had the `-a` in the wrong place.