### PR TITLE
Fix websocket deadlock

### DIFF
--- a/libraries/psibase_http/websocket.cpp
+++ b/libraries/psibase_http/websocket.cpp
@@ -99,7 +99,7 @@ bool WebSocket::handleP2P()
       }
       else if (p2pState == P2PState::reading)
       {
-         p2pState == P2PState::messageReady;
+         p2pState = P2PState::messageReady;
          return true;
       }
    }

--- a/libraries/psibase_http/websocket.hpp
+++ b/libraries/psibase_http/websocket.hpp
@@ -350,13 +350,12 @@ namespace psibase::http
                    std::unique_lock l{self->mutex};
                    if (ec)
                    {
+                      auto outbox = std::move(self->outbox);
+                      l.unlock(); // `error()` locks the mutex
                       if (ec != make_error_code(boost::asio::error::operation_aborted))
                       {
-                         // FIXME: recursive lock
                          self->error(ec);
                       }
-                      auto outbox = std::move(self->outbox);
-                      l.unlock();
                       self->clearOutbox(std::move(outbox), ec);
                       return;
                    }


### PR DESCRIPTION
This should resolve the deadlock, and I can't see why any race window between `unlock()` and `error()` should matter.

This is what is currently hanging my testnet node.

This also fixes a `==/=` typo in `handleP2P` that left `p2pState` stuck in `reading`, dropping early p2p messages.