### PR TITLE
Fix XProxy service retrieval

### DIFF
--- a/packages/local/XProxy/src/XProxy.cpp
+++ b/packages/local/XProxy/src/XProxy.cpp
@@ -141,13 +141,24 @@ std::optional<HttpReply> XProxy::serveSys(HttpRequest req, std::optional<std::in
    }
    else
    {
+      // Load any configured upstream first so bypass prefixes can short-circuit
+      // before we touch HttpServer (e.g. /common should fall through to the
+      // normal HttpServer/common-api path).
+      auto                           table = open<OriginServerTable>();
+      std::optional<OriginServerRow> originServer;
+      PSIBASE_SUBJECTIVE_TX
+      {
+         originServer = table.get(subdomain);
+      }
+      if (originServer && originServer->bypassPrefixes &&
+          pathMatchesBypassPrefix(req.path(), *originServer->bypassPrefixes))
+         return {};
+
       // Try the server registered in HttpServer
       // This allows RPC calls to be handled by the registered server
-      if (auto registered = HttpServer::Tables(HttpServer::service, KvMode::read)
-                                .open<RegServTable>()
-                                .get(subdomain))
+      if (auto registered = to<HttpServer>().getServer(subdomain))
       {
-         to<XHttp>().giveSocket(*socket, registered->server, false);
+         to<XHttp>().giveSocket(*socket, *registered, false);
 
          auto user = to<RTransact>().getUser(req);
 
@@ -156,7 +167,7 @@ std::optional<HttpReply> XProxy::serveSys(HttpRequest req, std::optional<std::in
          req.removeCookie("SESSION");
          std::erase_if(req.headers, [](auto& header) { return header.matches("authorization"); });
          auto reply = from(HttpServer::service)
-                          .to<ServerInterface>(registered->server)
+                          .to<ServerInterface>(*registered)
                           .serveSys(req, socket, user);
 
          if (!to<XHttp>().takeSocket(*socket, false))
@@ -164,49 +175,39 @@ std::optional<HttpReply> XProxy::serveSys(HttpRequest req, std::optional<std::in
          if (reply)
             return reply;
       }
-   }
 
-   // Try the upstream server
-   auto                           table = open<OriginServerTable>();
-   std::optional<OriginServerRow> originServer;
-   PSIBASE_SUBJECTIVE_TX
-   {
-      originServer = table.get(subdomain);
-   }
-   if (originServer)
-   {
-      if (originServer->bypassPrefixes &&
-          pathMatchesBypassPrefix(req.path(), *originServer->bypassPrefixes))
-         return {};
-
-      if (auto originUrl = psibase::splitURL(originServer->host); !originUrl.scheme.empty())
+      // Try the upstream server
+      if (originServer)
       {
-         if (!originUrl.host.empty())
-            req.host = originUrl.host;
-         req.target = joinPath(originUrl.path, req.target);
-      }
-      else
-      {
-         req.host = originServer->host;
-      }
-      std::int32_t          upstream;
-      psibase::MethodNumber callback;
-      if (isWebSocketHandshake(req))
-      {
-         upstream = to<XHttp>().websocket(req, originServer->tls, originServer->endpoint);
-         callback = MethodNumber{"onAccept"};
-      }
-      else
-      {
-         upstream = to<XHttp>().sendRequest(req, originServer->tls, originServer->endpoint);
-         callback = MethodNumber{"onReply"};
-      }
-      auto requests = open<ProxyTable>();
-      PSIBASE_SUBJECTIVE_TX
-      {
-         to<XHttp>().autoClose(*socket, false);
-         to<XHttp>().setCallback(upstream, callback, MethodNumber{"onError"});
-         requests.put({upstream, *socket});
+         if (auto originUrl = psibase::splitURL(originServer->host); !originUrl.scheme.empty())
+         {
+            if (!originUrl.host.empty())
+               req.host = originUrl.host;
+            req.target = joinPath(originUrl.path, req.target);
+         }
+         else
+         {
+            req.host = originServer->host;
+         }
+         std::int32_t          upstream;
+         psibase::MethodNumber callback;
+         if (isWebSocketHandshake(req))
+         {
+            upstream = to<XHttp>().websocket(req, originServer->tls, originServer->endpoint);
+            callback = MethodNumber{"onAccept"};
+         }
+         else
+         {
+            upstream = to<XHttp>().sendRequest(req, originServer->tls, originServer->endpoint);
+            callback = MethodNumber{"onReply"};
+         }
+         auto requests = open<ProxyTable>();
+         PSIBASE_SUBJECTIVE_TX
+         {
+            to<XHttp>().autoClose(*socket, false);
+            to<XHttp>().setCallback(upstream, callback, MethodNumber{"onError"});
+            requests.put({upstream, *socket});
+         }
       }
    }
    return {};

--- a/packages/local/XProxy/src/XProxy.cpp
+++ b/packages/local/XProxy/src/XProxy.cpp
@@ -141,19 +141,6 @@ std::optional<HttpReply> XProxy::serveSys(HttpRequest req, std::optional<std::in
    }
    else
    {
-      // Load any configured upstream first so bypass prefixes can short-circuit
-      // before we touch HttpServer (e.g. /common should fall through to the
-      // normal HttpServer/common-api path).
-      auto                           table = open<OriginServerTable>();
-      std::optional<OriginServerRow> originServer;
-      PSIBASE_SUBJECTIVE_TX
-      {
-         originServer = table.get(subdomain);
-      }
-      if (originServer && originServer->bypassPrefixes &&
-          pathMatchesBypassPrefix(req.path(), *originServer->bypassPrefixes))
-         return {};
-
       // Try the server registered in HttpServer
       // This allows RPC calls to be handled by the registered server
       if (auto registered = to<HttpServer>().getServer(subdomain))
@@ -175,39 +162,49 @@ std::optional<HttpReply> XProxy::serveSys(HttpRequest req, std::optional<std::in
          if (reply)
             return reply;
       }
+   }
 
-      // Try the upstream server
-      if (originServer)
+   // Try the upstream server
+   auto                           table = open<OriginServerTable>();
+   std::optional<OriginServerRow> originServer;
+   PSIBASE_SUBJECTIVE_TX
+   {
+      originServer = table.get(subdomain);
+   }
+   if (originServer)
+   {
+      if (originServer->bypassPrefixes &&
+          pathMatchesBypassPrefix(req.path(), *originServer->bypassPrefixes))
+         return {};
+
+      if (auto originUrl = psibase::splitURL(originServer->host); !originUrl.scheme.empty())
       {
-         if (auto originUrl = psibase::splitURL(originServer->host); !originUrl.scheme.empty())
-         {
-            if (!originUrl.host.empty())
-               req.host = originUrl.host;
-            req.target = joinPath(originUrl.path, req.target);
-         }
-         else
-         {
-            req.host = originServer->host;
-         }
-         std::int32_t          upstream;
-         psibase::MethodNumber callback;
-         if (isWebSocketHandshake(req))
-         {
-            upstream = to<XHttp>().websocket(req, originServer->tls, originServer->endpoint);
-            callback = MethodNumber{"onAccept"};
-         }
-         else
-         {
-            upstream = to<XHttp>().sendRequest(req, originServer->tls, originServer->endpoint);
-            callback = MethodNumber{"onReply"};
-         }
-         auto requests = open<ProxyTable>();
-         PSIBASE_SUBJECTIVE_TX
-         {
-            to<XHttp>().autoClose(*socket, false);
-            to<XHttp>().setCallback(upstream, callback, MethodNumber{"onError"});
-            requests.put({upstream, *socket});
-         }
+         if (!originUrl.host.empty())
+            req.host = originUrl.host;
+         req.target = joinPath(originUrl.path, req.target);
+      }
+      else
+      {
+         req.host = originServer->host;
+      }
+      std::int32_t          upstream;
+      psibase::MethodNumber callback;
+      if (isWebSocketHandshake(req))
+      {
+         upstream = to<XHttp>().websocket(req, originServer->tls, originServer->endpoint);
+         callback = MethodNumber{"onAccept"};
+      }
+      else
+      {
+         upstream = to<XHttp>().sendRequest(req, originServer->tls, originServer->endpoint);
+         callback = MethodNumber{"onReply"};
+      }
+      auto requests = open<ProxyTable>();
+      PSIBASE_SUBJECTIVE_TX
+      {
+         to<XHttp>().autoClose(*socket, false);
+         to<XHttp>().setCallback(upstream, callback, MethodNumber{"onError"});
+         requests.put({upstream, *socket});
       }
    }
    return {};

--- a/packages/system/HttpServer/include/services/system/HttpServer.hpp
+++ b/packages/system/HttpServer/include/services/system/HttpServer.hpp
@@ -96,6 +96,9 @@ namespace SystemService
       /// * Respond to GraphQL requests
       void registerServer(psibase::AccountNumber server);
 
+      /// Returns the server registered for `service`, if any
+      std::optional<psibase::AccountNumber> getServer(psibase::AccountNumber service);
+
       // Entry point for messages
       void recv(std::int32_t socket, psio::view<const std::vector<char>> data, std::uint32_t flags);
 
@@ -136,6 +139,7 @@ namespace SystemService
                 method(giveSocket, socket, service),
                 method(takeSocket, socket),
                 method(registerServer, server),
+                method(getServer, service),
                 method(recv, socket, data, flags),
                 method(serve, socket, req),
                 method(rootHost, host),

--- a/packages/system/HttpServer/src/HttpServer.cpp
+++ b/packages/system/HttpServer/src/HttpServer.cpp
@@ -25,13 +25,6 @@ namespace SystemService
                 && req.host[req.host.size() - rootHost.size() - 1] == '.';
       }
 
-      std::optional<RegisteredServiceRow> getServer(const AccountNumber& server)
-      {
-         return HttpServer::Tables(HttpServer::service, KvMode::read)
-             .open<RegServTable>()
-             .get(server);
-      }
-
       std::optional<AccountNumber> getRedirect(const AccountNumber& account)
       {
          auto row = HttpServer::Tables(HttpServer::service, KvMode::read)
@@ -60,6 +53,13 @@ namespace SystemService
           .service = sender,
           .server  = server,
       });
