### PR TITLE
Secret storage

### DIFF
--- a/doc/src/default-apps/x-admin/http-endpoints.md
+++ b/doc/src/default-apps/x-admin/http-endpoints.md
@@ -91,7 +91,7 @@ A typical boot sequence contains more configuration than is able to fit in a sin
 | `id`       | String  | An opaque string that uniquely identifies the device |
 | `unlocked` | Boolean | `true` if the device is currently unlocked           |
 
-`POST` to `/native/admin/keys/unlock` unlocks a cryptographic device.
+`POST` to `/native/admin/keys/unlock` unlocks a cryptographic device. If [persistent secrets](../../run-infrastructure/cli/psinode.md#general-options) are enabled, the device will remain unlocked when the server restarts.
 
 | Field    | Type   | Description                 |
 |----------|--------|-----------------------------|

--- a/doc/src/run-infrastructure/cli/psinode.md
+++ b/doc/src/run-infrastructure/cli/psinode.md
@@ -42,6 +42,10 @@ psinode - The psibase blockchain server
 
   Use this private key to sign blocks. Any number of keys may be provided, but only the one that matches the public key corresponding to the producer name will be used.
 
+- `--passphrase-file` *filename*
+
+  Provides a passphrase that will be used to encrypt secrets stored by the node. The passphrase can also be passed in the environment variable `PSIBASE_PASSPHRASE`. If no passphrase is provided, secrets will not be stored and will be discarded when the server exits.
+
 - `--pkcs11-module` *filename*
 
   Loads a PKCS #11 module from *filename*. The server will be able to sign blocks using keys from the module. The tokens that the module provides must be unlocked using the HTTP API before they can be used. This option can appear any number of times.

--- a/libraries/psibase/CMakeLists.txt
+++ b/libraries/psibase/CMakeLists.txt
@@ -217,6 +217,7 @@ function(add suffix)
             native/src/prefix.cpp
             native/src/Prover.cpp
             native/src/RunQueue.cpp
+            native/src/Secrets.cpp
             native/src/Socket.cpp
             native/src/SystemContext.cpp
             native/src/TransactionContext.cpp

--- a/libraries/psibase/native/include/psibase/Secrets.hpp
+++ b/libraries/psibase/native/include/psibase/Secrets.hpp
@@ -10,7 +10,7 @@ namespace psibase
    class Secrets
    {
      public:
-      Secrets(const std::filesystem::path& file, std::span<const char, 32> master_key);
+      Secrets(const std::filesystem::path& file, std::string_view passphrase);
       ~Secrets();
       std::optional<std::span<const char>> get(std::span<const char> key);
       void put(std::span<const char> key, std::span<const char> value);

--- a/libraries/psibase/native/include/psibase/Secrets.hpp
+++ b/libraries/psibase/native/include/psibase/Secrets.hpp
@@ -14,6 +14,7 @@ namespace psibase
       ~Secrets();
       std::optional<std::span<const char>> get(std::span<const char> key);
       void put(std::span<const char> key, std::span<const char> value);
+      void remove(std::span<const char> key);
 
      private:
       struct Impl;

--- a/libraries/psibase/native/include/psibase/Secrets.hpp
+++ b/libraries/psibase/native/include/psibase/Secrets.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <span>
+
+namespace psibase
+{
+   class Secrets
+   {
+     public:
+      Secrets(const std::filesystem::path& file, std::span<const char, 32> master_key);
+      ~Secrets();
+      std::optional<std::span<const char>> get(std::span<const char> key);
+      void put(std::span<const char> key, std::span<const char> value);
+
+     private:
+      struct Impl;
+      std::unique_ptr<Impl> impl;
+   };
+}  // namespace psibase

--- a/libraries/psibase/native/include/psibase/openssl.hpp
+++ b/libraries/psibase/native/include/psibase/openssl.hpp
@@ -2,6 +2,7 @@
 
 #include <openssl/ec.h>
 #include <openssl/evp.h>
+#include <openssl/kdf.h>
 
 // Some C++ wrappers for OpenSSL
 
@@ -13,6 +14,9 @@ namespace psibase
       void operator()(EVP_MD_CTX* ctx) const { EVP_MD_CTX_free(ctx); }
       void operator()(EVP_PKEY* key) const { EVP_PKEY_free(key); }
       void operator()(EVP_PKEY_CTX* ctx) const { EVP_PKEY_CTX_free(ctx); }
+      void operator()(EVP_KDF* kdf) const { EVP_KDF_free(kdf); }
+      void operator()(EVP_KDF_CTX* ctx) const { EVP_KDF_CTX_free(ctx); }
+      void operator()(EVP_CIPHER_CTX* ctx) const { EVP_CIPHER_CTX_free(ctx); }
       void operator()(ECDSA_SIG* sig) const { ECDSA_SIG_free(sig); }
       void operator()(BIGNUM* bn) const { BN_free(bn); }
       void operator()(ASN1_OCTET_STRING* s) const { ASN1_OCTET_STRING_free(s); }

--- a/libraries/psibase/native/src/Secrets.cpp
+++ b/libraries/psibase/native/src/Secrets.cpp
@@ -1,0 +1,206 @@
+#include <psibase/Secrets.hpp>
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <cassert>
+#include <cstring>
+#include <fstream>
+#include <psibase/check.hpp>
+#include <psibase/fileUtil.hpp>
+#include <psio/fracpack.hpp>
+#include <psio/reflect.hpp>
+#include <vector>
+
+using namespace psibase;
+
+// AES-GCM
+// magic (4-bytes) || version (4-bytes) || iv (16-bytes) || cyphertext || tag (16-bytes)
+
+namespace
+{
+   constexpr unsigned char prefix[] = {0, 0xcf, 0x88, 's', 1, 0, 0, 0};
+
+   constexpr std::size_t prefix_size = sizeof(prefix);
+   constexpr std::size_t block_size  = 16;
+   constexpr std::size_t iv_size     = block_size;
+   constexpr std::size_t tag_size    = block_size;
+
+   struct FreeCipher
+   {
+      void operator()(EVP_CIPHER_CTX* ctx) const { EVP_CIPHER_CTX_free(ctx); }
+   };
+
+   void writeEncryptedFile(const std::filesystem::path& file,
+                           std::span<const char>        data,
+                           std::span<const char, 32>    master_key)
+   {
+      const std::size_t cyphertext_size = data.size();
+      const std::size_t output_size     = prefix_size + iv_size + cyphertext_size + tag_size;
+      auto error = [&] { abortMessage("Failed to write encrypted file: " + file.string()); };
+      std::vector<unsigned char> buffer(output_size);
+      {
+         auto ctx = std::unique_ptr<EVP_CIPHER_CTX, FreeCipher>(EVP_CIPHER_CTX_new());
+         if (!ctx)
+            error();
+         unsigned char* outp = buffer.data();
+         std::memcpy(outp, prefix, prefix_size);
+         outp += prefix_size;
+
+         if (RAND_bytes(outp, iv_size) != 1)
+            error();
+         const unsigned char* iv = outp;
+         outp += iv_size;
+
+         if (!EVP_EncryptInit_ex2(ctx.get(), EVP_aes_256_gcm(),
+                                  reinterpret_cast<const unsigned char*>(master_key.data()), iv,
+                                  nullptr))
+         {
+            error();
+         }
+         std::size_t          remaining = data.size();
+         const unsigned char* pos       = reinterpret_cast<const unsigned char*>(data.data());
+         int                  outl;
+         if (!EVP_EncryptUpdate(ctx.get(), nullptr, &outl, prefix, prefix_size))
+         {
+            error();
+         }
+         if (!EVP_EncryptUpdate(ctx.get(), outp, &outl, pos, remaining))
+         {
+            error();
+         }
+         outp += outl;
+         if (!EVP_EncryptFinal_ex(ctx.get(), outp, &outl))
+         {
+            error();
+         }
+         outp += outl;
+         if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_GET_TAG, tag_size, outp))
+         {
+            error();
+         }
+         outp += tag_size;
+         assert(outp - buffer.data() == buffer.size());
+      }
+      std::ofstream stream(file, std::ios_base::binary);
+      if (!stream.write(reinterpret_cast<const char*>(buffer.data()), buffer.size()))
+      {
+         error();
+      }
+   }
+
+   std::vector<char> readEncryptedFile(const std::filesystem::path& file,
+                                       std::span<const char, 32>    master_key)
+   {
+      auto error = [&] { abortMessage("Failed to read encrypted file: " + file.string()); };
+      auto data  = readWholeFile(file.string());
+      if (data.size() < prefix_size + iv_size + tag_size)
+      {
+         error();
+      }
+      const unsigned char* inp = reinterpret_cast<const unsigned char*>(data.data());
+      auto                 pfx = std::span<const unsigned char, prefix_size>{inp, prefix_size};
+      inp += prefix_size;
+      auto iv = std::span<const unsigned char, iv_size>{inp, iv_size};
+      inp += iv_size;
+      auto ciphertext_size = data.size() - prefix_size - iv_size - tag_size;
+      auto ciphertext      = std::span<const unsigned char>{inp, ciphertext_size};
+      inp += ciphertext_size;
+      auto tag = std::span<const unsigned char, tag_size>{inp, tag_size};
+      inp += tag_size;
+      assert(inp - reinterpret_cast<const unsigned char*>(data.data()) == data.size());
+      if (!std::ranges::equal(prefix, pfx))
+      {
+         error();
+      }
+      auto ctx = std::unique_ptr<EVP_CIPHER_CTX, FreeCipher>(EVP_CIPHER_CTX_new());
+      if (!ctx)
+         error();
+      if (!EVP_DecryptInit_ex2(ctx.get(), EVP_aes_256_gcm(),
+                               reinterpret_cast<const unsigned char*>(master_key.data()), iv.data(),
+                               nullptr))
+      {
+         error();
+      }
+      if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_TAG, tag.size(),
+                               const_cast<void*>(static_cast<const void*>(tag.data()))))
+      {
+         error();
+      }
+      std::vector<char> result(ciphertext_size);
+      auto              out = reinterpret_cast<unsigned char*>(result.data());
+      int               outl;
+      if (!EVP_DecryptUpdate(ctx.get(), nullptr, &outl, pfx.data(), prefix_size))
+      {
+         error();
+      }
+      if (!EVP_DecryptUpdate(ctx.get(), out, &outl, ciphertext.data(), ciphertext_size))
+      {
+         error();
+      }
+      out += outl;
+      if (!EVP_DecryptFinal_ex(ctx.get(), out, &outl))
+      {
+         error();
+      }
+      out += outl;
+      assert(out - reinterpret_cast<const unsigned char*>(result.data()) == result.size());
+      return result;
+   }
+
+   struct KeyValue
+   {
+      std::vector<char> key;
+      std::vector<char> value;
+      std::string_view  skey() const { return {key.data(), key.size()}; }
+      PSIO_REFLECT(KeyValue, key, value);
+   };
+}  // namespace
+
+struct Secrets::Impl
+{
+   std::filesystem::path filename;
+   std::vector<KeyValue> items;
+   std::array<char, 32>  key;
+};
+
+Secrets::Secrets(const std::filesystem::path& file, std::span<const char, 32> master_key)
+    : impl(new Impl{file, std::filesystem::exists(file) ? psio::from_frac<std::vector<KeyValue>>(
+                                                              readEncryptedFile(file, master_key))
+                                                        : std::vector<KeyValue>()})
+{
+   std::memcpy(impl->key.data(), master_key.data(), master_key.size());
+}
+
+Secrets::~Secrets() = default;
+
+std::optional<std::span<const char>> Secrets::get(std::span<const char> key)
+{
+   auto k   = std::string_view{key.data(), key.size()};
+   auto pos = std::ranges::lower_bound(impl->items, k, {}, &KeyValue::skey);
+   if (pos != impl->items.end() && pos->skey() == k)
+   {
+      return pos->value;
+   }
+   else
+   {
+      return {};
+   }
+}
+
+void Secrets::put(std::span<const char> key, std::span<const char> value)
+{
+   auto k   = std::string_view{key.data(), key.size()};
+   auto pos = std::ranges::lower_bound(impl->items, k, {}, &KeyValue::skey);
+   if (pos != impl->items.end() && pos->skey() == k)
+   {
+      pos->value.reserve(value.size());
+      pos->value.clear();
+      pos->value.insert(pos->value.end(), value.begin(), value.end());
+   }
+   else
+   {
+      impl->items.insert(pos, KeyValue{std::vector(key.begin(), key.end()),
+                                       std::vector(value.begin(), value.end())});
+   }
+   writeEncryptedFile(impl->filename, psio::to_frac(impl->items), impl->key);
+}

