### PR TITLE
Allow mounting individual files

### DIFF
--- a/libraries/psibase/native/src/Mount.cpp
+++ b/libraries/psibase/native/src/Mount.cpp
@@ -73,8 +73,14 @@ namespace psibase
                if (linkValue.starts_with('/'))
                {
                   // absolute symlink: find longest matching prefix
-                  auto pos = std::ranges::find_if(mountpoints, [&](const auto& dir)
-                                                  { return linkValue.starts_with(dir->hostPath); });
+                  auto pos =
+                      std::ranges::find_if(mountpoints,
+                                           [&](const auto& dir)
+                                           {
+                                              return linkValue.starts_with(dir->hostPath) &&
+                                                     (dir->hostPath.back() == '/' ||
+                                                      linkValue[dir->hostPath.size()] == '/');
+                                           });
                   if (pos == mountpoints.end())
                      throw std::system_error{ENOENT, std::generic_category()};
                   mount          = *pos;
@@ -207,6 +213,14 @@ namespace psibase
          }
          Fd get(std::string item)
          {
+            if (dirsBelowMount == 0)
+            {
+               auto pos = mount->children.find(item);
+               if (pos != mount->children.end() && pos->second.isMountpoint)
+               {
+                  return Fd{::open(pos->second.hostPath.c_str(), O_RDONLY)};
+               }
+            }
             if (path.empty())
             {
                throw std::system_error{ENOENT, std::generic_category()};
@@ -237,8 +251,6 @@ namespace psibase
       validatePath(hostpath);
       validatePath(mountpath);
       hostpath = std::filesystem::canonical(hostpath).string();
-      if (!hostpath.ends_with('/'))
-         hostpath.push_back('/');
 
       Dir* current = &root;
       for (auto range : mountpath | std::views::split('/'))

--- a/libraries/psibase/native/tests/MountTests.cpp
+++ b/libraries/psibase/native/tests/MountTests.cpp
@@ -308,3 +308,34 @@ TEST_CASE(".. in virtual root")
    mount.mount(dir.path.string(), "/subdir");
    CHECK(readFile(mount.open("/subdir/../../../subdir/one")) == "1");
 }
+
+TEST_CASE("mount file")
+{
+   TempDirectory dir;
+   writeFile(dir.path / "one", "1");
+   Mount mount;
+   mount.mount((dir.path / "one").string(), "/one");
+   CHECK(readFile(mount.open("/one")) == "1");
+}
+
+TEST_CASE("mount file nested")
+{
+   TempDirectory dir;
+   writeFile(dir.path / "one", "1");
+   writeFile(dir.path / "two" / "three", "3");
+   Mount mount;
+   mount.mount((dir.path / "one").string(), "/one");
+   mount.mount((dir.path / "two").string(), "/");
+   CHECK(readFile(mount.open("/one")) == "1");
+}
+
+TEST_CASE("symlink prefix match")
+{
+   TempDirectory dir;
+   writeFile(dir.path / "one" / "two", "2");
+   writeFile(dir.path / "one" / "x" / "two", "2");
+   std::filesystem::create_directory_symlink(dir.path / "onex", dir.path / "one" / "three");
+   Mount mount;
+   mount.mount((dir.path / "one").string(), "/");
+   CHECK_THROWS_AS(readFile(mount.open("/three/two")), std::system_error);
+}


### PR DESCRIPTION
Previously, only directories could be mounted. This turns out to be somewhat inconvenient, since quite often what needs to be exposed is a single file.