### PR TITLE
Clean up JSON docs

### DIFF
--- a/doc/src/specifications/data-formats/json.md
+++ b/doc/src/specifications/data-formats/json.md
@@ -8,88 +8,74 @@ Both psio and serde_json represent structs with named fields as JSON objects.
 
 ## Tuples
 
-Both psio and serde_json represent tuples as JSON arrays. The empty tuple has a problem. `psio` renders `std::tuple<>{}` as you'd expect: `[]`. `serde_json`, however, renders `()`, the unit, as `null`. See `Empty`, below, for a workaround.
+Tuples are represented as JSON arrays. Beware of the [special cases](#special-cases-rust).
 
-- TODO: psio json support for tuples
+## Numbers
 
-## Unit Structs (Rust)
+Numbers in JSON are complicated by the fact that many JSON parsers treat all numbers as IEEE double precision floating point. To work around this limitation, some numbers MAY be represented as JSON strings.
 
-serde_json represents unit structs (like below) as `null`. We recommend against using this; [fracpack](fracpack.html) and [schema](schema.html) don't support it. See `Empty`, below, for an alternative.
+- Numbers that cannot be represented exactly in double precision SHOULD be represented as strings, unless the consumer is known to preserve the value correctly.
+- Numbers whose type can always be represented exactly in double precision, such as `i32` SHOULD be represented as numbers.
+- Parsers SHOULD accept either a number or string wherever a number is expected
+- Parsers SHOULD NOT round integer or fixed point fields. Note that many JSON parsers including JavaScript's `JSON.parse` and Rust's `serde_json` make this difficult or impossible when the field is a JSON number.
 
+## Strings
+
+Strings are represented as JSON strings.
+
+## Optional
+
+The empty case is represented as `null` and the non-empty case as the inner type. A struct field that is an empty optional MAY be omitted, instead.
+
+## Vectors and Arrays
+
+Both psio and serde_json represent vectors (`std::Vector`, `Vec`) and arrays (`std::array`, `[T]`) as JSON arrays. Beware of the [special cases](#special-cases-c).
+
+## Variants / Enums
+
+Variants are externally tagged, which is the [default representation in serde](https://serde.rs/enum-representations.html#externally-tagged).
+
+{{#tabs}}
+{{#tab name="Rust"}}
+```rust
+enum Fruit {
+    Banana(Banana),
+    Apple(Apple),
+    Orange(Orange),
+}
 ```
-struct MyUnit;
+{{#endtab}}
+{{#tab name="C++"}}
+```c++
+using Fruit = std::variant<Banana, Apple, Orange>;
 ```
+{{#endtab}}
+{{#endtabs}}
 
-## Tuple Structs (Rust)
-
-serde_json represents these structs as tuples. Beware of the [special cases](#special-cases-rust).
-
-```
-struct Empty();                         // []
-struct TupleOfOne((u32,));              // [value]
-struct TupleOfTwo(u32, String);         // [value, value]
-struct TupleOfThree(u32, String, f64);  // [value, value, value]
+```json
+{"Apple": {"variety": "Red Delicious"}}
 ```
 
 ### Special Cases (Rust)
 
-serde_json represents these structs as their inner values instead of as tuples (`[...]`). [Fracpack](fracpack.html) and [Schema](schema.html) act the same.
-
-```
-struct Single1(u32);        // 1234
-struct Single2(String, );   // "A string"
-```
-
-## Numbers
-
-64-bit Numbers are incredibly tricky in JSON, thanks in part to JavaScript, and thanks in part to common JSON libraries in type-safe languages.
-
-- JavaScript's number type can handle integers up to 53 bits unsigned, 54 signed. Extra precision is silently truncated. e.g. `10000000000000001 == 10000000000000000`.
-- JavaScript's [BigInt type](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) supports arbitrary precision, but JavaScript's built-in JSON conversions don't support it.
-
-The cleanest workaround seems to be to store 64-bit integers in quoted strings, but several widely-used JSON libraries in type-safe languages decided against that workaround, and reject incoming quoted numbers. serde_json used to support it (input only), but hit some [nasty conflicts](https://github.com/serde-rs/serde/pull/839) and had to remove it. serde_json provides customization (`serialize_with` and `deserialize_with`), but that gets cumbersome in nested types, e.g. `Option<Vec<u64>>`.
-
-Instead of trying to get type-safe JSON libraries to work around JavaScript's limitations, it's probably time we ask JavaScript to pull its own weight. JavaScript JSON Libraries exist which [handle BigInt](https://www.npmjs.com/package/json-bigint).
-
-`psio::to_json` (C++) does not place 64-bit numbers in quoted strings, but for a time `psio::from_json` will accept numbers in quoted strings for backwards compatibility. `serde_json` (Rust) does not place or accept numbers in quoted strings, unless you use customization. JavaScript needs a JSON library or will silently truncate values.
-
-- TODO: update `psio::to_json` to not quote numbers
-- TODO: Rethink GraphQL numeric handling. It currently relies on `to_json`.
-- TODO: update JavaScript code
-
-## Strings
-
-`psio::to_json` and `psio::from_json` use JSON strings for `std::string`. serde_json uses JSON strings for rust's various string types.
-
-## Optional
-
-Both psio (`std::optional`) and serde_json (`Option`) represent the empty case as `null` and the non-empty case as the inner type.
-
-## Vectors and Arrays
-
-Both psio and serde_json represent vectors (`std::Vector`, `Vec`) and arrays (`std::array`, `[]` (Rust)) as JSON arrays.
-
-## Byte vectors and arrays
-
-Byte vectors and arrays create a tricky problem. The JSON array-of-numbers representation is wasteful and annoying for this; hex strings are more compact and readable. Base-64 is even more compact, but it is near impossible to read and there are 7 standard RFC encodings, plus more.
-
-When should a vector or array use a hex representation? It's convenient to automatically switch when the element type is an 8-bit number, but this can be jarring for new service developers who don't expect it. We could have a separate hex type, but that's annoying for experienced developers in both Rust and C++. serdes already made a choice: vectors by default use the array notation in JSON. `serialize_with` and `deserialize_with` can opt into other representations, but they are cumbersome in nested types, e.g. `Option<Vec<u8>>`. That leaves a separate hex type.
-
-The Rust psibase library provides this wrapper type, which uses hex strings as its JSON format:
+By convention a tuple struct with a single element is used for the newtype pattern. Such a struct is represented as the inner value instead of as a tuple.
 
 ```rust
-// T must be `Vec<u8>`, `&[u8]`, or `[u8; SIZE]`
-pub struct Hex<T>(pub T);
+struct Single1(u32);        // 1234
 ```
 
-- TODO: C++: A fixed-size hex type
-- TODO: C++: Switch existing byte vectors and arrays within psibase structs to hex wrappers
-- TODO: C++: Remove hex representation from `std::vector<*>` and `std::array<*>`
-- TODO: C++: fracpack support for encoding `psio::bytes` as a vector instead of a struct of vector
-- TODO: C++: fracpack support for encoding new fixed-size hex type as an array instead of a struct of array
+If a tuple is intended the inner type can be a tuple
 
-## Variants / Enums
+```rust
+struct Single((u32,));      // [1234]
+```
 
-There are probably as many ways to represent these in JSON as there are grains of sand on the beach. serde_json supports [4 approaches](https://serde.rs/enum-representations.html). Of these, only the [externally tagged](https://serde.rs/enum-representations.html#externally-tagged) and [adjacently tagged](https://serde.rs/enum-representations.html#adjacently-tagged) representations cover all situations unambiguously.
+The unit type in Rust, `()`, is the same type as empty tuple and `serde_json` represents it as `null`. To get a JSON representation like other tuples, `[]`, use a tuple struct:
 
-- TODO: pick one. It will be easier on rust devs if we choose serde_json's default (externally tagged). It looks like I can take advantage of the syntax of the externally-tagged option to represent nested types in the schema without falling back on a DSL.
+```rust
+struct Empty();
+```
+
+### Special Cases (C++)
+
+A `std::vector`, `std::array`, or `std::span` with a value type of `char` or `unsigned char` is represented as a hex string. (Rust has a separate `Hex` type).


### PR DESCRIPTION
Random rants and design commentary don't belong in user facing documentation.