--- a/libraries/psibase/native/src/Secrets.cpp
+++ b/libraries/psibase/native/src/Secrets.cpp
@@ -280,6 +280,11 @@ struct Secrets::Impl
          items(psio::from_frac<std::vector<KeyValue>>(contents.data))
    {
    }
+   void flush()
+   {
+      if (file)
+         writeEncryptedFile(file->filename, psio::to_frac(items), file->params, file->key);
+   }
    std::optional<EncryptedFileInfo> file;
    std::vector<KeyValue>            items;
 };
@@ -322,7 +327,16 @@ void Secrets::put(std::span<const char> key, std::span<const char> value)
       impl->items.insert(pos, KeyValue{std::vector(key.begin(), key.end()),
                                        std::vector(value.begin(), value.end())});
    }
-   if (impl->file)
-      writeEncryptedFile(impl->file->filename, psio::to_frac(impl->items), impl->file->params,
-                         impl->file->key);
+   impl->flush();
+}
+
+void Secrets::remove(std::span<const char> key)
+{
+   auto k   = std::string_view{key.data(), key.size()};
+   auto pos = std::ranges::lower_bound(impl->items, k, {}, &KeyValue::skey);
+   if (pos != impl->items.end() && pos->skey() == k)
+   {
+      impl->items.erase(pos);
+      impl->flush();
+   }
 }

