### PR TITLE
add transient key imports and explicit extra signatures for invites

### DIFF
--- a/packages/system/Cargo.lock
+++ b/packages/system/Cargo.lock
@@ -658,9 +658,6 @@ dependencies = [
  "credentials",
  "psibase",
  "psibase-system-workspace-hack",
- "serde",
- "serde_json",
- "sha2",
  "wit-bindgen-rt",
 ]
 

--- a/packages/system/Credentials/plugin/Cargo.toml
+++ b/packages/system/Credentials/plugin/Cargo.toml
@@ -8,10 +8,7 @@ publish.workspace = true
 [dependencies]
 credentials = { path = "../service/", version = "0.27.0" }
 psibase.workspace = true
-serde.workspace = true
-serde_json.workspace = true
 wit-bindgen-rt.workspace = true
-sha2 = "0.10.7"
 psibase-system-workspace-hack.workspace = true
 
 [lib]
@@ -25,8 +22,6 @@ world = "impl"
 
 [package.metadata.component.target.dependencies]
 "host:common" = { path = "../../../user/Host/plugin/common/wit/world.wit" }
-"host:db" = { path = "../../../user/Host/plugin/db/wit/world.wit" }
 "host:types" = { path = "../../../user/Host/plugin/types/wit/world.wit" }
 "host:crypto" = { path = "../../../user/Host/plugin/crypto/wit/world.wit" }
 "transact:plugin" = { path = "../../Transact/plugin/wit/world.wit" }
-"base64:plugin" = { path = "../../../user/Base64/plugin/wit/world.wit" }

