### PR TITLE
Remove unused checkFirstAuthAndExit parameter

### DIFF
--- a/doc/src/specifications/blockchain/entry-points.md
+++ b/doc/src/specifications/blockchain/entry-points.md
@@ -8,10 +8,9 @@ Each entry point starts a fresh transaction context. Modules will be instantiate
 
 `processTransaction` applies a transaction to the chain. It should be defined as a WASM export. Only subjective services can access subjective databases. Objective databases are readable and writable.
 
-| Argument              | Type       | Description                                                                                                                                                    |
-|-----------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| transaction           | byte array | A packed `Transaction`                                                                                                                                         |
-| checkFirstAuthAndExit | bool       | If true, instead of applying the transaction, check the authorization of the account to be billed for this transaction. This mode must not write the database. |
+| Argument    | Type       | Description            |
+|-------------|------------|------------------------|
+| transaction | byte array | A packed `Transaction` |
 
 Any result is ignored
 

--- a/libraries/psibase/common/include/psibase/serviceEntry.hpp
+++ b/libraries/psibase/common/include/psibase/serviceEntry.hpp
@@ -11,8 +11,7 @@ namespace psibase
    struct ProcessTransactionArgs
    {
       psio::shared_view_ptr<Transaction> transaction;
-      bool                               checkFirstAuthAndExit;
-      PSIO_REFLECT(ProcessTransactionArgs, transaction, checkFirstAuthAndExit)
+      PSIO_REFLECT(ProcessTransactionArgs, transaction)
    };
 
    struct VerifyArgs

--- a/libraries/psibase/native/src/TransactionContext.cpp
+++ b/libraries/psibase/native/src/TransactionContext.cpp
@@ -149,8 +149,7 @@ namespace psibase
    // TODO: eliminate extra copies
    static void execProcessTransaction(TransactionContext& self)
    {
-      ProcessTransactionArgs args{.transaction           = self.signedTransaction.transaction,
-                                  .checkFirstAuthAndExit = false};
+      ProcessTransactionArgs args{.transaction = self.signedTransaction.transaction};
 
       Action action{
           .sender  = AccountNumber(),
@@ -415,7 +414,7 @@ namespace psibase
       // interleaving with the regular modules, so they can
       // be cleared safely.
       auto  memidx = impl->altMode ? blockContext.systemContext.executionMemories.size() -
-                                        impl->altExecContexts.size() - 1
+                                         impl->altExecContexts.size() - 1
                                    : impl->executionContexts.size();
       auto& memory = blockContext.systemContext.executionMemories[memidx];
       ExecutionContext            execContext{*this, impl->wasmConfig.vmOptions, memory, service};


### PR DESCRIPTION
Since speculative execution is managed by RTransact, this parameter is no longer used.