--- a/libraries/psibase/native/src/Secrets.cpp
+++ b/libraries/psibase/native/src/Secrets.cpp
@@ -26,7 +26,7 @@ namespace
 
    constexpr std::size_t prefix_size = sizeof(prefix);
    constexpr std::size_t block_size  = 16;
-   constexpr std::size_t iv_size     = block_size;
+   constexpr std::size_t iv_size     = 12;
    constexpr std::size_t tag_size    = block_size;
 
    template <std::size_t N>
@@ -152,7 +152,9 @@ namespace
          const unsigned char* iv = outp;
          outp += iv_size;
 
-         if (!EVP_EncryptInit_ex2(ctx.get(), EVP_aes_256_gcm(), master_key.data(), iv, nullptr))
+         const EVP_CIPHER* cipher = EVP_aes_256_gcm();
+         assert(EVP_CIPHER_get_iv_length(cipher) == iv_size);
+         if (!EVP_EncryptInit_ex2(ctx.get(), cipher, master_key.data(), iv, nullptr))
          {
             error();
          }
@@ -218,7 +220,9 @@ namespace
       auto ctx        = std::unique_ptr<EVP_CIPHER_CTX, OpenSSLDeleter>(EVP_CIPHER_CTX_new());
       if (!ctx)
          error();
-      if (!EVP_DecryptInit_ex2(ctx.get(), EVP_aes_256_gcm(), master_key.data(), iv.data(), nullptr))
+      const EVP_CIPHER* cipher = EVP_aes_256_gcm();
+      assert(EVP_CIPHER_get_iv_length(cipher) == iv_size);
+      if (!EVP_DecryptInit_ex2(ctx.get(), cipher, master_key.data(), iv.data(), nullptr))
       {
          error();
       }

--- a/libraries/psibase/native/src/Secrets.cpp
+++ b/libraries/psibase/native/src/Secrets.cpp
@@ -255,30 +255,39 @@ namespace
       std::string_view  skey() const { return {key.data(), key.size()}; }
       PSIO_REFLECT(KeyValue, key, value);
    };
+
+   DecryptedFile newEncryptedFile(std::string_view passphrase)
+   {
+      SCryptParams params;
+      auto         key = deriveKey<32>(passphrase, params);
+      return {key, params, psio::to_frac(std::vector<KeyValue>())};
+   }
+
+   struct EncryptedFileInfo
+   {
+      SCryptParams                  params;
+      std::array<unsigned char, 32> key;
+      std::filesystem::path         filename;
+   };
 }  // namespace
 
 struct Secrets::Impl
 {
-   Impl(const std::filesystem::path& path, std::string_view passphrase)
-       : params(), key(deriveKey<32>(passphrase, params)), filename(path)
-   {
-   }
+   Impl() = default;
    Impl(const std::filesystem::path& path, DecryptedFile&& contents)
-       : params(std::move(contents.params)),
-         key(std::move(contents.key)),
-         filename(path),
+       : file{
+             {.params{std::move(contents.params)}, .key{std::move(contents.key)}, .filename{path}}},
          items(psio::from_frac<std::vector<KeyValue>>(contents.data))
    {
    }
-   SCryptParams                  params;
-   std::array<unsigned char, 32> key;
-   std::filesystem::path         filename;
-   std::vector<KeyValue>         items;
+   std::optional<EncryptedFileInfo> file;
+   std::vector<KeyValue>            items;
 };
 
 Secrets::Secrets(const std::filesystem::path& file, std::string_view passphrase)
     : impl(new Impl{std::filesystem::exists(file) ? Impl(file, readEncryptedFile(file, passphrase))
-                                                  : Impl(file, passphrase)})
+                    : !passphrase.empty()         ? Impl(file, newEncryptedFile(passphrase))
+                                                  : Impl()})
 {
 }
 
@@ -313,5 +322,7 @@ void Secrets::put(std::span<const char> key, std::span<const char> value)
       impl->items.insert(pos, KeyValue{std::vector(key.begin(), key.end()),
                                        std::vector(value.begin(), value.end())});
    }
-   writeEncryptedFile(impl->filename, psio::to_frac(impl->items), impl->params, impl->key);
+   if (impl->file)
+      writeEncryptedFile(impl->file->filename, psio::to_frac(impl->items), impl->file->params,
+                         impl->file->key);
 }

--- a/libraries/psibase/native/src/Secrets.cpp
+++ b/libraries/psibase/native/src/Secrets.cpp
@@ -15,10 +15,10 @@
 using namespace psibase;
 
 // AES-GCM
-// magic (4-bytes) || version (4-bytes) || KDF params || iv (16-bytes) || cyphertext || tag (16-bytes)
+// magic (4-bytes) || version (4-bytes) || KDF params || iv (12-bytes) || cyphertext || tag (16-bytes)
 
 // KDF uses scrypt
-// salt (16 bytes) || logn (4-bytes) || r (4-bytes) || p (4-bytes)
+// salt (16 bytes) || log n (4-bytes) || r (4-bytes) || p (4-bytes)
 
 namespace
 {

--- a/libraries/psibase/native/src/Secrets.cpp
+++ b/libraries/psibase/native/src/Secrets.cpp
@@ -50,9 +50,9 @@ namespace
       return result;
    }
 
