### PR TITLE
Adjust number handling in AuthDyn

### DIFF
--- a/packages/system/AuthDyn/service/src/lib.rs
+++ b/packages/system/AuthDyn/service/src/lib.rs
@@ -172,7 +172,7 @@ pub mod service {
         let total_possible_weight = policy
             .authorizers
             .iter()
-            .fold(0, |acc, authorizer| acc + authorizer.weight);
+            .fold(0u8, |acc, authorizer| acc.checked_add(authorizer.weight).unwrap());
 
         if policy.threshold > total_possible_weight {
             return !is_approval;
@@ -188,7 +188,7 @@ pub mod service {
             .authorizers
             .into_iter()
             .filter(|authorizer| authorizers.contains(&authorizer.account))
-            .fold(0, |acc, authorizer| acc + authorizer.weight);
+            .fold(0u8, |acc, authorizer| acc.checked_add(authorizer.weight).unwrap());
 
         total_weight_approved >= required_weight
     }

--- a/packages/user/Fractals/de-facto/src/lib.rs
+++ b/packages/user/Fractals/de-facto/src/lib.rs
@@ -30,8 +30,8 @@ pub mod service {
             .is_some()
     }
 
-    fn two_thirds_plus_one(count: u8) -> u8 {
-        ((count as u16 * 2 + 3) / 3) as u8
+    fn two_thirds_plus_one(count: usize) -> u8 {
+        u8::try_from((count * 2 + 3) / 3).unwrap()
     }
 
     #[action]
@@ -43,7 +43,7 @@ pub mod service {
                 .map(|account| (account.account, 1))
                 .collect();
 
-        let threshold = two_thirds_plus_one(accounts.len() as u8);
+        let threshold = two_thirds_plus_one(accounts.len());
         DynamicAuthPolicy::from_weighted_authorizers(accounts, threshold)
     }
 }


### PR DESCRIPTION
I didn't realise when I wrote the code for `AuthDyn` around [overflow](https://doc.rust-lang.org/book/ch03-02-data-types.html#integer-overflow) that Rust only panics when compiling in debug mode, however in release mode it will overflow. 

I'm wondering if we got something that changes this process given the context the services run in, however if not, I've adopted `checked_add` with unwrap to ensure the clean panic I was expecting.  