### PR TITLE
Update transaction expiration handling

### DIFF
--- a/packages/system/Transact/plugin/src/types.rs
+++ b/packages/system/Transact/plugin/src/types.rs
@@ -26,6 +26,12 @@ pub trait FromExpirationTime {
 
 impl FromExpirationTime for Tapos {
     fn from_expiration_time(seconds: u64) -> Self {
+        let tapos_str =
+            Host::server::get_json("/common/tapos/head").expect("[finish_tx] Failed to get TaPoS");
+
+        let partial_tapos: PartialTapos =
+            serde_json::from_str(&tapos_str).expect("[finish_tx] Failed to deserialize TaPoS");
+
         let expiration_time = SystemTime::now() + Duration::from_secs(seconds);
         let expiration = expiration_time
             .duration_since(UNIX_EPOCH)
@@ -33,11 +39,6 @@ impl FromExpirationTime for Tapos {
             .as_secs();
         assert!(expiration <= i64::MAX as u64, "expiration out of range");
         let expiration_timepoint = TimePointSec::from(expiration as i64);
-
-        let tapos_str =
-            Host::server::get_json("/common/tapos/head").expect("[finish_tx] Failed to get TaPoS");
-        let partial_tapos: PartialTapos =
-            serde_json::from_str(&tapos_str).expect("[finish_tx] Failed to deserialize TaPoS");
 
         Tapos {
             expiration: expiration_timepoint,


### PR DESCRIPTION
This makes the `/common/tapos/head` request occur prior to setting expiration by `SystemTime::now() + Duration::from_secs(seconds);` making it less likely to run into expiration issues faced in https://github.com/gofractally/psibase/issues/2005 

