### PR TITLE
XAdmin: Introduce UI for managing allowed peers whitelist

### DIFF
--- a/doc/src/default-apps/x-admin.md
+++ b/doc/src/default-apps/x-admin.md
@@ -14,10 +14,6 @@ Access to `x-admin` is allowed only if
 
 All of these options can also be specified on the command line or in the server's config file. Changes applied through the web API will be saved to the config file and will be remembered across server restarts. Except where noted otherwise, a new configuration takes effect when saved.
 
-### Accept incoming P2P connections
-
-If enabled, the node will accept p2p connections from other nodes.
-
 ### Block Producer Name
 
 The name that the server uses to produce blocks. It must be a valid [account name](../development/services/cpp-service/reference/magic-numbers.md#psibaseaccountnumber). The node will only produce blocks when its producer name is one of the currently active producers specified by the chain. To disable block production, the producer name can be left blank.
@@ -33,3 +29,11 @@ The TCP port on which the server listens. The server must be restarted for a cha
 ### Logger
 
 See [Logging](x-admin/http-endpoints.md#logging) for a list of the available logger types and their parameters.
+
+### Accept all incoming P2P connections
+
+If enabled, the node accepts incoming P2P connections from any peer. If disabled, incoming connections are accepted only from accounts listed under [Allowed peers](#allowed-peers). With the option disabled and an empty allow list, no incoming P2P connections are accepted.
+
+### Allowed peers
+
+A whitelist of on-chain accounts that may open an incoming P2P connection when [Accept all incoming P2P connections](#accept-all-incoming-p2p-connections) is disabled. The list has no effect while that option is enabled, because all incoming peers are already accepted.

--- a/doc/src/default-apps/x-admin.md
+++ b/doc/src/default-apps/x-admin.md
@@ -30,10 +30,17 @@ The TCP port on which the server listens. The server must be restarted for a cha
 
 See [Logging](x-admin/http-endpoints.md#logging) for a list of the available logger types and their parameters.
 
-### Accept all incoming P2P connections
+### Incoming connection policy
 
-If enabled, the node accepts incoming P2P connections from any peer. If disabled, incoming connections are accepted only from accounts listed under [Allowed peers](#allowed-peers). With the option disabled and an empty allow list, no incoming P2P connections are accepted.
+The `p2p` config option (`--p2p`). Also editable on the Peers page under Settings. Chooses who may open a P2P connection to this node:
+
+- **Accept all incoming P2P connections** — any peer may connect (`p2p` enabled).
+- **Accept incoming P2P connections from whitelisted accounts only** — only accounts listed under [Allowed peers](#allowed-peers) may connect (`p2p` disabled). With an empty allow list, no incoming P2P connections are accepted.
+
+## Peering
+
+Peer connections and the incoming allow list are managed on the Peers page (and via [x-peers](x-peers.md)).
 
 ### Allowed peers
 
-A whitelist of on-chain accounts that may open an incoming P2P connection when [Accept all incoming P2P connections](#accept-all-incoming-p2p-connections) is disabled. The list has no effect while that option is enabled, because all incoming peers are already accepted.
+A whitelist of on-chain accounts that may open an incoming P2P connection when [Incoming connection policy](#incoming-connection-policy) is set to accept whitelisted accounts only. The list is unused while the policy accepts all incoming connections. It is stored by [x-peers](x-peers.md) and is not part of the server config file.

--- a/packages/local/XAdmin/ui/src/configuration/configuration-page.tsx
+++ b/packages/local/XAdmin/ui/src/configuration/configuration-page.tsx
@@ -17,7 +17,6 @@ import {
     SelectValue,
 } from "@shared/shadcn/ui/select";
 import { Skeleton } from "@shared/shadcn/ui/skeleton";
-import { Switch } from "@shared/shadcn/ui/switch";
 import {
     Tabs,
     TabsContent,
@@ -235,21 +234,6 @@ export const ConfigurationForm = ({
                             </TabsTrigger>
                         </TabsList>
                         <TabsContent value="connections">
-                            <Controller
-                                name="p2p"
-                                control={configForm.control}
-                                render={({ field }) => (
-                                    <div className="my-6 flex items-center space-x-2">
-                                        <Switch
-                                            onCheckedChange={field.onChange}
-                                            checked={field.value}
-                                        />
-                                        <Label>
-                                            Accept incoming P2P connections
-                                        </Label>
-                                    </div>
-                                )}
-                            />
                             <div className="flex justify-between gap-4">
                                 <div className="grid w-full items-center gap-1.5">
                                     <Label htmlFor="blockProducerName">

--- a/packages/local/XAdmin/ui/src/hooks/use-peer-users.ts
+++ b/packages/local/XAdmin/ui/src/hooks/use-peer-users.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { chain } from "@/lib/chain-endpoints";
+import { queryKeys } from "@/lib/query-keys";
+
+export const usePeerUsers = () =>
+    useQuery<string[], string>({
+        queryKey: queryKeys.peerUsers,
+        queryFn: async () => {
+            try {
+                return await chain.getPeerUsers();
+            } catch (e) {
+                console.error("Failed to fetch peer users", e);
+                throw "Failed to fetch peer users";
+            }
+        },
+        initialData: [],
+        refetchInterval: 10000,
+    });
+
+export const useSetPeerUser = () =>
+    useMutation<void, string, { account: string; accept: boolean }>({
+        mutationKey: queryKeys.setPeerUser,
+        mutationFn: async ({ account, accept }) => {
+            try {
+                await chain.setPeerUser(account, accept);
+            } catch (e) {
+                console.error("Failed to update peer user", e);
+                throw "Failed to update peer user";
+            }
+        },
+        onSuccess: (_data, _variables, _onMutateResult, context) => {
+            context.client.invalidateQueries({ queryKey: queryKeys.peerUsers });
+        },
+    });

--- a/packages/local/XAdmin/ui/src/lib/chain-endpoints.ts
+++ b/packages/local/XAdmin/ui/src/lib/chain-endpoints.ts
@@ -102,6 +102,21 @@ class Chain {
         return Peers.parse(res.data.peers.edges.map((e: any) => e.node));
     }
 
+    public async getPeerUsers(): Promise<string[]> {
+        const url = siblingUrl(null, "x-peers", "/graphql");
+        const query = "query { users { edges { node { name } } } }";
+        const res: any = await postGraphQLGetJson(url, query);
+        return z
+            .string()
+            .array()
+            .parse(res.data.users.edges.map((e: any) => e.node.name));
+    }
+
+    public async setPeerUser(account: string, accept: boolean): Promise<void> {
+        const url = siblingUrl(null, "x-peers", "/users");
+        await postJson(url, { account, accept });
+    }
+
     public async getStatus(): Promise<string[]> {
         return getJson("/native/admin/status");
     }

--- a/packages/local/XAdmin/ui/src/lib/query-keys.ts
+++ b/packages/local/XAdmin/ui/src/lib/query-keys.ts
@@ -9,6 +9,8 @@ export const queryKeys = {
     installedLocalPackages: ["installedLocalPackages"] as const,
     packages: ["packages"] as const,
     peers: ["peers"] as const,
+    peerUsers: ["peerUsers"] as const,
+    setPeerUser: ["setPeerUser"] as const,
     producers: ["producers"] as const,
     statuses: ["statuses"] as const,
 

--- a/packages/local/XAdmin/ui/src/peers/peers-page.tsx
+++ b/packages/local/XAdmin/ui/src/peers/peers-page.tsx
@@ -1,6 +1,5 @@
 import {
     Clipboard,
-    Info,
     MoreHorizontal,
     Plus,
     Trash,
@@ -26,7 +25,6 @@ import {
 import { EmptyBlock } from "@shared/components/empty-block";
 import { zAccount } from "@shared/lib/schemas/account";
 import { cn } from "@shared/lib/utils";
-import { Alert, AlertDescription, AlertTitle } from "@shared/shadcn/ui/alert";
 import { Button } from "@shared/shadcn/ui/button";
 import {
     Dialog,
@@ -46,7 +44,7 @@ import {
 } from "@shared/shadcn/ui/dropdown-menu";
 import { Input } from "@shared/shadcn/ui/input";
 import { Label } from "@shared/shadcn/ui/label";
-import { Switch } from "@shared/shadcn/ui/switch";
+import { RadioGroup, RadioGroupItem } from "@shared/shadcn/ui/radio-group";
 import {
     Table,
     TableBody,
@@ -54,6 +52,12 @@ import {
     TableHeader,
     TableRow,
 } from "@shared/shadcn/ui/table";
+import {
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from "@shared/shadcn/ui/tabs";
 
 import { useConfig, useConfigUpdate } from "../hooks/use-config";
 import {
@@ -293,8 +297,8 @@ export const PeersPage = () => {
                         <DialogHeader>
                             <DialogTitle>Add allowed peer</DialogTitle>
                             <DialogDescription>
-                                Allow an on-chain account to peer with this
-                                node when "Accept all incoming P2P connections" is disabled.
+                                Allow an on-chain account to open an incoming
+                                P2P connection to this node.
                             </DialogDescription>
                         </DialogHeader>
                         <div className="grid gap-2 py-4">
@@ -326,198 +330,232 @@ export const PeersPage = () => {
                 </DialogContent>
             </Dialog>
 
-            <div className="my-6 flex items-center space-x-2">
-                <Switch
-                    checked={p2pEnabled}
-                    disabled={isUpdatingConfig || config === undefined}
-                    onCheckedChange={onP2pChange}
-                />
-                <Label>Accept all incoming P2P connections</Label>
-            </div>
-
-            <div className="flex items-center justify-between py-2">
-                <h3 className="text-lg font-semibold tracking-tight">
-                    Connections
-                </h3>
-                {combinedPeers.length !== 0 && (
-                    <Button
-                        variant="outline"
-                        onClick={() => setShowModalConnection(true)}
-                    >
-                        <Plus size={20} />
-                    </Button>
-                )}
-            </div>
-            {combinedPeers.length == 0 ? (
-                <EmptyBlock
-                    buttonLabel="Add Connection"
-                    onButtonClick={() => setShowModalConnection(true)}
-                    title="No connections"
-                    description="No existing connections to other nodes."
-                />
-            ) : (
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>URL</TableHead>
-                            <TableHead>Address</TableHead>
-                            <TableHead>Status</TableHead>
-                            <TableHead>Status</TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {combinedPeers.map((peer) => (
-                            <TableRow key={peer.id}>
-                                <TableHead>
-                                    <span className={cn({ italic: !peer.url })}>
-                                        {peer.url ?? "Unknown"}
-                                    </span>
-                                </TableHead>
-                                <TableHead>{peer.endpoint}</TableHead>
-                                <TableHead>
-                                    <Status state={peer.state} />
-                                </TableHead>
-                                <TableHead>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <Button
-                                                variant="ghost"
-                                                className="my-auto h-full w-8 p-0"
-                                            >
-                                                <span className="sr-only">
-                                                    Open menu
-                                                </span>
-                                                <MoreHorizontal className="h-8 w-8" />
-                                            </Button>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent align="end">
-                                            <DropdownMenuLabel>
-                                                Actions
-                                            </DropdownMenuLabel>
-                                            <DropdownMenuItem
-                                                onClick={() => {
-                                                    navigator.clipboard.writeText(
-                                                        peer.url ||
-                                                            peer.endpoint,
-                                                    );
-                                                }}
-                                            >
-                                                <Clipboard className="mr-2 h-4 w-4" />
-                                                <span>Copy URL</span>
-                                            </DropdownMenuItem>
-                                            <DropdownMenuSeparator />
-                                            {peer.state == "transient" && (
-                                                <DropdownMenuItem
-                                                    onClick={() =>
-                                                        disconnectPeer(peer.id)
-                                                    }
-                                                >
-                                                    <Unplug className="mr-2 h-4 w-4" />
-                                                    <span>Disconnect</span>
-                                                </DropdownMenuItem>
-                                            )}
-                                            {peer.state !== "transient" && (
-                                                <DropdownMenuItem
-                                                    onClick={() =>
-                                                        removePeer(peer.id)
-                                                    }
-                                                >
-                                                    <Trash className="mr-2 h-4 w-4" />
-                                                    <span>Remove</span>
-                                                </DropdownMenuItem>
-                                            )}
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
-                                </TableHead>
-                            </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            )}
-            {configPeersError && <div>{configPeersError}</div>}
-
-            <div className="relative mt-10">
-                <div
-                    className={cn(
-                        "transition-all",
-                        p2pEnabled &&
-                            "pointer-events-none select-none opacity-40 blur-[1px]",
-                    )}
-                >
+            <Tabs defaultValue="connections" className="px-2">
+                <TabsList>
+                    <TabsTrigger value="connections">Connections</TabsTrigger>
+                    <TabsTrigger value="settings">Settings</TabsTrigger>
+                </TabsList>
+                <TabsContent value="connections">
                     <div className="flex items-center justify-between py-2">
-                        <div>
-                            <h3 className="text-lg font-semibold tracking-tight">
-                                Allowed peers
-                            </h3>
-                            <p className="text-muted-foreground text-sm">
-                                Accounts allowed to peer with this node when "Accept all
-                                incoming P2P connections" is disabled.
-                            </p>
-                        </div>
-                        {peerUsers.length !== 0 && (
+                        <div />
+                        {combinedPeers.length !== 0 && (
                             <Button
                                 variant="outline"
-                                onClick={() => setShowAddPeerUser(true)}
+                                onClick={() => setShowModalConnection(true)}
                             >
                                 <Plus size={20} />
                             </Button>
                         )}
                     </div>
-                    {peerUsers.length === 0 ? (
+                    {combinedPeers.length == 0 ? (
                         <EmptyBlock
-                            buttonLabel="Add allowed peer"
-                            onButtonClick={() => setShowAddPeerUser(true)}
-                            title="No allowed peers"
-                            description="Add an account to allow it to peer with this node."
+                            buttonLabel="Add Connection"
+                            onButtonClick={() => setShowModalConnection(true)}
+                            title="No connections"
+                            description="No existing connections to other nodes."
                         />
                     ) : (
                         <Table>
                             <TableHeader>
                                 <TableRow>
-                                    <TableHead>Account</TableHead>
-                                    <TableHead className="w-12" />
+                                    <TableHead>URL</TableHead>
+                                    <TableHead>Address</TableHead>
+                                    <TableHead>Status</TableHead>
+                                    <TableHead>Status</TableHead>
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
-                                {peerUsers.map((account) => (
-                                    <TableRow key={account}>
-                                        <TableHead>{account}</TableHead>
+                                {combinedPeers.map((peer) => (
+                                    <TableRow key={peer.id}>
                                         <TableHead>
-                                            <Button
-                                                variant="ghost"
-                                                className="h-8 w-8 p-0"
-                                                disabled={isUpdatingPeerUser}
-                                                onClick={() =>
-                                                    onRemovePeerUser(account)
-                                                }
+                                            <span
+                                                className={cn({
+                                                    italic: !peer.url,
+                                                })}
                                             >
-                                                <span className="sr-only">
-                                                    Remove {account}
-                                                </span>
-                                                <Trash className="h-4 w-4" />
-                                            </Button>
+                                                {peer.url ?? "Unknown"}
+                                            </span>
+                                        </TableHead>
+                                        <TableHead>{peer.endpoint}</TableHead>
+                                        <TableHead>
+                                            <Status state={peer.state} />
+                                        </TableHead>
+                                        <TableHead>
+                                            <DropdownMenu>
+                                                <DropdownMenuTrigger asChild>
+                                                    <Button
+                                                        variant="ghost"
+                                                        className="my-auto h-full w-8 p-0"
+                                                    >
+                                                        <span className="sr-only">
+                                                            Open menu
+                                                        </span>
+                                                        <MoreHorizontal className="h-8 w-8" />
+                                                    </Button>
+                                                </DropdownMenuTrigger>
+                                                <DropdownMenuContent align="end">
+                                                    <DropdownMenuLabel>
+                                                        Actions
+                                                    </DropdownMenuLabel>
+                                                    <DropdownMenuItem
+                                                        onClick={() => {
+                                                            navigator.clipboard.writeText(
+                                                                peer.url ||
+                                                                    peer.endpoint,
+                                                            );
+                                                        }}
+                                                    >
+                                                        <Clipboard className="mr-2 h-4 w-4" />
+                                                        <span>Copy URL</span>
+                                                    </DropdownMenuItem>
+                                                    <DropdownMenuSeparator />
+                                                    {peer.state ==
+                                                        "transient" && (
+                                                        <DropdownMenuItem
+                                                            onClick={() =>
+                                                                disconnectPeer(
+                                                                    peer.id,
+                                                                )
+                                                            }
+                                                        >
+                                                            <Unplug className="mr-2 h-4 w-4" />
+                                                            <span>
+                                                                Disconnect
+                                                            </span>
+                                                        </DropdownMenuItem>
+                                                    )}
+                                                    {peer.state !==
+                                                        "transient" && (
+                                                        <DropdownMenuItem
+                                                            onClick={() =>
+                                                                removePeer(
+                                                                    peer.id,
+                                                                )
+                                                            }
+                                                        >
+                                                            <Trash className="mr-2 h-4 w-4" />
+                                                            <span>Remove</span>
+                                                        </DropdownMenuItem>
+                                                    )}
+                                                </DropdownMenuContent>
+                                            </DropdownMenu>
                                         </TableHead>
                                     </TableRow>
                                 ))}
                             </TableBody>
                         </Table>
                     )}
-                </div>
-
-                {p2pEnabled && (
-                    <div className="absolute inset-0 flex items-center justify-center p-4">
-                        <Alert className="bg-background max-w-md shadow-sm">
-                            <Info />
-                            <AlertTitle>Whitelist disabled</AlertTitle>
-                            <AlertDescription>
-                                Open P2P is accepting all incoming peers. Turn
-                                off &quot;Accept all incoming P2P connections&quot;
-                                above to use the allowed-peers whitelist.
-                            </AlertDescription>
-                        </Alert>
+                    {configPeersError && <div>{configPeersError}</div>}
+                </TabsContent>
+                <TabsContent value="settings">
+                    <div className="py-2">
+                        <h3 className="text-lg font-semibold tracking-tight">
+                            Incoming connection policy
+                        </h3>
+                        <p className="text-muted-foreground text-sm">
+                            Choose who may open a P2P connection to this node.
+                        </p>
                     </div>
-                )}
-            </div>
+                    <RadioGroup
+                        className="mb-6 mt-3 gap-3"
+                        value={p2pEnabled ? "all" : "whitelist"}
+                        disabled={isUpdatingConfig || config === undefined}
+                        onValueChange={(value) =>
+                            onP2pChange(value === "all")
+                        }
+                    >
+                        <div className="flex items-center space-x-2">
+                            <RadioGroupItem value="all" id="p2p-all" />
+                            <Label htmlFor="p2p-all">
+                                Accept all incoming P2P connections
+                            </Label>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                            <RadioGroupItem
+                                value="whitelist"
+                                id="p2p-whitelist"
+                            />
+                            <Label htmlFor="p2p-whitelist">
+                                Accept incoming P2P connections from
+                                whitelisted accounts only
+                            </Label>
+                        </div>
+                    </RadioGroup>
+
+                    {!p2pEnabled && (
+                        <div>
+                            <div className="flex items-center justify-between py-2">
+                                <div>
+                                    <h3 className="text-lg font-semibold tracking-tight">
+                                        Allowed peers whitelist
+                                    </h3>
+                                    <p className="text-muted-foreground text-sm">
+                                        On-chain accounts allowed to open an
+                                        incoming P2P connection to this node.
+                                    </p>
+                                </div>
+                                {peerUsers.length !== 0 && (
+                                    <Button
+                                        variant="outline"
+                                        onClick={() =>
+                                            setShowAddPeerUser(true)
+                                        }
+                                    >
+                                        <Plus size={20} />
+                                    </Button>
+                                )}
+                            </div>
+                            {peerUsers.length === 0 ? (
+                                <EmptyBlock
+                                    buttonLabel="Add allowed peer"
+                                    onButtonClick={() =>
+                                        setShowAddPeerUser(true)
+                                    }
+                                    title="No allowed peers"
+                                    description="Add an account to allow it to peer with this node."
+                                />
+                            ) : (
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead>Account</TableHead>
+                                            <TableHead className="w-12" />
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {peerUsers.map((account) => (
+                                            <TableRow key={account}>
+                                                <TableHead>
+                                                    {account}
+                                                </TableHead>
+                                                <TableHead>
+                                                    <Button
+                                                        variant="ghost"
+                                                        className="h-8 w-8 p-0"
+                                                        disabled={
+                                                            isUpdatingPeerUser
+                                                        }
+                                                        onClick={() =>
+                                                            onRemovePeerUser(
+                                                                account,
+                                                            )
+                                                        }
+                                                    >
+                                                        <span className="sr-only">
+                                                            Remove {account}
+                                                        </span>
+                                                        <Trash className="h-4 w-4" />
+                                                    </Button>
+                                                </TableHead>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            )}
+                        </div>
+                    )}
+                </TabsContent>
+            </Tabs>
         </>
     );
 };

--- a/packages/local/XAdmin/ui/src/peers/peers-page.tsx
+++ b/packages/local/XAdmin/ui/src/peers/peers-page.tsx
@@ -294,15 +294,15 @@ export const PeersPage = () => {
                             <DialogTitle>Add allowed peer</DialogTitle>
                             <DialogDescription>
                                 Allow an on-chain account to peer with this
-                                node when open P2P is disabled.
+                                node when "Accept all incoming P2P connections" is disabled.
                             </DialogDescription>
                         </DialogHeader>
                         <div className="grid gap-2 py-4">
-                            <Label htmlFor="peer-user-account">Account</Label>
+                            <Label htmlFor="peer-user-account">Account name</Label>
                             <Input
                                 id="peer-user-account"
                                 autoComplete="off"
-                                placeholder="account-name"
+                                placeholder="Account name"
                                 {...peerUserForm.register("account")}
                             />
                             {peerUserForm.formState.errors.account && (
@@ -450,8 +450,8 @@ export const PeersPage = () => {
                                 Allowed peers
                             </h3>
                             <p className="text-muted-foreground text-sm">
-                                Accounts allowed to peer with this node when
-                                open P2P is disabled.
+                                Accounts allowed to peer with this node when "Accept all
+                                incoming P2P connections" is disabled.
                             </p>
                         </div>
                         {peerUsers.length !== 0 && (

--- a/packages/local/XAdmin/ui/src/peers/peers-page.tsx
+++ b/packages/local/XAdmin/ui/src/peers/peers-page.tsx
@@ -1,5 +1,13 @@
-import { Clipboard, MoreHorizontal, Plus, Trash, Unplug } from "lucide-react";
+import {
+    Clipboard,
+    Info,
+    MoreHorizontal,
+    Plus,
+    Trash,
+    Unplug,
+} from "lucide-react";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { useToast } from "@/components/ui/use-toast";
@@ -16,12 +24,15 @@ import {
 } from "@/lib/chain-endpoints";
 
 import { EmptyBlock } from "@shared/components/empty-block";
+import { zAccount } from "@shared/lib/schemas/account";
 import { cn } from "@shared/lib/utils";
+import { Alert, AlertDescription, AlertTitle } from "@shared/shadcn/ui/alert";
 import { Button } from "@shared/shadcn/ui/button";
 import {
     Dialog,
     DialogContent,
     DialogDescription,
+    DialogFooter,
     DialogHeader,
     DialogTitle,
 } from "@shared/shadcn/ui/dialog";
@@ -33,6 +44,9 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@shared/shadcn/ui/dropdown-menu";
+import { Input } from "@shared/shadcn/ui/input";
+import { Label } from "@shared/shadcn/ui/label";
+import { Switch } from "@shared/shadcn/ui/switch";
 import {
     Table,
     TableBody,
@@ -41,7 +55,11 @@ import {
     TableRow,
 } from "@shared/shadcn/ui/table";
 
-import { useConfig } from "../hooks/use-config";
+import { useConfig, useConfigUpdate } from "../hooks/use-config";
+import {
+    usePeerUsers,
+    useSetPeerUser,
+} from "../hooks/use-peer-users";
 import { usePeers } from "../hooks/use-peers";
 
 const randomIntFromInterval = (min: number, max: number) =>
@@ -118,10 +136,22 @@ const Status = ({ state }: { state: z.infer<typeof StateEnum> }) => {
     );
 };
 
+const PeerUserFormSchema = z.object({
+    account: zAccount,
+});
+
+type PeerUserForm = z.infer<typeof PeerUserFormSchema>;
+
 export const PeersPage = () => {
     const { data: livePeers, refetch: refetchPeers } = usePeers();
     const { data: config, refetch: refetchConfig } = useConfig();
+    const { mutate: updateConfig, isPending: isUpdatingConfig } =
+        useConfigUpdate();
+    const { data: peerUsers } = usePeerUsers();
+    const { mutateAsync: setPeerUser, isPending: isUpdatingPeerUser } =
+        useSetPeerUser();
     const configPeers = config?.peers || [];
+    const p2pEnabled = config?.p2p ?? false;
 
     const combinedPeers = combinePeers(configPeers, livePeers);
 
@@ -129,6 +159,10 @@ export const PeersPage = () => {
     const { toast } = useToast();
 
     const [showAddModalConnection, setShowModalConnection] = useState(false);
+    const [showAddPeerUser, setShowAddPeerUser] = useState(false);
+    const peerUserForm = useForm<PeerUserForm>({
+        defaultValues: { account: "" },
+    });
 
     const onConnection = async () => {
         setShowModalConnection(false);
@@ -173,6 +207,60 @@ export const PeersPage = () => {
         }
     };
 
+    const onP2pChange = (checked: boolean) => {
+        updateConfig(
+            { p2p: checked },
+            {
+                onError: () => {
+                    toast({
+                        title: "Error",
+                        description: "Failed to update P2P setting",
+                    });
+                },
+            },
+        );
+    };
+
+    const onAddPeerUser = async (values: PeerUserForm) => {
+        const parsed = PeerUserFormSchema.safeParse(values);
+        if (!parsed.success) {
+            const message =
+                parsed.error.issues[0]?.message ?? "Invalid account name";
+            peerUserForm.setError("account", { message });
+            return;
+        }
+
+        try {
+            await setPeerUser({ account: parsed.data.account, accept: true });
+            setShowAddPeerUser(false);
+            peerUserForm.reset({ account: "" });
+            toast({
+                title: "Allowed peer added",
+                description: `${parsed.data.account} can now peer with this node.`,
+            });
+        } catch {
+            toast({
+                title: "Error",
+                description: "Failed to add allowed peer",
+            });
+        }
+    };
+
+    const onRemovePeerUser = async (account: string) => {
+        try {
+            await setPeerUser({ account, accept: false });
+            toast({
+                title: "Allowed peer removed",
+                description: `${account} can no longer peer with this node.`,
+            });
+        } catch {
+            toast({
+                title: "Error",
+                description: "Failed to remove allowed peer",
+            });
+        }
+    };
+
     return (
         <>
             <Dialog
@@ -191,17 +279,73 @@ export const PeersPage = () => {
                 </DialogContent>
             </Dialog>
 
-            <div className="flex justify-between py-2">
-                <div></div>
+            <Dialog
+                open={showAddPeerUser}
+                onOpenChange={(show) => {
+                    setShowAddPeerUser(show);
+                    if (!show) {
+                        peerUserForm.reset({ account: "" });
+                    }
+                }}
+            >
+                <DialogContent>
+                    <form onSubmit={peerUserForm.handleSubmit(onAddPeerUser)}>
+                        <DialogHeader>
+                            <DialogTitle>Add allowed peer</DialogTitle>
+                            <DialogDescription>
+                                Allow an on-chain account to peer with this
+                                node when open P2P is disabled.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <div className="grid gap-2 py-4">
+                            <Label htmlFor="peer-user-account">Account</Label>
+                            <Input
+                                id="peer-user-account"
+                                autoComplete="off"
+                                placeholder="account-name"
+                                {...peerUserForm.register("account")}
+                            />
+                            {peerUserForm.formState.errors.account && (
+                                <p className="text-destructive text-sm">
+                                    {
+                                        peerUserForm.formState.errors.account
+                                            .message
+                                    }
+                                </p>
+                            )}
+                        </div>
+                        <DialogFooter>
+                            <Button
+                                type="submit"
+                                disabled={isUpdatingPeerUser}
+                            >
+                                Add
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            <div className="my-6 flex items-center space-x-2">
+                <Switch
+                    checked={p2pEnabled}
+                    disabled={isUpdatingConfig || config === undefined}
+                    onCheckedChange={onP2pChange}
+                />
+                <Label>Accept all incoming P2P connections</Label>
+            </div>
+
+            <div className="flex items-center justify-between py-2">
+                <h3 className="text-lg font-semibold tracking-tight">
+                    Connections
+                </h3>
                 {combinedPeers.length !== 0 && (
-                    <div>
-                        <Button
-                            variant="outline"
-                            onClick={() => setShowModalConnection(true)}
-                        >
-                            <Plus size={20} />
-                        </Button>
-                    </div>
+                    <Button
+                        variant="outline"
+                        onClick={() => setShowModalConnection(true)}
+                    >
+                        <Plus size={20} />
+                    </Button>
                 )}
             </div>
             {combinedPeers.length == 0 ? (
@@ -291,6 +435,89 @@ export const PeersPage = () => {
                 </Table>
             )}
             {configPeersError && <div>{configPeersError}</div>}
+
+            <div className="relative mt-10">
+                <div
+                    className={cn(
+                        "transition-all",
+                        p2pEnabled &&
+                            "pointer-events-none select-none opacity-40 blur-[1px]",
+                    )}
+                >
+                    <div className="flex items-center justify-between py-2">
+                        <div>
+                            <h3 className="text-lg font-semibold tracking-tight">
+                                Allowed peers
+                            </h3>
+                            <p className="text-muted-foreground text-sm">
+                                Accounts allowed to peer with this node when
+                                open P2P is disabled.
+                            </p>
+                        </div>
+                        {peerUsers.length !== 0 && (
+                            <Button
+                                variant="outline"
+                                onClick={() => setShowAddPeerUser(true)}
+                            >
+                                <Plus size={20} />
+                            </Button>
+                        )}
+                    </div>
+                    {peerUsers.length === 0 ? (
+                        <EmptyBlock
+                            buttonLabel="Add allowed peer"
+                            onButtonClick={() => setShowAddPeerUser(true)}
+                            title="No allowed peers"
+                            description="Add an account to allow it to peer with this node."
+                        />
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Account</TableHead>
+                                    <TableHead className="w-12" />
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {peerUsers.map((account) => (
+                                    <TableRow key={account}>
+                                        <TableHead>{account}</TableHead>
+                                        <TableHead>
+                                            <Button
+                                                variant="ghost"
+                                                className="h-8 w-8 p-0"
+                                                disabled={isUpdatingPeerUser}
+                                                onClick={() =>
+                                                    onRemovePeerUser(account)
+                                                }
+                                            >
+                                                <span className="sr-only">
+                                                    Remove {account}
+                                                </span>
+                                                <Trash className="h-4 w-4" />
+                                            </Button>
+                                        </TableHead>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                </div>
+
+                {p2pEnabled && (
+                    <div className="absolute inset-0 flex items-center justify-center p-4">
+                        <Alert className="bg-background max-w-md shadow-sm">
+                            <Info />
+                            <AlertTitle>Whitelist disabled</AlertTitle>
+                            <AlertDescription>
+                                Open P2P is accepting all incoming peers. Turn
+                                off &quot;Accept all incoming P2P connections&quot;
+                                above to use the allowed-peers whitelist.
+                            </AlertDescription>
+                        </Alert>
+                    </div>
+                )}
+            </div>
         </>
     );
 };


### PR DESCRIPTION
## In this PR

Adds UI to the Peers page allowing node operators to manage the incoming peers whitelist. This hooks into existing functionality in `x-peers`. This UI will be further refined when we do an overall ref(actor|inement) of the XAdmin UI soon.

## Follow-up work

- Validate the `x-peers` is doing what it needs to do with these account names

## Future work for XAdmin

- Transition `react-hook-form` forms to `@tanstack/react-form`
- Clean up and reorganize XAdmin UI; allow pre-boot/peered access to all relevant XAdmin settings

## Screenshots

<img width="1413" height="1018" alt="image" src="https://github.com/user-attachments/assets/efb1a38f-484f-4eb9-b4d8-99de07fcc177" />

<img width="1414" height="1017" alt="image" src="https://github.com/user-attachments/assets/cc4d087a-2a17-4b96-ab7d-4fd0831c84f9" />

<img width="1416" height="1015" alt="image" src="https://github.com/user-attachments/assets/cf5d5f81-87c2-437f-9bfa-4b9f9edaa43c" />

<img width="1417" height="1011" alt="image" src="https://github.com/user-attachments/assets/344a2a2b-3ca4-490c-af76-d13d9dd77914" />

<img width="1418" height="1015" alt="image" src="https://github.com/user-attachments/assets/0083d97b-bc11-47f9-978f-bb7d876b18b8" />