-   void writeLE(std::uint32_t value, unsigned char*& out)
+   void writeLE(std::unsigned_integral auto value, unsigned char*& out)
    {
-      for (std::size_t i = 0; i < 4; ++i)
+      for (std::size_t i = 0; i < sizeof(value); ++i)
       {
          *out++ = value & 0xffu;
          value >>= 8;
@@ -127,7 +127,9 @@ namespace
    void writeEncryptedFile(const std::filesystem::path&       file,
                            std::span<const char>              data,
                            const SCryptParams                 params,
-                           std::span<const unsigned char, 32> master_key)
+                           std::span<const unsigned char, 32> master_key,
+                           std::uint32_t                      iv_fixed,
+                           std::uint64_t                      iv_invocation)
    {
       const std::size_t cyphertext_size = data.size();
       const std::size_t output_size =
@@ -147,10 +149,10 @@ namespace
 
          std::size_t additional_data_size = outp - additional_data;
 
-         if (RAND_bytes(outp, iv_size) != 1)
-            error();
+         static_assert(sizeof(iv_fixed) + sizeof(iv_invocation) == iv_size);
          const unsigned char* iv = outp;
-         outp += iv_size;
+         writeLE(iv_fixed, outp);
+         writeLE(iv_invocation, outp);
 
          const EVP_CIPHER* cipher = EVP_aes_256_gcm();
          assert(EVP_CIPHER_get_iv_length(cipher) == iv_size);
@@ -249,7 +251,10 @@ namespace
       }
       out += outl;
       assert(out - reinterpret_cast<const unsigned char*>(result.data()) == result.size());
-      return {master_key, params, std::move(result)};
+
+      SCryptParams new_params;
+      auto         new_key = deriveKey<32>(passphrase, new_params);
+      return {new_key, new_params, std::move(result)};
    }
 
    struct KeyValue
@@ -271,6 +276,7 @@ namespace
    {
       SCryptParams                  params;
       std::array<unsigned char, 32> key;
+      std::uint64_t                 iv_invocation;
       std::filesystem::path         filename;
    };
 }  // namespace