+   }
+
+   std::optional<AccountNumber> HttpServer::getServer(AccountNumber service)
+   {
+      if (auto row = Tables{getReceiver(), KvMode::read}.open<RegServTable>().get(service))
+         return row->server;
+      return std::nullopt;
    }
 
    static void checkRecvAuth(const Action& act)
@@ -341,7 +341,7 @@ namespace SystemService
 
       if (registered)
       {
-         result = checkServer(registered->server);
+         result = checkServer(*registered);
       }
 
       // Otherwise, check the sites service

--- a/rust/psibase/src/services/http_server.rs
+++ b/rust/psibase/src/services/http_server.rs
@@ -72,6 +72,12 @@ mod service {
         unimplemented!()
     }
 
+    /// Returns the server registered for `service`, if any
+    #[action]
+    fn getServer(service: AccountNumber) -> Option<AccountNumber> {
+        unimplemented!()
+    }
+
     /// Entry point for messages
     #[action]
     fn recv(socket: i32, data: Hex<Vec<u8>>, flags: u32) {


### PR DESCRIPTION
Note: This code is entirely AI generated; scrutinize accordingly.

XProxy stopped working.

`x-http::serve failed: service 'db' aborted with message: x-proxy cannot read from another service's prefix: http:0` showing up on proxied requests like `GET network.psibase.localhost:8080/ 500`