--- a/packages/system/Credentials/plugin/src/errors.rs
+++ b/packages/system/Credentials/plugin/src/errors.rs
@@ -1,6 +1,0 @@
-use psibase::plugin_error;
-
-plugin_error! {
-    pub ErrorType<'a>
-    Unauthorized(msg: &'a str) => "Unauthorized: {msg}",
-}

--- a/packages/system/Credentials/plugin/src/lib.rs
+++ b/packages/system/Credentials/plugin/src/lib.rs
@@ -1,84 +1,26 @@
 #[allow(warnings)]
 mod bindings;
 
-mod errors;
-use errors::ErrorType::*;
-
-use base64::plugin::url as base64;
 use bindings::*;
-use exports::credentials::plugin::{api::Guest as Api, types::Credential};
-use exports::transact_hook_action_auth::Guest as HookActionAuth;
-use host::common::client as Client;
-use host::db::store as Store;
-use host::types::types::Error;
-use sha2::Digest;
-use sha2::Sha256;
-use transact::plugin::{hooks::*, types::*};
-
-use crate::bindings::host::crypto::keyvault::sign_explicit;
+use exports::credentials::plugin::api::Guest as Api;
+use host::crypto::keyvault as HostCrypto;
+use host::types::types::Pem;
+use transact::plugin::intf as Transact;
+use transact::plugin::types::Claim;
 
 struct Credentials;
 
-const DB: Store::Database = Store::Database {
-    mode: Store::DbMode::NonTransactional,
-    duration: Store::StorageDuration::Ephemeral,
-};
-
-fn public_keys() -> Store::Bucket {
-    Store::Bucket::new(DB, "pubkeys")
-}
-
-fn private_keys() -> Store::Bucket {
-    Store::Bucket::new(DB, "privkeys")
-}
-
 impl Api for Credentials {
-    fn sign_latch(credential: Credential) {
-        // Implies an app can only sign for one credential at at a time in a particular call context
-        public_keys().set(&Client::get_sender(), &credential.p256_pub);
+    fn use_p256_credential(p256_priv: Pem) {
+        let pubkey_pem = HostCrypto::import_key_transient(&p256_priv)
+            .expect("host:crypto::import_key_transient failed");
+        let pubkey_der = HostCrypto::to_der(&pubkey_pem).expect("host:crypto::to_der failed");
 
-        let hash = Sha256::digest(credential.p256_pub.as_slice());
-        private_keys().set(&base64::encode(hash.as_ref()), &credential.p256_priv);
-
-        hook_action_auth();
-    }
-}
-
-impl HookActionAuth for Credentials {
-    fn on_action_auth_claims(action: Action) -> Result<Vec<Claim>, Error> {
-        if Client::get_sender() != "transact" {
-            return Err(Unauthorized("on_action_auth_proofs").into());
-        }
-        let pubkey = public_keys().get(&action.service);
-
-        if let Some(pubkey) = pubkey {
-            return Ok(vec![Claim {
-                verify_service: psibase::services::verify_sig::SERVICE.to_string(),
-                raw_data: pubkey,
-            }]);
-        }
-        return Ok(vec![]);
-    }
-
-    fn on_action_auth_proofs(
-        claims: Vec<Claim>,
-        transaction_hash: Vec<u8>,
-    ) -> Result<Vec<Proof>, Error> {
-        if Client::get_sender() != "transact" {
-            return Err(Unauthorized("on_action_auth_proofs").into());
-        }
-
-        let mut result = Vec::new();
-        for claim in claims {
-            let hash = Sha256::digest(claim.raw_data.as_slice());
-            if let Some(private_key) = private_keys().get(&base64::encode(hash.as_ref())) {
-                result.push(Proof {
-                    signature: sign_explicit(&transaction_hash, &private_key)?,
-                });
-            }
-        }
-
-        Ok(result)
+        let claim = Claim {
+            verify_service: psibase::services::verify_sig::SERVICE.to_string(),
+            raw_data: pubkey_der,
+        };
+        Transact::add_signature(&claim).expect("transact::add_signature failed");
     }
 }
 

--- a/packages/system/Credentials/plugin/wit/impl.wit
+++ b/packages/system/Credentials/plugin/wit/impl.wit
@@ -1,12 +1,9 @@
 package credentials:plugin;
 
 world impl {
-    include transact:plugin/hook-action-auth;
     include host:common/imports;
-    include host:db/imports;
     include host:crypto/imports;
-    include base64:plugin/imports;
+    include transact:plugin/imports;
 
     export api;
-    export types;
 }

--- a/packages/system/Credentials/plugin/wit/world.wit
+++ b/packages/system/Credentials/plugin/wit/world.wit
@@ -3,22 +3,12 @@
 ///   the account construction the transaction.
 package credentials:plugin;
 
-interface types {
-    record credential {
-        p256-pub: list<u8>,
-        p256-priv: list<u8>
-    }
-}
-
 interface api {
-    use types.{credential};
+    use host:types/types.{pem};
 
-    /// Sets a latch such that the next time the caller schedules an action to be
-    ///   added to the transaction during this execution context, the transaction
-    ///   will contain a proof for the specified credential.
-    /// During a given call context, a plugin can only authorize one credential.
-    /// Creating a second `sign-latch` will overwrite the first.
-    sign-latch: func(credential: credential);
+    /// Adds a signature to the current transaction using a P-256 private key.
+    /// The key is not permanently imported into the host's keyvault.
+    use-p256-credential: func(p256-priv: pem);
 }
 
 world imports {

--- a/packages/system/Transact/plugin/Cargo.toml
+++ b/packages/system/Transact/plugin/Cargo.toml
@@ -30,6 +30,7 @@ world = "impl"
 "accounts:plugin" = { path = "../../Accounts/plugin/accounts/wit/world.wit" }
 "permissions:plugin" = { path = "../../../user/Permissions/plugin/wit/world.wit" }
 "virtual-server:plugin" = { path = "../../VirtualServer/plugin/wit/transact.wit" }
+"host:crypto" = { path = "../../../user/Host/plugin/crypto/wit/world.wit" }
 
 [package.metadata.component.bindings]
 derives = ["serde::Serialize", "serde::Deserialize"]

--- a/packages/system/Transact/plugin/src/db.rs
+++ b/packages/system/Transact/plugin/src/db.rs
@@ -1,34 +1,12 @@
 use crate::bindings::clientdata::plugin::keyvalue as Keyvalue;
 use crate::bindings::transact::plugin::types::{Action, Claim};
 use psibase::fracpack::{Pack, Unpack};
-use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::thread_local;
 
-pub struct ActionAuthPlugins;
-impl ActionAuthPlugins {
-    const KEY: &'static str = "action_auth_plugin";
-
-    pub fn set(auth_plugin: String) {
-        Keyvalue::set(Self::KEY, &auth_plugin.packed());
-    }
-
-    pub fn get() -> Option<String> {
-        Keyvalue::get(Self::KEY)
-            .map(|a| <String>::unpacked(&a).expect("Failed to unpack auth plugin"))
-    }
-
-    pub fn has() -> bool {
-        Keyvalue::get(Self::KEY).is_some()
-    }
-
-    pub fn clear() {
-        Keyvalue::delete(Self::KEY);
-    }
-}
-
 thread_local! {
     static TX_ACTIONS: RefCell<Vec<Action>> = const { RefCell::new(Vec::new()) };
+    static TX_SIGNATURES: RefCell<Vec<Claim>> = const { RefCell::new(Vec::new()) };
     static LATCH: RefCell<Option<ProposeLatch>> = const { RefCell::new(None) };
 }
 
@@ -56,6 +34,26 @@ impl TxActions {
 
     pub fn take() -> Vec<Action> {
         TX_ACTIONS.with(|t| std::mem::take(&mut *t.borrow_mut()))
+    }
+}
+
+pub struct TxSignatures;
+
+impl TxSignatures {
+    pub fn reset() {
+        TX_SIGNATURES.with(|t| t.borrow_mut().clear());
+    }
+
+    pub fn add(claim: Claim) {
+        TX_SIGNATURES.with(|t| t.borrow_mut().push(claim));
+    }
+
+    pub fn is_empty() -> bool {
+        TX_SIGNATURES.with(|t| t.borrow().is_empty())
+    }
+
+    pub fn with<R>(f: impl FnOnce(&[Claim]) -> R) -> R {
+        TX_SIGNATURES.with(|t| f(&t.borrow()))
     }
 }
 
@@ -102,49 +100,6 @@ impl ProposeLatch {
 
     pub fn clear() {
         LATCH.with(|l| *l.borrow_mut() = None);
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct Claims {
-    pub claimant: String,
-    pub claims: Vec<Claim>,
-}
-
-pub struct ActionClaims;
-impl ActionClaims {
-    const KEY_CLAIMS: &'static str = "claims";
-
-    pub fn get_all() -> Vec<Claims> {
-        Keyvalue::get(Self::KEY_CLAIMS)
-            .map(|a| serde_json::from_slice(&a).expect("Failed to unpack claims"))
-            .unwrap_or_default()
-    }
-
-    pub fn get_all_flat() -> Vec<Claim> {
-        Self::get_all().into_iter().flat_map(|c| c.claims).collect()
-    }
-
-    pub fn push(claimant: String, new_claims: Vec<Claim>) {
-        let mut all_claims = Self::get_all();
-
-        if let Some(existing) = all_claims.iter_mut().find(|c| c.claimant == claimant) {
-            existing.claims.extend(new_claims);
-        } else {
-            all_claims.push(Claims {
-                claimant,
-                claims: new_claims,
-            });
-        }
-
-        Keyvalue::set(
-            Self::KEY_CLAIMS,
-            &serde_json::to_vec(&all_claims).expect("Failed to pack claims"),
-        );
-    }
-
-    pub fn clear() {
-        Keyvalue::delete(Self::KEY_CLAIMS);
     }
 }
 

--- a/packages/system/Transact/plugin/src/helpers.rs
+++ b/packages/system/Transact/plugin/src/helpers.rs
@@ -1,11 +1,13 @@
 use crate::bindings::accounts::plugin::api::get_account;
 use crate::bindings::accounts::plugin::api::get_current_user;
 use crate::bindings::host::common as Host;
+use crate::bindings::host::crypto::keyvault as HostCrypto;
 use crate::bindings::host::types::types::{self as HostTypes, BodyTypes, PluginRef};
 use crate::bindings::transact::plugin::hook_handlers::*;
+use crate::bindings::transact::plugin::types::{Action, Claim};
 use crate::errors::ErrorType::*;
 use crate::types::FromExpirationTime;
-use crate::{ActionAuthPlugins, ActionClaims, ActionSenderHook, ProposeLatch};
+use crate::{ActionSenderHook, ProposeLatch, TxSignatures};
 use psibase::fracpack::Pack;
 use psibase::{Hex, MethodNumber, SignedTransaction, Tapos, Transaction};
 use serde::Serialize;
@@ -59,18 +61,19 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-// The auth service can parameterize what claims to add to a transaction by both the sender
-//   and the actions in the transaction.
-// The auth service is therefore the only service other than transact that gets to see
-//   in full what actions are being taken by a user.
-pub fn get_claims(actions: &[Action], use_hooks: bool) -> Result<Vec<Claim>, HostTypes::Error> {
+pub fn sign_with_claim(claim: &Claim, tx_hash: &[u8]) -> Result<Vec<u8>, HostTypes::Error> {
+    HostCrypto::sign(tx_hash, &claim.raw_data)
+}
+
+// User auth claims come from hook-user-auth. Extra signatures added via
+// add-signature (e.g. invite credentials) are appended after.
+pub fn get_claims(actions: &[Action]) -> Result<Vec<Claim>, HostTypes::Error> {
     if actions.is_empty() {
         return Ok(vec![]);
     }
 
     let mut claims = vec![];
 
-    // Add claims for the logged-in user if there are any
     if let Some(user) = get_current_user() {
         let auth_service_acc = get_account(&user)?.unwrap().auth_service;
         let plugin_ref = PluginRef::new(&auth_service_acc, "plugin", "transact-hook-user-auth");
@@ -79,10 +82,14 @@ pub fn get_claims(actions: &[Action], use_hooks: bool) -> Result<Vec<Claim>, Hos
         }
     }
 
-    if use_hooks {
-        // Add additional claims from action hooks
-        claims.extend(ActionClaims::get_all_flat());
-    }
+    TxSignatures::with(|extra| {
+        for c in extra {
+            claims.push(Claim {
+                verify_service: c.verify_service.clone(),
+                raw_data: c.raw_data.clone(),
+            });
+        }
+    });
 
     Ok(claims)
 }
@@ -99,35 +106,26 @@ pub fn get_claims_for_user(user: &String) -> Result<Vec<Claim>, HostTypes::Error
     Ok(claims)
 }
 
-pub fn get_proofs(
-    tx_hash: &[u8; 32],
-    use_hooks: bool,
-) -> Result<Vec<Hex<Vec<u8>>>, HostTypes::Error> {
+pub fn get_proofs(tx_hash: &[u8; 32]) -> Result<Vec<Hex<Vec<u8>>>, HostTypes::Error> {
     let mut proofs = vec![];
 
     if let Some(user) = get_current_user() {
         let auth_service_acc = get_account(&user)?.unwrap().auth_service;
         let plugin_ref = PluginRef::new(&auth_service_acc, "plugin", "transact-hook-user-auth");
         if let Some(proof) = on_user_auth_proof(plugin_ref, &user, tx_hash)? {
-            proofs.push(proof);
+            proofs.push(Hex::from(proof.signature));
         }
     }
 
-    if use_hooks {
-        for claims in ActionClaims::get_all() {
-            let plugin_ref =
-                PluginRef::new(&claims.claimant, "plugin", "transact-hook-action-auth");
-            proofs.extend(on_action_auth_proofs(plugin_ref, &claims.claims, tx_hash)?);
-        }
+    let extra_proofs = TxSignatures::with(|extra| -> Result<Vec<Hex<Vec<u8>>>, HostTypes::Error> {
+        extra
+            .iter()
+            .map(|claim| sign_with_claim(claim, tx_hash).map(Hex::from))
+            .collect()
+    })?;
+    proofs.extend(extra_proofs);
 
-        ActionAuthPlugins::clear();
-        ActionClaims::clear();
-    }
-
-    Ok(proofs
-        .into_iter()
-        .map(|proof| Hex::from(proof.signature))
-        .collect())
+    Ok(proofs)
 }
 
 pub fn get_proofs_for_user(
@@ -194,12 +192,10 @@ impl From<Transaction> for SimpleTx {
 }
 
 pub fn make_transaction(actions: Vec<Action>, expiration_seconds: u64) -> Transaction {
-    let claims = get_claims(&actions, true).expect("Failed to retrieve claims from auth plugin");
+    let claims = get_claims(&actions).expect("Failed to retrieve claims from auth plugin");
     let claims: Vec<psibase::Claim> = claims.into_iter().map(Into::into).collect();
 
     let actions: Vec<psibase::Action> = actions.into_iter().map(Into::into).collect();
-
-    // TODO: hook_tapos?
 
     let tapos = Tapos::from_expiration_time(expiration_seconds);
 

--- a/packages/system/Transact/plugin/src/lib.rs
+++ b/packages/system/Transact/plugin/src/lib.rs
@@ -15,7 +15,7 @@ use db::*;
 use host::common::{self as Host, server as Server};
 use host::db::store as Store;
 use host::types::types::{self as HostTypes, BodyTypes};
-use transact::plugin::types::Claim;
+use transact::plugin::types::{Action, Claim};
 use virtual_server::plugin::transact as VirtualServer;
 
 // Exported interfaces/types

--- a/packages/system/Transact/plugin/src/lib.rs
+++ b/packages/system/Transact/plugin/src/lib.rs
@@ -11,12 +11,11 @@ mod db;
 mod types;
 use db::*;
 
-use transact::plugin::hook_handlers::*;
-
 // Other plugins
 use host::common::{self as Host, server as Server};
 use host::db::store as Store;
 use host::types::types::{self as HostTypes, BodyTypes};
+use transact::plugin::types::Claim;
 use virtual_server::plugin::transact as VirtualServer;
 
 // Exported interfaces/types
@@ -45,7 +44,7 @@ psibase::define_trust! {
         ",
     }
     functions {
-        None => [hook_action_auth, unhook_actions_sender, add_action_to_transaction],
+        None => [add_signature, unhook_actions_sender, add_action_to_transaction],
         Low => [],
         High => [hook_actions_sender],
         Max => [set_propose_latch, propose, set_snapshot_time, start_tx, finish_tx, get_query_token],
@@ -60,23 +59,19 @@ psibase::define_trust! {
 // 3.   on-actions-sender           - the propose-latch account (if any) is used;
 //                                    otherwise the hooked plugin can set the sender of the action;
 //                                    otherwise the logged-in user is used by default.
-// 4.   on-action-auth-claims       - the hooked plugin can add claims for this action
+// 4. add-signature                 - callers may append extra claims (e.g. invite credentials)
 //
 // 5. finish-tx
 // 6.   on-user-claim               - the user auth plugin adds the user claim
-// 7.   construct transaction
+// 7.   construct transaction       - includes any claims from add-signature
 // 8.   hash-transaction
 // 9.   on-user-auth-proof          - the user auth plugin adds the user proof
-// 10.  on-action-auth-proofs       - the hooked plugin can add proofs for their action claims
+// 10.  sign extra claims           - proofs for add-signature claims via host:crypto
 // 11.  publish transaction
 
 struct TransactPlugin {}
 
 impl Hooks for TransactPlugin {
-    fn hook_action_auth() {
-        ActionAuthPlugins::set(Host::client::get_sender());
-    }
-
     fn hook_actions_sender() {
         assert_authorized_with_whitelist(FunctionName::hook_actions_sender, vec!["invite".into()])
             .unwrap();
@@ -116,13 +111,6 @@ fn schedule_action(
         raw_data: packed_args,
     };
 
-    if let Some(plugin) = ActionAuthPlugins::get() {
-        ActionAuthPlugins::clear();
-        let plugin_ref = HostTypes::PluginRef::new(&plugin, "plugin", "transact-hook-action-auth");
-        let claims = on_action_auth_claims(plugin_ref, &action)?;
-        ActionClaims::push(plugin, claims);
-    }
-
     if ProposeLatch::is_active() {
         ProposeLatch::add(action);
     } else {
@@ -138,6 +126,11 @@ impl Intf for TransactPlugin {
         packed_args: Vec<u8>,
     ) -> Result<(), HostTypes::Error> {
         schedule_action(Host::client::get_sender(), method_name, packed_args)
+    }
+
+    fn add_signature(claim: Claim) -> Result<(), HostTypes::Error> {
+        TxSignatures::add(claim);
+        Ok(())
     }
 
     fn set_propose_latch(account: Option<String>) -> Result<(), HostTypes::Error> {
@@ -226,17 +219,13 @@ impl Admin for TransactPlugin {
             println!("[Warning] Propose latch should already have been cleared.");
             ProposeLatch::clear();
         }
-        if ActionAuthPlugins::has() {
-            println!("[Warning] Auth plugins should already have been cleared.");
-            ActionAuthPlugins::clear();
-        }
         if ActionSenderHook::has() {
             println!("[Warning] Action sender hook should already have been cleared.");
             ActionSenderHook::clear();
         }
-        if ActionClaims::get_all().len() > 0 {
-            println!("[Warning] Action claims should already have been cleared.");
-            ActionClaims::clear();
+        if !TxSignatures::is_empty() {
+            println!("[Warning] Tx signatures should already have been cleared.");
+            TxSignatures::reset();
         }
     }
 
@@ -257,6 +246,7 @@ impl Admin for TransactPlugin {
         let mut actions = TxActions::take();
 
         if actions.len() == 0 {
+            TxSignatures::reset();
             Store::flush_transactional_data();
             return Ok(());
         }
@@ -271,7 +261,7 @@ impl Admin for TransactPlugin {
 
         let signed_tx = SignedTransaction {
             transaction: Hex::from(tx.packed()),
-            proofs: get_proofs(&sha256(&tx.packed()), true)?,
+            proofs: get_proofs(&sha256(&tx.packed()))?,
             subjectiveData: None,
         };
         if signed_tx.proofs.len() != tx.claims.len() {
@@ -297,6 +287,7 @@ impl Admin for TransactPlugin {
             Some(err) => Err(TransactionError(err).into()),
             None => {
                 println!("Transaction executed successfully");
+                TxSignatures::reset();
                 Store::flush_transactional_data();
                 Ok(())
             }

--- a/packages/system/Transact/plugin/wit/impl.wit
+++ b/packages/system/Transact/plugin/wit/impl.wit
@@ -21,6 +21,7 @@ world impl {
     include permissions:plugin/imports;
     
     import virtual-server:plugin/transact;
+    include host:crypto/imports;
 
     export admin;
     export intf;

--- a/packages/system/Transact/plugin/wit/world.wit
+++ b/packages/system/Transact/plugin/wit/world.wit
@@ -6,7 +6,8 @@ interface types {
     record claim {
         /// The name of the service used to verify the claim is valid
         verify-service: string,
-        /// The raw claim data
+        /// The raw claim data (typically the DER-encoded public key
+        /// whose matching private key produces the proof)
         raw-data: list<u8>,
     }
 
@@ -29,13 +30,7 @@ interface types {
     }
 }
 
-/// Hooks allow plugins to hook into the transact plugin and customize its behavior
-/// during transaction construction and authorization.
 interface hooks {
-    /// Allows the the caller plugin to add transaction authorization claims and proofs
-    /// based on the next action added to this transaction.
-    hook-action-auth: func();
-
     /// Allows the caller plugin to manage the sender of any subsequent actions added to this
     /// transaction.
     hook-actions-sender: func();
@@ -68,6 +63,7 @@ interface admin {
 
 interface intf {
     use host:types/types.{error};
+    use types.{claim};
 
     /// Adds the specified service action to the current transaction.
     ///
@@ -79,6 +75,16 @@ interface intf {
     /// * `method-name`: The method name of the action being called
     /// * `packed-args`: The arguments for the action, packed into fracpack format
     add-action-to-transaction: func(method-name: string, packed-args: list<u8>) -> result<_, error>;
+
+    /// Append a `claim` to the current transaction. At finish-tx, Transact
+    /// produces the matching proof by calling `host:crypto/keyvault.sign`
+    /// with `claim.raw-data` (typically a DER-encoded public key); the host
+    /// keystore (persistent or transient — see
+    /// `host:crypto/keyvault.import-key-transient`) must contain the matching
+    /// private key.
+    ///
+    /// May be called any number of times during transaction construction.
+    add-signature: func(claim: claim) -> result<_, error>;
 
     /// Set or clear the propose-latch.
     ///
@@ -144,29 +150,6 @@ interface network {
 
     /// Set snapshot interval period network wide
     set-snapshot-time: func(seconds: u32) -> result<_, error>;
-}
-
-world hook-action-auth {
-    import hooks;
-    export transact-hook-action-auth: interface {
-        use host:types/types.{error};
-        use types.{claim, proof, action};
-
-        /// Gets the claim(s) needed to satisfy the authorization of the sender of this transaction
-        ///
-        /// Parameters
-        /// * `action`: The action being added to the current transaction context
-        on-action-auth-claims: func(action: action) -> result<list<claim>, error>;
-
-        /// Provides proof(s) of the claim(s).
-        /// If there are multiple claims, the returned list of proofs must be in the same order as the
-        /// claims were specified.
-        ///
-        /// Parameters
-        /// * `claims`: The claims this transaction is attempting to satisfy
-        /// * `transaction-hash`: A hash of the current transaction. Often signed to generate a proof.
-        on-action-auth-proofs: func(claims: list<claim>, transaction-hash: list<u8>) -> result<list<proof>, error>;
-    }
 }
 
 world hook-actions-sender {

--- a/packages/user/Host/plugin/crypto/src/lib.rs
+++ b/packages/user/Host/plugin/crypto/src/lib.rs
@@ -29,7 +29,7 @@ psibase::define_trust! {
         ",
     }
     functions {
-        None => [generate_unmanaged_keypair, pub_from_priv, to_der, sign_explicit],
+        None => [generate_unmanaged_keypair, pub_from_priv, to_der, sign_explicit, import_key_transient],
         Low => [import_key],
         High => [sign],
     }
@@ -95,6 +95,11 @@ impl KeyVault for HostCrypto {
         )?;
 
         Supervisor::import_key(&private_key)
+    }
+
+    fn import_key_transient(private_key: Pem) -> Result<Pem, HostTypes::Error> {
+        assert_authorized(FunctionName::import_key_transient)?;
+        Supervisor::import_key_transient(&private_key)
     }
 }
 

--- a/packages/user/Host/plugin/crypto/wit/deps/supervisor.wit
+++ b/packages/user/Host/plugin/crypto/wit/deps/supervisor.wit
@@ -13,6 +13,11 @@ interface intf {
     /// Imports a PEM-encoded private key into the keyvault.
     /// Returns the corresponding public key in PEM format.
     import-key: func(private-key: pem) -> result<pem, error>;
+
+    /// Imports a PEM-encoded private key into a transient keyvault that
+    /// is automatically cleared at the end of the current transaction
+    /// context. Returns the corresponding public key in PEM format.
+    import-key-transient: func(private-key: pem) -> result<pem, error>;
 }
 
 world imports {

--- a/packages/user/Host/plugin/crypto/wit/world.wit
+++ b/packages/user/Host/plugin/crypto/wit/world.wit
@@ -25,6 +25,11 @@ interface keyvault {
     /// Imports a PEM-encoded private key into the keyvault.
     /// Returns the corresponding public key in PEM format.
     import-key: func(private-key: pem) -> result<pem, error>;
+
+    /// Imports a PEM-encoded private key into a transient keyvault that
+    /// is automatically cleared at the end of the current transaction
+    /// context. Returns the corresponding public key in PEM format.
+    import-key-transient: func(private-key: pem) -> result<pem, error>;
 }
 
 world imports {

--- a/packages/user/Invite/plugin/src/lib.rs
+++ b/packages/user/Invite/plugin/src/lib.rs
@@ -162,13 +162,7 @@ impl Invitee for InvitePlugin {
 fn use_active_invite() {
     hook_actions_sender();
 
-    let cred_private_key = InviteTokensTable::active_credential_key().unwrap();
-    let cred_public_key = host::crypto::pub_from_priv(&cred_private_key).unwrap();
-
-    credentials::api::sign_latch(&credentials::types::Credential {
-        p256_pub: host::crypto::to_der(&cred_public_key).unwrap(),
-        p256_priv: host::crypto::to_der(&cred_private_key).unwrap(),
-    });
+    credentials::api::use_p256_credential(&InviteTokensTable::active_credential_key().unwrap());
 }
 
 impl Redemption for InvitePlugin {

--- a/packages/user/Supervisor/ui/src/host-interface.ts
+++ b/packages/user/Supervisor/ui/src/host-interface.ts
@@ -41,6 +41,7 @@ export interface BridgeImports {
         sign: (msg: Uint8Array, publicKey: string) => Uint8Array;
         signExplicit: (msg: Uint8Array, privateKey: string) => Uint8Array;
         importKey: (privateKey: string) => string;
+        importKeyTransient: (privateKey: string) => string;
     };
     "supervisor:bridge/database": {
         get: (duration: number, key: string) => Uint8Array | null;

--- a/packages/user/Supervisor/ui/src/plugin/plugin-host.ts
+++ b/packages/user/Supervisor/ui/src/plugin/plugin-host.ts
@@ -219,6 +219,8 @@ export class PluginHost implements HostInterface {
                     this.supervisor.signExplicit(msg, privateKey),
                 importKey: (privateKey) =>
                     this.supervisor.importKey(privateKey),
+                importKeyTransient: (privateKey) =>
+                    this.supervisor.importKeyTransient(privateKey),
             },
             "supervisor:bridge/database": {
                 get: (duration, key) => this.dbGet(duration, key),

--- a/packages/user/Supervisor/ui/src/supervisor.ts
+++ b/packages/user/Supervisor/ui/src/supervisor.ts
@@ -284,6 +284,14 @@ export class Supervisor implements AppInterface {
         );
     }
 
+    importKeyTransient(privateKey: string): string {
+        return this.supervisorCall(
+            getCallArgs("webcrypto", "plugin", "api", "import-key-transient", [
+                privateKey,
+            ]),
+        );
+    }
+
     signExplicit(msg: Uint8Array, privateKey: string): Uint8Array {
         // future: call out to SubtleCrypto
         return this.supervisorCall(

--- a/packages/user/WebCrypto/plugin/src/db.rs
+++ b/packages/user/WebCrypto/plugin/src/db.rs
@@ -12,6 +12,16 @@ fn keys_table() -> Bucket {
     )
 }
 
+fn temp_keys_table() -> Bucket {
+    Bucket::new(
+        Database {
+            mode: DbMode::NonTransactional,
+            duration: StorageDuration::Ephemeral,
+        },
+        "temp_keys",
+    )
+}
+
 fn get_hash(key: &Pem) -> String {
     let pem = pem::Pem::try_from_pem_str(&key).expect("Failed to hash key");
     let digest = seahash::hash(&pem.contents().to_vec());
@@ -25,17 +35,19 @@ impl ManagedKeys {
         keys_table().set(&get_hash(pubkey), &privkey);
     }
 
-    pub fn get(pubkey: &Pem) -> Vec<u8> {
-        keys_table()
-            .get(&get_hash(pubkey))
-            .expect("ManagedKeys::get: Key not found")
+    pub fn get(pubkey: &Pem) -> Option<Vec<u8>> {
+        keys_table().get(&get_hash(pubkey))
+    }
+}
+
+pub struct TempKeys;
+
+impl TempKeys {
+    pub fn add(pubkey: &Pem, privkey: &[u8]) {
+        temp_keys_table().set(&get_hash(pubkey), &privkey);
     }
 
-    pub fn _has(pubkey: &Pem) -> bool {
-        keys_table().get(&get_hash(pubkey)).is_some()
-    }
-
-    pub fn _delete(pubkey: &Pem) {
-        keys_table().delete(&get_hash(pubkey));
+    pub fn get(pubkey: &Pem) -> Option<Vec<u8>> {
+        temp_keys_table().get(&get_hash(pubkey))
     }
 }

--- a/packages/user/WebCrypto/plugin/src/lib.rs
+++ b/packages/user/WebCrypto/plugin/src/lib.rs
@@ -63,7 +63,10 @@ impl Api for WebCryptoShim {
     fn sign(hashed_message: Vec<u8>, public_key: Vec<u8>) -> Result<Vec<u8>, HostTypes::Error> {
         assert!(Client::get_sender() == "supervisor");
 
-        let private_key = ManagedKeys::get(&pub_from_der(public_key)?);
+        let pubkey_pem = pub_from_der(public_key)?;
+        let private_key = ManagedKeys::get(&pubkey_pem)
+            .or_else(|| TempKeys::get(&pubkey_pem))
+            .expect("WebCrypto::sign: Key not found");
         Self::sign_explicit(hashed_message, private_key)
     }
 
@@ -76,6 +79,14 @@ impl Api for WebCryptoShim {
 
         // Hypothetical call out to SubtleCrypto
         // convert SubtleCrypto types to psibase types
+        Ok(public_key)
+    }
+
+    fn import_key_transient(private_key: Pem) -> Result<Pem, HostTypes::Error> {
+        assert!(Client::get_sender() == "supervisor");
+
+        let public_key = pub_from_priv(private_key.clone())?;
+        TempKeys::add(&public_key, &to_der(private_key)?);
         Ok(public_key)
     }
 }

--- a/packages/user/WebCrypto/plugin/wit/world.wit
+++ b/packages/user/WebCrypto/plugin/wit/world.wit
@@ -15,6 +15,11 @@ interface api {
     ///   with the specified private key.
     /// Returns the corresponding public key in PEM format.
     import-key: func(private-key: pem) -> result<pem, error>;
+
+    /// Imports a PEM-encoded private key into a transient keyvault that
+    ///   is automatically cleared at the end of the current transaction
+    ///   context. Returns the corresponding public key in PEM format.
+    import-key-transient: func(private-key: pem) -> result<pem, error>;
 }
 
 world imports {


### PR DESCRIPTION
PR #2 in the series that started with https://github.com/gofractally/psibase/pull/1831

This is progress in the direction of the removal of our custom callback infrastructure. It would be better to simply do without callbacks until the component model defines a standard solution for them, and only then add them, instead of using this non-portable PluginRef solution.

This one replaces `hook-action-auth`, with an explicit `transact.add-signature` plus a host `import-key-transient`. `import-key-transient` allows the host to sign for a pubkey that was imported in the same call context. 

This PR also simplifies the `credentials` plugin (which was the only other consumer of hook-action-auth).