@@ -279,15 +285,18 @@ struct Secrets::Impl
 {
    Impl() = default;
    Impl(const std::filesystem::path& path, DecryptedFile&& contents)
-       : file{
-             {.params{std::move(contents.params)}, .key{std::move(contents.key)}, .filename{path}}},
+       : file{{.params{std::move(contents.params)},
+               .key{std::move(contents.key)},
+               .iv_invocation{0},
+               .filename{path}}},
          items(psio::from_frac<std::vector<KeyValue>>(contents.data))
    {
    }
    void flush()
    {
       if (file)
-         writeEncryptedFile(file->filename, psio::to_frac(items), file->params, file->key);
+         writeEncryptedFile(file->filename, psio::to_frac(items), file->params, file->key, 0,
+                            file->iv_invocation++);
    }
    std::optional<EncryptedFileInfo> file;
    std::vector<KeyValue>            items;

--- a/libraries/psibase/native/src/Secrets.cpp
+++ b/libraries/psibase/native/src/Secrets.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <psibase/check.hpp>
 #include <psibase/fileUtil.hpp>
+#include <psibase/openssl.hpp>
 #include <psio/fracpack.hpp>
 #include <psio/reflect.hpp>
 #include <vector>
@@ -14,7 +15,10 @@
 using namespace psibase;
 
 // AES-GCM
-// magic (4-bytes) || version (4-bytes) || iv (16-bytes) || cyphertext || tag (16-bytes)
+// magic (4-bytes) || version (4-bytes) || KDF params || iv (16-bytes) || cyphertext || tag (16-bytes)
+
+// KDF uses scrypt
+// salt (16 bytes) || logn (4-bytes) || r (4-bytes) || p (4-bytes)
 
 namespace
 {
@@ -25,42 +29,137 @@ namespace
    constexpr std::size_t iv_size     = block_size;
    constexpr std::size_t tag_size    = block_size;
 
-   struct FreeCipher
+   template <std::size_t N>
+   std::array<unsigned char, N> randomSalt()
    {
-      void operator()(EVP_CIPHER_CTX* ctx) const { EVP_CIPHER_CTX_free(ctx); }
+      std::array<unsigned char, N> result;
+      if (RAND_bytes(result.data(), result.size()) != 1)
+      {
+         abortMessage("Could not generate salt");
+      }
+      return result;
+   }
+
+   std::uint32_t readLE(const unsigned char*& in)
+   {
+      std::uint32_t result = 0;
+      for (std::uint32_t i = 0; i < 4; ++i)
+      {
+         result += (static_cast<std::uint32_t>(*in++) << i * 8);
+      }
+      return result;
+   }
+
+   void writeLE(std::uint32_t value, unsigned char*& out)
+   {
+      for (std::size_t i = 0; i < 4; ++i)
+      {
+         *out++ = value & 0xffu;
+         value >>= 8;
+      }
+   }
+
+   struct SCryptParams
+   {
+      static constexpr std::size_t salt_size = 16;
+      SCryptParams() : salt(randomSalt<SCryptParams::salt_size>()), logn(14), r(8), p(1) {}
+      SCryptParams(const unsigned char*& in)
+      {
+         std::memcpy(salt.data(), in, salt.size());
+         in += salt.size();
+         logn = readLE(in);
+         r    = readLE(in);
+         p    = readLE(in);
+      }
+      std::array<unsigned char, salt_size> salt;
+      std::uint32_t                        logn;
+      std::uint32_t                        r;
+      std::uint32_t                        p;
+      static constexpr std::size_t         size()
+      {
+         return salt_size + sizeof(logn) + sizeof(r) + sizeof(p);
+      }
    };
 
-   void writeEncryptedFile(const std::filesystem::path& file,
-                           std::span<const char>        data,
-                           std::span<const char, 32>    master_key)
+   void writeParams(const SCryptParams& params, unsigned char*& out)
+   {
+      std::memcpy(out, params.salt.data(), params.salt.size());
+      out += params.salt.size();
+      writeLE(params.logn, out);
+      writeLE(params.r, out);
+      writeLE(params.p, out);
+   }
+
+   struct DecryptedFile
+   {
+      std::array<unsigned char, 32> key;
+      SCryptParams                  params;
+      std::vector<char>             data;
+   };
+
+   template <std::size_t N>
+   std::array<unsigned char, N> deriveKey(std::string_view passphrase, const SCryptParams& params)
+   {
+      if (params.logn > 63)
+      {
+         abortMessage("invalid scrypt parameters");
+      }
+      auto kdf = std::unique_ptr<EVP_KDF, OpenSSLDeleter>(EVP_KDF_fetch(NULL, "SCRYPT", NULL));
+      auto ctx = std::unique_ptr<EVP_KDF_CTX, OpenSSLDeleter>(EVP_KDF_CTX_new(kdf.get()));
+      std::uint64_t n           = std::uint64_t(1) << params.logn;
+      OSSL_PARAM    sslparams[] = {
+          OSSL_PARAM_octet_string("pass", const_cast<char*>(passphrase.data()), passphrase.size()),
+          OSSL_PARAM_octet_string("salt", const_cast<unsigned char*>(params.salt.data()),
+                                  params.salt.size()),
+          OSSL_PARAM_uint64("n", &n),
+          OSSL_PARAM_uint32("r", const_cast<std::uint32_t*>(&params.r)),
+          OSSL_PARAM_uint32("p", const_cast<std::uint32_t*>(&params.p)),
+          OSSL_PARAM_END,
+      };
+      std::array<unsigned char, N> result;
+      if (EVP_KDF_derive(ctx.get(), result.data(), result.size(), sslparams) != 1)
+      {
+         abortMessage("failed to derive key");
+      }
+      return result;
+   }
+
+   void writeEncryptedFile(const std::filesystem::path&       file,
+                           std::span<const char>              data,
+                           const SCryptParams                 params,
+                           std::span<const unsigned char, 32> master_key)
    {
       const std::size_t cyphertext_size = data.size();
-      const std::size_t output_size     = prefix_size + iv_size + cyphertext_size + tag_size;
+      const std::size_t output_size =
+          prefix_size + params.size() + iv_size + cyphertext_size + tag_size;
       auto error = [&] { abortMessage("Failed to write encrypted file: " + file.string()); };
       std::vector<unsigned char> buffer(output_size);
       {
-         auto ctx = std::unique_ptr<EVP_CIPHER_CTX, FreeCipher>(EVP_CIPHER_CTX_new());
+         auto ctx = std::unique_ptr<EVP_CIPHER_CTX, OpenSSLDeleter>(EVP_CIPHER_CTX_new());
          if (!ctx)
             error();
-         unsigned char* outp = buffer.data();
+         unsigned char* outp            = buffer.data();
+         auto           additional_data = outp;
          std::memcpy(outp, prefix, prefix_size);
          outp += prefix_size;
+
+         writeParams(params, outp);
+
+         std::size_t additional_data_size = outp - additional_data;
 
          if (RAND_bytes(outp, iv_size) != 1)
             error();
          const unsigned char* iv = outp;
          outp += iv_size;
 
-         if (!EVP_EncryptInit_ex2(ctx.get(), EVP_aes_256_gcm(),
-                                  reinterpret_cast<const unsigned char*>(master_key.data()), iv,
-                                  nullptr))
+         if (!EVP_EncryptInit_ex2(ctx.get(), EVP_aes_256_gcm(), master_key.data(), iv, nullptr))
          {
             error();
          }
          std::size_t          remaining = data.size();
          const unsigned char* pos       = reinterpret_cast<const unsigned char*>(data.data());
          int                  outl;
-         if (!EVP_EncryptUpdate(ctx.get(), nullptr, &outl, prefix, prefix_size))
+         if (!EVP_EncryptUpdate(ctx.get(), nullptr, &outl, additional_data, additional_data_size))
          {
             error();
          }
@@ -88,36 +187,38 @@ namespace
       }
    }
 
-   std::vector<char> readEncryptedFile(const std::filesystem::path& file,
-                                       std::span<const char, 32>    master_key)
+   DecryptedFile readEncryptedFile(const std::filesystem::path& file, std::string_view passphrase)
    {
-      auto error = [&] { abortMessage("Failed to read encrypted file: " + file.string()); };
-      auto data  = readWholeFile(file.string());
-      if (data.size() < prefix_size + iv_size + tag_size)
+      auto error        = [&] { abortMessage("Failed to read encrypted file: " + file.string()); };
+      auto data         = readWholeFile(file.string());
+      auto nondata_size = prefix_size + SCryptParams::size() + iv_size + tag_size;
+      if (data.size() < nondata_size)
       {
          error();
       }
       const unsigned char* inp = reinterpret_cast<const unsigned char*>(data.data());
       auto                 pfx = std::span<const unsigned char, prefix_size>{inp, prefix_size};
       inp += prefix_size;
-      auto iv = std::span<const unsigned char, iv_size>{inp, iv_size};
+      if (!std::ranges::equal(prefix, pfx))
+      {
+         error();
+      }
+      auto params               = SCryptParams(inp);
+      auto additional_data      = pfx.data();
+      auto additional_data_size = inp - additional_data;
+      auto iv                   = std::span<const unsigned char, iv_size>{inp, iv_size};
       inp += iv_size;
-      auto ciphertext_size = data.size() - prefix_size - iv_size - tag_size;
+      auto ciphertext_size = data.size() - nondata_size;
       auto ciphertext      = std::span<const unsigned char>{inp, ciphertext_size};
       inp += ciphertext_size;
       auto tag = std::span<const unsigned char, tag_size>{inp, tag_size};
       inp += tag_size;
       assert(inp - reinterpret_cast<const unsigned char*>(data.data()) == data.size());
-      if (!std::ranges::equal(prefix, pfx))
-      {
-         error();
-      }
-      auto ctx = std::unique_ptr<EVP_CIPHER_CTX, FreeCipher>(EVP_CIPHER_CTX_new());
+      auto master_key = deriveKey<32>(passphrase, params);
+      auto ctx        = std::unique_ptr<EVP_CIPHER_CTX, OpenSSLDeleter>(EVP_CIPHER_CTX_new());
       if (!ctx)
          error();
-      if (!EVP_DecryptInit_ex2(ctx.get(), EVP_aes_256_gcm(),
-                               reinterpret_cast<const unsigned char*>(master_key.data()), iv.data(),
-                               nullptr))
+      if (!EVP_DecryptInit_ex2(ctx.get(), EVP_aes_256_gcm(), master_key.data(), iv.data(), nullptr))
       {
          error();
       }
@@ -129,7 +230,7 @@ namespace
       std::vector<char> result(ciphertext_size);
       auto              out = reinterpret_cast<unsigned char*>(result.data());
       int               outl;
-      if (!EVP_DecryptUpdate(ctx.get(), nullptr, &outl, pfx.data(), prefix_size))
+      if (!EVP_DecryptUpdate(ctx.get(), nullptr, &outl, additional_data, additional_data_size))
       {
          error();
       }
@@ -144,7 +245,7 @@ namespace
       }
       out += outl;
       assert(out - reinterpret_cast<const unsigned char*>(result.data()) == result.size());
-      return result;
+      return {master_key, params, std::move(result)};
    }
 
    struct KeyValue
@@ -158,17 +259,27 @@ namespace
 
 struct Secrets::Impl
 {
-   std::filesystem::path filename;
-   std::vector<KeyValue> items;
-   std::array<char, 32>  key;
+   Impl(const std::filesystem::path& path, std::string_view passphrase)
+       : params(), key(deriveKey<32>(passphrase, params)), filename(path)
+   {
+   }
+   Impl(const std::filesystem::path& path, DecryptedFile&& contents)
+       : params(std::move(contents.params)),
+         key(std::move(contents.key)),
+         filename(path),
+         items(psio::from_frac<std::vector<KeyValue>>(contents.data))
+   {
+   }
+   SCryptParams                  params;
+   std::array<unsigned char, 32> key;
+   std::filesystem::path         filename;
+   std::vector<KeyValue>         items;
 };
 
-Secrets::Secrets(const std::filesystem::path& file, std::span<const char, 32> master_key)
-    : impl(new Impl{file, std::filesystem::exists(file) ? psio::from_frac<std::vector<KeyValue>>(
-                                                              readEncryptedFile(file, master_key))
-                                                        : std::vector<KeyValue>()})
+Secrets::Secrets(const std::filesystem::path& file, std::string_view passphrase)
+    : impl(new Impl{std::filesystem::exists(file) ? Impl(file, readEncryptedFile(file, passphrase))
+                                                  : Impl(file, passphrase)})
 {
-   std::memcpy(impl->key.data(), master_key.data(), master_key.size());
 }
 
 Secrets::~Secrets() = default;
@@ -202,5 +313,5 @@ void Secrets::put(std::span<const char> key, std::span<const char> value)
       impl->items.insert(pos, KeyValue{std::vector(key.begin(), key.end()),
                                        std::vector(value.begin(), value.end())});
    }
