### PR TITLE
Allow credentials for x-admin accessing x-peers

### DIFF
--- a/packages/local/XAdmin/ui/src/lib/chain-endpoints.ts
+++ b/packages/local/XAdmin/ui/src/lib/chain-endpoints.ts
@@ -96,7 +96,9 @@ class Chain {
     public async getPeers(): Promise<z.infer<typeof Peers>> {
         const url = siblingUrl(null, "x-peers", "/graphql");
         const query = "query { peers { edges { node { id urls endpoint } } } }";
-        const res: any = await postGraphQLGetJson(url, query);
+        const res: any = await postGraphQLGetJson(url, query, {
+            credentials: "include",
+        });
         return Peers.parse(res.data.peers.edges.map((e: any) => e.node));
     }
 
@@ -179,7 +181,7 @@ class Chain {
                 `Failed to find peer with ID ${id} in existing peers`,
             );
         const url = siblingUrl(null, "x-peers", "/disconnect");
-        await postJson(url, { id });
+        await postJson(url, { id }, { credentials: "include" });
     }
 
     public pushArrayBufferBoot(buffer: ArrayBufferLike) {
@@ -221,7 +223,9 @@ class Chain {
         url: string;
     }): Promise<z.infer<typeof Peer>> {
         const url = siblingUrl(null, "x-peers", "/connect");
-        const result = await postJsonGetJson(url, config);
+        const result = await postJsonGetJson(url, config, {
+            credentials: "include",
+        });
         result.urls = [url];
         return Peer.parse(result);
     }

--- a/packages/local/XPeers/src/XPeers.cpp
+++ b/packages/local/XPeers/src/XPeers.cpp
@@ -48,6 +48,21 @@ namespace
       PSIO_REFLECT(AuthorizationRequest, url, token)
    };
 
+   std::vector<HttpHeader> allowCorsCredentials(const HttpRequest& req, AccountNumber account)
+   {
+      auto result = allowCors(req, account);
+      result.push_back({"Access-Control-Allow-Credentials", "true"});
+      for (auto& h : result)
+      {
+         if (h.matches("Access-Control-Allow-Headers"))
+         {
+            h.value = "Content-Type, Authorization";
+            break;
+         }
+      }
+      return result;
+   }
+
    HttpReply error(HttpStatus status, std::string_view msg)
    {
       return HttpReply{.status = status, .contentType = "text/html", .body{msg.begin(), msg.end()}};
@@ -145,8 +160,8 @@ namespace
       std::optional<SocketEndpoint> endpoint;
       auto                          url = splitURL(peer);
       HttpRequest                   request{
-                            .method = "GET",
-                            .target = "/p2p",
+          .method = "GET",
+          .target = "/p2p",
       };
       std::vector<std::string> hosts;
       bool                     secure = false;
@@ -189,7 +204,7 @@ namespace
             auto connectionRequests = XPeers{}.open<ConnectionRequestTable>();
             check(originalRequest != nullptr, "request is required if requestSocket is provided");
             connectionRequests.put(
-                {socket, *requestSocket, allowCors(*originalRequest, XAdmin::service)});
+                {socket, *requestSocket, allowCorsCredentials(*originalRequest, XAdmin::service)});
             to<XHttp>().autoClose(*requestSocket, false);
          }
 
@@ -589,15 +604,16 @@ auto XPeers::serveSys(const HttpRequest& request, std::optional<std::int32_t> so
       }
    }
 
-   if (auto reply = to<XAdmin>().checkAuth(request, socket))
-      return reply;
-
    if (request.method == "OPTIONS")
    {
-      HttpReply result{.headers = allowCors(request, XAdmin::service)};
+      HttpReply result{.headers = allowCorsCredentials(request, XAdmin::service)};
       result.headers.push_back({"Allow", "GET, POST, PUT, OPTIONS, DELETE"});
       return result;
    }
+
+   if (auto reply = to<XAdmin>().checkAuth(request, socket))
+      return reply;
+
    if (target == "/connect")
    {
       if (request.contentType != "application/json")
@@ -642,7 +658,7 @@ auto XPeers::serveSys(const HttpRequest& request, std::optional<std::int32_t> so
       }
       if (row)
       {
-         return HttpReply{.headers = allowCors(request, XAdmin::service)};
+         return HttpReply{.headers = allowCorsCredentials(request, XAdmin::service)};
       }
       else
       {
@@ -650,7 +666,7 @@ auto XPeers::serveSys(const HttpRequest& request, std::optional<std::int32_t> so
          return HttpReply{.status      = HttpStatus::notFound,
                           .contentType = "text/html",
                           .body{msg.begin(), msg.end()},
-                          .headers = allowCors(request, XAdmin::service)};
+                          .headers = allowCorsCredentials(request, XAdmin::service)};
       }
    }
    else if (target == "/users")
