### PR TITLE
Vscode settings update

### DIFF
--- a/.vscode/settings.json.sample
+++ b/.vscode/settings.json.sample
@@ -8,6 +8,7 @@
   "prettier.prettierPath": "packages/.yarn/sdks/prettier/index.cjs",
   "js/ts.tsdk.path": "packages/.yarn/sdks/typescript/lib",
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  "rust-analyzer.server.path": "rust-analyzer",
   "rust-analyzer.linkedProjects": ["rust/Cargo.toml", "packages/user/Cargo.toml", "packages/system/Cargo.toml", "packages/Cargo.toml"],
   "editor.formatOnSave": true,
   "[markdown]": {

--- a/.vscode/settings.json.sample
+++ b/.vscode/settings.json.sample
@@ -6,8 +6,8 @@
   },
   "eslint.nodePath": "packages/.yarn/sdks",
   "prettier.prettierPath": "packages/.yarn/sdks/prettier/index.cjs",
-  "typescript.tsdk": "packages/.yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.tsdk.path": "packages/.yarn/sdks/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "rust-analyzer.linkedProjects": ["rust/Cargo.toml", "packages/user/Cargo.toml", "packages/system/Cargo.toml", "packages/Cargo.toml"],
   "editor.formatOnSave": true,
   "[markdown]": {


### PR DESCRIPTION
* Fixes some use of deprecated settings.json keys
* Uses the rust-analyzer resolved from path. 
  * Requires `rustup component add rust-analyzer`. Therefore this PR should probably wait until psibase-contributor gets updated with this component.