-   writeEncryptedFile(impl->filename, psio::to_frac(impl->items), impl->key);
+   writeEncryptedFile(impl->filename, psio::to_frac(impl->items), impl->params, impl->key);
 }

--- a/libraries/psibase/native/tests/CMakeLists.txt
+++ b/libraries/psibase/native/tests/CMakeLists.txt
@@ -14,3 +14,8 @@ add_executable(MountTests MountTests.cpp)
 target_compile_definitions(MountTests PUBLIC -DCATCH_CONFIG_ENABLE_ALL_STRINGMAKERS=1)
 target_link_libraries(MountTests psibase Catch2::Catch2WithMain Threads::Threads)
 add_test(NAME MountTests COMMAND MountTests)
+
+add_executable(SecretsTests SecretsTests.cpp)
+target_compile_definitions(SecretsTests PUBLIC -DCATCH_CONFIG_ENABLE_ALL_STRINGMAKERS=1)
+target_link_libraries(SecretsTests psibase Catch2::Catch2WithMain Threads::Threads)
+add_test(NAME SecrestsTests COMMAND SecretsTests)

--- a/libraries/psibase/native/tests/MountTests.cpp
+++ b/libraries/psibase/native/tests/MountTests.cpp
@@ -3,40 +3,12 @@
 #include <unistd.h>
 #include <filesystem>
 #include <fstream>
-#include <random>
+#include "TempDirectory.hpp"
 
 #include <catch2/catch_all.hpp>
 #include <iostream>
 
 using namespace psibase;
-
-struct TempDirectory
-{
-   TempDirectory() : path(randomName()) { std::filesystem::create_directory(path); }
-   ~TempDirectory() { std::filesystem::remove_all(path); }
-   static std::filesystem::path randomName()
-   {
-      constexpr int                              max_tries = 8;
-      constexpr int                              len       = 24;
-      auto                                       root      = std::filesystem::temp_directory_path();
-      std::string_view                           chars     = "abcdefghijklmnopqrstuvwxyz1234567890";
-      std::uniform_int_distribution<std::size_t> dist(0, chars.size() - 1);
-      std::random_device                         rng;
-      for (int i = 0; i < max_tries; ++i)
-      {
-         std::string name;
-         for (int j = 0; j < len; ++j)
-         {
-            name += chars[dist(rng)];
-         }
-         auto result = root / name;
-         if (!std::filesystem::exists(result))
-            return result;
-      }
-      throw std::runtime_error("Failed to find unused directory name");
-   }
-   std::filesystem::path path;
-};
 
 std::string readFile(const Mount::Fd& fd)
 {

--- a/libraries/psibase/native/tests/SecretsTests.cpp
+++ b/libraries/psibase/native/tests/SecretsTests.cpp
@@ -25,6 +25,17 @@ TEST_CASE("Secret put/get")
    CHECK(sv(secrets.get("a"sv)) == "value");
 }
 
+TEST_CASE("Secret remove")
+{
+   TempDirectory    dir;
+   std::string_view passphrase = "open sesame";
+   Secrets          secrets{dir.path / "secrets", passphrase};
+   secrets.put("a"sv, "value"sv);
+   CHECK(sv(secrets.get("a"sv)) == "value");
+   secrets.remove("a"sv);
+   CHECK(secrets.get("a"sv) == std::nullopt);
+}
+
 TEST_CASE("Secret load")
 {
    TempDirectory    dir;
@@ -36,6 +47,25 @@ TEST_CASE("Secret load")
    {
       Secrets secrets{dir.path / "secrets", passphrase};
       CHECK(sv(secrets.get("a"sv)) == "value");
+   }
+}
+
+TEST_CASE("Secret remove load")
+{
+   TempDirectory    dir;
+   std::string_view passphrase = "open sesame";
+   {
+      Secrets secrets{dir.path / "secrets", passphrase};
+      secrets.put("a"sv, "value"sv);
+   }
+   {
+      Secrets secrets{dir.path / "secrets", passphrase};
+      CHECK(sv(secrets.get("a"sv)) == "value");
+      secrets.remove("a"sv);
+   }
+   {
+      Secrets secrets{dir.path / "secrets", passphrase};
+      CHECK(secrets.get("a"sv) == std::nullopt);
    }
 }
 

--- a/libraries/psibase/native/tests/SecretsTests.cpp
+++ b/libraries/psibase/native/tests/SecretsTests.cpp
@@ -50,3 +50,17 @@ TEST_CASE("Wrong passphrase")
       CHECK_THROWS(Secrets{dir.path / "secrets", "open sez me"});
    }
 }
