### PR TITLE
Fix fractals scoring / ppm bug

### DIFF
--- a/packages/user/Fractals/service/src/tables/fractal.rs
+++ b/packages/user/Fractals/service/src/tables/fractal.rs
@@ -1,7 +1,7 @@
 use async_graphql::connection::Connection;
 use async_graphql::ComplexObject;
 use psibase::services::sites;
-use psibase::services::tokens::{Precision, Quantity};
+use psibase::services::tokens::{Decimal, Precision, Quantity};
 
 use crate::constants::{token_distributions::TOKEN_SUPPLY, TOKEN_PRECISION};
 use crate::constants::{
@@ -11,7 +11,7 @@ use crate::constants::{
 use psibase::services::fractals::distribute::{allocations, combine_group_scores};
 use psibase::services::fractals::weighted_normalization::{
     curves::{get_curve, Curve},
-    weighted_normalization,
+    weighted_normalization, HasScore,
 };
 use psibase::services::fractals::FractalRole::{
     self, Executive, Judiciary, Legislature, Recruitment,
@@ -30,6 +30,17 @@ use psibase::services::fractals::{self, occu_wrapper};
 use psibase::services::tokens::Wrapper as Tokens;
 use psibase::services::transact::Wrapper as TransactSvc;
 use psibase::{get_sender, RawKey, TableQuery, TimePointSec};
+
+struct MemberScore {
+    account: AccountNumber,
+    score: u32,
+}
+
+impl HasScore for MemberScore {
+    fn get_score(&self) -> Decimal {
+        Decimal::new((self.score as u64).into(), Precision::new(0).unwrap())
+    }
+}
 
 impl Fractal {
     fn new(account: AccountNumber, name: String, mission: String) -> Self {
@@ -158,7 +169,7 @@ impl Fractal {
         }
 
         let mut dust = withdrawn.value;
-        allocations(self.member_reward_shares(), withdrawn.value).for_each(|(member, amount)| {
+        allocations(self.member_reward_ppm(), withdrawn.value).for_each(|(member, amount)| {
             dust -= amount;
             RewardStream::get_assert(self.account, member)
                 .deposit(amount.into(), "Fractal reward".into());
@@ -169,20 +180,31 @@ impl Fractal {
         }
     }
 
-    fn member_reward_shares(&self) -> std::collections::HashMap<AccountNumber, u32> {
+    fn member_reward_ppm(&self) -> std::collections::HashMap<AccountNumber, u32> {
         let members = FractalMember::get_all(self.account);
         let is_member = |acc: &AccountNumber| members.iter().any(|m| m.account == *acc);
 
-        let ranked_occ = Occupation::get_ordered(self.account);
-        let weights = weighted_normalization(ranked_occ.iter(), get_curve(self.dist_strat.into()));
+        let ranked_occupations = Occupation::get_ordered(self.account);
+        let weighted_occupations =
+            weighted_normalization(ranked_occupations.iter(), get_curve(self.dist_strat.into()));
 
-        let groups = ranked_occ.into_iter().zip(weights).map(|(occ, w)| {
-            let member_scores = occu_wrapper::call_to(occ.occupation)
-                .get_scores(self.account)
-                .into_iter()
-                .filter(|(m, _)| is_member(m));
-            (w, member_scores)
-        });
+        let groups = ranked_occupations
+            .into_iter()
+            .zip(weighted_occupations)
+            .map(|(occupation, weight)| {
+                let member_scores: Vec<MemberScore> = occu_wrapper::call_to(occupation.occupation)
+                    .get_scores(self.account)
+                    .into_iter()
+                    .filter(|(m, _)| is_member(m))
+                    .map(|(account, score)| MemberScore { account, score })
+                    .collect();
+                let member_ppm =
+                    weighted_normalization(member_scores.iter(), get_curve(Curve::Identity));
+                (
+                    weight,
+                    member_scores.into_iter().map(|m| m.account).zip(member_ppm),
+                )
+            });
 
         combine_group_scores(groups)
     }

--- a/rust/psibase/src/services/fractals/distribute.rs
+++ b/rust/psibase/src/services/fractals/distribute.rs
@@ -15,34 +15,31 @@ where
 {
     let mut member_allocations: HashMap<Member, u32> = HashMap::new();
 
-    for (total, member_shares) in groups {
-        for (member, allocation) in allocations(member_shares, total as u64) {
+    for (total, member_ppm) in groups {
+        for (member, allocation) in allocations(member_ppm, total as u64) {
             *member_allocations.entry(member).or_insert(0u32) += allocation as u32;
         }
     }
     member_allocations
 }
 
-/// Yields `(element, amount)` pairs, where `amount = (share / PPM) * total`
+/// Yields `(element, amount)` pairs, where `amount = (ppm / PPM) * budget`
 /// (integer-floored). Elements whose computed amount is zero are skipped.
 ///
-/// Aborts if the cumulative shares exceed `PPM`.
-pub fn allocations<I, Element>(
-    element_shares: I,
-    total: u64,
-) -> impl Iterator<Item = (Element, u64)>
+/// Aborts if the cumulative ppm exceeds `PPM`.
+pub fn allocations<I, Element>(element_ppm: I, budget: u64) -> impl Iterator<Item = (Element, u64)>
 where
     I: IntoIterator<Item = (Element, u32)>,
 {
-    let mut total_shares = 0u64;
-    element_shares
+    let mut total_ppm = 0u64;
+    element_ppm
         .into_iter()
-        .filter_map(move |(element, share)| {
-            total_shares += share as u64;
-            if total_shares > PPM as u64 {
-                abort_message("provided shares exceed 100%");
+        .filter_map(move |(element, ppm)| {
+            total_ppm += ppm as u64;
+            if total_ppm > PPM as u64 {
+                abort_message("ppm sum exceeds 1,000,000 / 100%");
             }
-            let amount = ((share as u128 * total as u128) / PPM as u128) as u64;
+            let amount = ((ppm as u128 * budget as u128) / PPM as u128) as u64;
             (amount > 0).then_some((element, amount))
         })
 }


### PR DESCRIPTION
During distribution of tokens to fractal members, function `member_reward_shares` is responsible for producing a `HashMap` of users and their slice of the token allocation. 

Function `allocations` is used to divide a total / budget across a list of accounts, however it expects each members allocation to be in `ppm` e.g. 500,000 for 50% but instead it's passed the results of `occu_wrapper::call_to(occ.occupation) .get_scores(self.account)` which returns a raw score. 

So in a 3 man Fractal, alice, bob and charlie each with a score of 10, **should** be sending in 333,333 each into `allocations` however it's just `10` instead, resulting in tiny allocations and huge amounts of tokens recycled as dust. 

I've also slipped in renaming away from the `share` idea as it's ambiguous between a share in a company, which is relative to total shares, or ppm share, which is always out of 1,000,000. 