@@ -675,7 +691,7 @@ auto XPeers::serveSys(const HttpRequest& request, std::optional<std::int32_t> so
             table.erase(body.account);
          }
       }
-      return HttpReply{.headers = allowCors(request, XAdmin::service)};
+      return HttpReply{.headers = allowCorsCredentials(request, XAdmin::service)};
    }
    else if (target == "/authorization")
    {
@@ -699,7 +715,7 @@ auto XPeers::serveSys(const HttpRequest& request, std::optional<std::int32_t> so
             table.erase(body.url);
          }
       }
-      return HttpReply{.headers = allowCors(request, XAdmin::service)};
+      return HttpReply{.headers = allowCorsCredentials(request, XAdmin::service)};
    }
    else if (target == "/peers")
    {

--- a/packages/local/XPeers/src/XPeers.cpp
+++ b/packages/local/XPeers/src/XPeers.cpp
@@ -753,7 +753,9 @@ auto XPeers::serveSys(const HttpRequest& request, std::optional<std::int32_t> so
    {
       PSIBASE_SUBJECTIVE_TX
       {
-         return serveGraphQL(request, Query{});
+         auto result     = serveGraphQL(request, Query{});
+         result->headers = allowCorsCredentials(request, XAdmin::service);
+         return result;
       }
    }
    return {};

--- a/packages/local/XPeers/src/XPeers.cpp
+++ b/packages/local/XPeers/src/XPeers.cpp
@@ -753,8 +753,9 @@ auto XPeers::serveSys(const HttpRequest& request, std::optional<std::int32_t> so
    {
       PSIBASE_SUBJECTIVE_TX
       {
-         auto result     = serveGraphQL(request, Query{});
-         result->headers = allowCorsCredentials(request, XAdmin::service);
+         auto result = serveGraphQL(request, Query{});
+         if (result)
+            result->headers = allowCorsCredentials(request, XAdmin::service);
          return result;
       }
    }

--- a/packages/user/CommonApi/common/packages/common-lib/src/rpc.ts
+++ b/packages/user/CommonApi/common/packages/common-lib/src/rpc.ts
@@ -1,9 +1,10 @@
+import hashJs from "hash.js";
+
 import {
     privateStringToKeyPair,
     publicKeyPairToDER,
     signatureToBin,
 } from "./key-conversions";
-import hashJs from "hash.js";
 
 export class RPCError extends Error {
     trace: any;
@@ -105,7 +106,14 @@ export async function postText(url: string, text: string) {
     );
 }
 
-export async function postGraphQL(url: string, graphql: string) {
+export async function postGraphQL(
+    url: string,
+    graphql: string,
+    options?: RequestInit,
+) {
+    if (!options) {
+        options = {};
+    }
     return throwIfError(
         await fetch(url, {
             method: "POST",
@@ -113,11 +121,15 @@ export async function postGraphQL(url: string, graphql: string) {
                 "Content-Type": "application/graphql",
             },
             body: graphql,
+            ...options,
         }),
     );
 }
 
-export async function postJson(url: string, json: any) {
+export async function postJson(url: string, json: any, options?: RequestInit) {
+    if (!options) {
+        options = {};
+    }
     return throwIfError(
         await fetch(url, {
             method: "POST",
@@ -125,6 +137,7 @@ export async function postJson(url: string, json: any) {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify(json),
+            ...options,
         }),
     );
 }
@@ -149,13 +162,18 @@ export async function postTextGetJson(url: string, text: string) {
 export async function postGraphQLGetJson<GqlResponse>(
     url: string,
     graphQL: string,
+    options?: RequestInit,
 ): Promise<GqlResponse> {
-    const res = await postGraphQL(url, graphQL);
+    const res = await postGraphQL(url, graphQL, options);
     return res.json();
 }
 
-export async function postJsonGetJson(url: string, json: any) {
-    const res = await postJson(url, json);
+export async function postJsonGetJson(
+    url: string,
+    json: any,
+    options?: RequestInit,
+) {
+    const res = await postJson(url, json, options);
     return res.json();
 }
 


### PR DESCRIPTION
- CORS preflight never includes credentials, so we need to handle `OPTIONS` before checking authorization.
- Pass `credentials: include` to fetch
- Add `Access-Control-Allow-Credentials` and don't use `*` in `Access-Control-Allow-Headers`