+
+TEST_CASE("Secrets temporary")
+{
+   TempDirectory dir;
+   {
+      Secrets secrets{dir.path / "secrets", ""};
+      secrets.put("a"sv, "value"sv);
+      CHECK(!std::filesystem::exists(dir.path / "secrets"));
+   }
+   {
+      Secrets secrets{dir.path / "secrets", ""};
+      CHECK(secrets.get("a"sv) == std::nullopt);
+   }
+}

--- a/libraries/psibase/native/tests/SecretsTests.cpp
+++ b/libraries/psibase/native/tests/SecretsTests.cpp
@@ -1,0 +1,52 @@
+#include <psibase/Secrets.hpp>
+
+#include "TempDirectory.hpp"
+
+#include <catch2/catch_all.hpp>
+
+using namespace psibase;
+
+using namespace std::literals::string_view_literals;
+
+std::string_view sv(std::optional<std::span<const char>> value)
+{
+   if (value)
+      return {value->data(), value->size()};
+   else
+      return {};
+}
+
+TEST_CASE("Secret put/get")
+{
+   TempDirectory    dir;
+   std::string_view passphrase = "open sesame";
+   Secrets          secrets{dir.path / "secrets", passphrase};
+   secrets.put("a"sv, "value"sv);
+   CHECK(sv(secrets.get("a"sv)) == "value");
+}
+
+TEST_CASE("Secret load")
+{
+   TempDirectory    dir;
+   std::string_view passphrase = "open sesame";
+   {
+      Secrets secrets{dir.path / "secrets", passphrase};
+      secrets.put("a"sv, "value"sv);
+   }
+   {
+      Secrets secrets{dir.path / "secrets", passphrase};
+      CHECK(sv(secrets.get("a"sv)) == "value");
+   }
+}
+
+TEST_CASE("Wrong passphrase")
+{
+   TempDirectory dir;
+   {
+      Secrets secrets{dir.path / "secrets", "open sesame"};
+      secrets.put("a"sv, "value"sv);
+   }
+   {
+      CHECK_THROWS(Secrets{dir.path / "secrets", "open sez me"});
+   }
+}

--- a/libraries/psibase/native/tests/TempDirectory.hpp
+++ b/libraries/psibase/native/tests/TempDirectory.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <filesystem>
+#include <random>
+#include <string_view>
+
+struct TempDirectory
+{
+   TempDirectory() : path(randomName()) { std::filesystem::create_directory(path); }
+   ~TempDirectory() { std::filesystem::remove_all(path); }
+   static std::filesystem::path randomName()
+   {
+      constexpr int                              max_tries = 8;
+      constexpr int                              len       = 24;
+      auto                                       root      = std::filesystem::temp_directory_path();
+      std::string_view                           chars     = "abcdefghijklmnopqrstuvwxyz1234567890";
+      std::uniform_int_distribution<std::size_t> dist(0, chars.size() - 1);
+      std::random_device                         rng;
+      for (int i = 0; i < max_tries; ++i)
+      {
+         std::string name;
+         for (int j = 0; j < len; ++j)
+         {
+            name += chars[dist(rng)];
+         }
+         auto result = root / name;
+         if (!std::filesystem::exists(result))
+            return result;
+      }
+      throw std::runtime_error("Failed to find unused directory name");
+   }
+   std::filesystem::path path;
+};

--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -1761,14 +1761,14 @@ void run(const std::string&              db_path,
       };
 
       http_config->lock_keyring =
-          [&chainContext, getPKCS11Slot](std::vector<char> json, auto callback)
+          [&chainContext, getPKCS11Slot, &secrets](std::vector<char> json, auto callback)
       {
          json.push_back('\0');
          psio::json_token_stream stream(json.data());
          auto                    id = psio::from_json<LockKeyringRequest>(stream);
          boost::asio::post(
              chainContext,
-             [getPKCS11Slot, callback = std::move(callback), id = std::move(id)]() mutable
+             [getPKCS11Slot, &secrets, callback = std::move(callback), id = std::move(id)]() mutable
              {
                 try
                 {
@@ -1777,6 +1777,7 @@ void run(const std::string&              db_path,
                    check(pos != sessions->end(), "Not logged in");
                    pos->second->Logout();
                    pos->second.clear();
+                   secrets.remove(pkcs11TokenKey(lib->GetTokenInfo(slot)));
                    callback(std::nullopt);
                 }
                 catch (std::exception& e)

--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -4,7 +4,9 @@
 #include <psibase/OpenSSLProver.hpp>
 #include <psibase/PKCS11Prover.hpp>
 #include <psibase/RunQueue.hpp>
+#include <psibase/Secrets.hpp>
 #include <psibase/TransactionContext.hpp>
+#include <psibase/fileUtil.hpp>
 #include <psibase/http.hpp>
 #include <psibase/log.hpp>
 #include <psibase/node.hpp>
@@ -422,6 +424,23 @@ struct LockKeyringRequest
    std::string device;
 };
 PSIO_REFLECT(LockKeyringRequest, device);
+
+std::vector<char> pkcs11TokenKey(const std::string& uri)
+{
+   return psio::composite_key(std::uint16_t{0}, std::uint8_t{0}, uri);
+}
+
+std::vector<char> pkcs11TokenKey(const pkcs11::token_info& token)
+{
+   return pkcs11TokenKey(pkcs11::makeURI(token));
+}
+
+struct UnlockKeyringRow
+{
+   std::string device;
+   std::string pin;
+};
+PSIO_REFLECT(UnlockKeyringRow, device, pin);
 
 struct PKCS11TokenInfo
 {
@@ -989,7 +1008,7 @@ struct PsinodeConfig
       constexpr std::string_view opts[] = {
           "producer", "pkcs11-modules",      "listen",       "tls-key",
           "tls-cert", "tls-trustfile",       "http-timeout", "service-threads",
-          "key",      "database-cache-size", "mount"};
+          "key",      "database-cache-size", "mount",        "passphrase-file"};
       return std::ranges::find(opts, name) != std::end(opts) || name.starts_with("logger.") ||
              name.starts_with("service.");
    }
@@ -1060,6 +1079,7 @@ void to_config(const PsinodeConfig& config, ConfigFile& file)
    file.keep("", "key");
    file.keep("", "database-cache-size");
    file.keep("", "mount");
+   file.keep("", "passphrase-file");
    //
    to_config(config.loggers, file);
 }
@@ -1152,6 +1172,7 @@ void run(const std::string&              db_path,
          const DbConfig&                 db_conf,
          AccountNumber                   producer,
          std::shared_ptr<CompoundProver> prover,
+         std::string_view                passphrase,
          std::vector<std::string>&       pkcs11_modules,
          std::vector<listen_spec>        listen,
          std::vector<MountArg>&          mountpoints,
@@ -1174,6 +1195,8 @@ void run(const std::string&              db_path,
        WasmCache{128});
    auto system      = sharedState->getSystemContext();
    auto proofSystem = sharedState->getSystemContext();
+
+   Secrets secrets{std::filesystem::path(db_path) / "secrets", passphrase};
 
    if (system->sharedDatabase.isSlow())
    {
@@ -1352,6 +1375,24 @@ void run(const std::string&              db_path,
       check(!!found, "No token matches URI");
       return std::tuple{*foundLib, *found, foundSessions};
    };
+
+   // Unlock cryptographic devices that we have known keys for
+   for (auto& [k, v] : pkcs11Libs)
+   {
+      auto& [lib, sessions] = v;
+      for (auto slot : lib->GetSlotList(true))
+      {
+         auto key = pkcs11TokenKey(lib->GetTokenInfo(slot));
+         if (auto row = secrets.get(key))
+         {
+            auto pin = psio::view<const UnlockKeyringRow>(*row).pin();
+
+            auto pos = sessions.try_emplace(slot, lib, slot).first;
+            pos->second->Login(std::string_view{pin.data(), pin.size()});
+            loadSessionKeys(pos->second);
+         }
+      }
+   }
 
    // http_config must live until server shutdown which happens when chainContext
    // is destroyed.
@@ -1689,15 +1730,15 @@ void run(const std::string&              db_path,
              });
       };
 
-      http_config->unlock_keyring = [&chainContext, &node, loadSessionKeys, getPKCS11Slot](
-                                        std::vector<char> json, auto callback)
+      http_config->unlock_keyring = [&chainContext, &node, loadSessionKeys, getPKCS11Slot,
+                                     &secrets](std::vector<char> json, auto callback)
       {
          json.push_back('\0');
          psio::json_token_stream stream(json.data());
          auto                    pin = psio::from_json<UnlockKeyringRequest>(stream);
          boost::asio::post(chainContext,
-                           [&node, getPKCS11Slot, loadSessionKeys, callback = std::move(callback),
-                            pin = std::move(pin)]() mutable
+                           [&node, getPKCS11Slot, &secrets, loadSessionKeys,
+                            callback = std::move(callback), pin = std::move(pin)]() mutable
                            {
                               try
                               {
@@ -1706,6 +1747,10 @@ void run(const std::string&              db_path,
                                  pos->second->Login(pin.pin);
                                  loadSessionKeys(pos->second);
                                  node.on_key_update();
+                                 UnlockKeyringRow row{
+                                     .device = pkcs11::makeURI(lib->GetTokenInfo(slot)),
+                                     .pin    = std::move(pin.pin)};
+                                 secrets.put(pkcs11TokenKey(row.device), psio::to_frac(row));
                                  callback(std::nullopt);
                               }
                               catch (std::exception& e)
@@ -1844,6 +1889,7 @@ int main(int argc, char* argv[])
    std::string              db_template;
    std::string              producer = {};
    auto                     keys     = std::make_shared<CompoundProver>();
+   std::string              passphrase;
    std::vector<std::string> pkcs11_modules;
    std::vector<listen_spec> listen;
    std::vector<MountArg>    mountpoints;
@@ -1865,6 +1911,28 @@ int main(int argc, char* argv[])
        "Name of this producer");
    opt("key,k", po::value(&keys->provers)->default_value({}, ""),
        "A private key to use for block production");
+   opt("passphrase-file",
+       po::value<std::string>()->default_value("")->notifier(
+           [&](const std::string& filename)
+           {
+              if (filename != "")
+              {
+                 auto contents = readWholeFile(filename);
+                 passphrase    = std::string(contents.data(), contents.size());
+              }
+              else
+              {
+                 if (const char* var = std::getenv("PSIBASE_PASSPHRASE"))
+                 {
+                    passphrase = var;
+                 }
+                 else
+                 {
+                    passphrase = "";
+                 }
+              }
+           }),
+       "A file containing a passphrase used to encrypt secrets");
    opt("listen,l", po::value(&listen)->default_value({}, "")->value_name("endpoint"),
        "TCP or local socket endpoint on which the server accepts connections");
    opt("mount",
@@ -1997,8 +2065,8 @@ int main(int argc, char* argv[])
       {
          restart.args.reset();
          run(db_path, db_template, DbConfig{db_cache_size}, AccountNumber{producer}, keys,
-             pkcs11_modules, listen, mountpoints, http_timeout, service_threads, root_ca, tls_cert,
-             tls_key, extra_options, restart);
+             passphrase, pkcs11_modules, listen, mountpoints, http_timeout, service_threads,
+             root_ca, tls_cert, tls_key, extra_options, restart);
          if (!restart.args || !restart.args->restart)
          {
             PSIBASE_LOG(psibase::loggers::generic::get(), info) << "Shutdown";

--- a/programs/psinode/main.cpp
+++ b/programs/psinode/main.cpp
@@ -1918,8 +1918,11 @@ int main(int argc, char* argv[])
            {
               if (filename != "")
               {
-                 auto contents = readWholeFile(filename);
-                 passphrase    = std::string(contents.data(), contents.size());
+                 auto                       contents = readWholeFile(filename);
+                 constexpr std::string_view nl_chars{"\r\n"};
+                 while (!contents.empty() && nl_chars.contains(contents.back()))
+                    contents.pop_back();
+                 passphrase = std::string(contents.data(), contents.size());
               }
               else
               {


### PR DESCRIPTION
Secrets are encrypted using a master passphrase. There are two methods for passing it to `psinode`:
- A file whose name is provided on the command line. This is useful for [systemd](https://systemd.io/CREDENTIALS/), [docker compose](https://docs.docker.com/compose/how-tos/use-secrets/) and any other environments that can pass secrets securely as files.
- The environmental variable `PSIBASE_PASSPHRASE`.
- If no passphrase is provided, the secrets will only be kept in memory (matching the current behavior)

The pins for unlocked devices are stored as secrets and they will be automatically unlocked when the node starts again (if the device is still present). Secrets are only used by native and are not available to services yet.
