### PR TITLE
Add recall shared and sub balances

### DIFF
--- a/packages/user/Tokens/include/services/user/Tokens.hpp
+++ b/packages/user/Tokens/include/services/user/Tokens.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <optional>
+#include <string>
+
 #include <psibase/Memo.hpp>
 #include <psibase/psibase.hpp>
 
@@ -179,16 +182,37 @@ namespace UserService
       /// * `memo`     - Memo
       void debit(TID tokenId, psibase::AccountNumber creditor, Quantity amount, Memo memo);
 
-      /// Recalls an amount of tokens from a user's balance and burns them
+      /// Recalls an amount of tokens from a user's primary or sub-account balance and burns them
+      ///
+      /// Only the token owner can recall tokens, and only if the token is not marked as unrecallable.
+      ///
+      /// # Arguments
+      /// * `token_id`    - Unique token identifier
+      /// * `from`        - User account from which to recall
+      /// * `amount`      - Amount of tokens to recall
+      /// * `memo`        - Memo
+      /// * `subAccount`  - If specified, recall from this sub-account of `from`
+      void recall(TID                        tokenId,
+                  psibase::AccountNumber     from,
+                  Quantity                   amount,
+                  Memo                       memo,
+                  std::optional<std::string> subAccount);
+
+      /// Recalls an amount of tokens from a shared balance and burns them
       ///
       /// Only the token owner can recall tokens, and only if the token is not marked as unrecallable.
       ///
       /// # Arguments
       /// * `token_id` - Unique token identifier
-      /// * `from`     - User account from which to recall
+      /// * `creditor` - Account that credited the tokens
+      /// * `debitor`  - Account that received the credit
       /// * `amount`   - Amount of tokens to recall
       /// * `memo`     - Memo
-      void recall(TID tokenId, psibase::AccountNumber from, Quantity amount, Memo memo);
+      void recallShared(TID                    tokenId,
+                        psibase::AccountNumber creditor,
+                        psibase::AccountNumber debitor,
+                        Quantity               amount,
+                        Memo                   memo);
 
       /// Sends tokens from an account's primary balance into a "sub-account" balance
       ///
@@ -383,7 +407,8 @@ namespace UserService
       method(createSub, subAccount),
       method(deleteSub, subAccount),
       method(debit, tokenId, creditor, amount, memo),
-      method(recall, tokenId, from, amount, memo),
+      method(recall, tokenId, from, amount, memo, subAccount),
+      method(recallShared, tokenId, creditor, debitor, amount, memo),
       method(getToken, tokenId),
       method(getUserConf, account, index),
       method(setSysToken, tokenId),

--- a/packages/user/Tokens/include/services/user/tokenErrors.hpp
+++ b/packages/user/Tokens/include/services/user/tokenErrors.hpp
@@ -13,6 +13,7 @@ namespace UserService
       constexpr std::string_view tokenOverflow             = "Token overflow";
       constexpr std::string_view insufficientBalance       = "insufficient balance";
       constexpr std::string_view insufficientSharedBalance = "Insufficient shared balance";
+      constexpr std::string_view insufficientSubBalance    = "Insufficient sub-account balance";
       constexpr std::string_view missingSharedBalance      = "Shared balance does not exist";
       constexpr std::string_view supplyGt0           = "Max issued supply must be greater than 0";
       constexpr std::string_view quantityGt0         = "Quantity must be greater than 0";

--- a/packages/user/Tokens/plugin/src/lib.rs
+++ b/packages/user/Tokens/plugin/src/lib.rs
@@ -53,12 +53,40 @@ impl Issuer for TokensPlugin {
     }
 
     #[psibase_plugin::authorized(High)]
-    fn recall(token_id: u32, amount: String, memo: String, account: String) -> Result<(), Error> {
+    fn recall(
+        token_id: u32,
+        amount: String,
+        memo: String,
+        account: String,
+        sub_account: Option<String>,
+    ) -> Result<(), Error> {
         let amount = Self::non_zero(token_id, amount)?;
+        let sub_account = sub_account.filter(|s| !s.is_empty());
 
         Tokens::add_to_tx().recall(
             token_id,
             account.parse().unwrap(),
+            amount,
+            memo.as_str().into(),
+            sub_account,
+        );
+        Ok(())
+    }
+
+    #[psibase_plugin::authorized(High)]
+    fn recall_shared(
+        token_id: u32,
+        amount: String,
+        memo: String,
+        creditor: String,
+        debitor: String,
+    ) -> Result<(), Error> {
+        let amount = Self::non_zero(token_id, amount)?;
+
+        Tokens::add_to_tx().recallShared(
+            token_id,
+            creditor.parse().unwrap(),
+            debitor.parse().unwrap(),
             amount,
             memo.as_str().into(),
         );

--- a/packages/user/Tokens/plugin/wit/world.wit
+++ b/packages/user/Tokens/plugin/wit/world.wit
@@ -16,14 +16,25 @@ interface issuer {
     /// * `max_supply` - The permanent max issued supply of the token
     create: func(precision: u8, max-supply: decimal) -> result<_, error>;
 
-    /// Recall an amount of tokens from a user's balance and burn them.
+    /// Recall an amount of tokens from a user's primary or sub-account balance and burn them.
+    ///
+    /// Arguments
+    /// * `token_id`    - Unique token identifier
+    /// * `amount`      - Amount of tokens to recall
+    /// * `memo`        - Memo describing the recall
+    /// * `account`     - Account from which tokens are recalled
+    /// * `sub-account` - If specified, recall from this sub-account of `account`
+    recall: func(token-id: u32, amount: decimal, memo: string, account: string, sub-account: option<string>) -> result<_, error>;
+
+    /// Recall an amount of tokens from a shared balance and burn them.
     ///
     /// Arguments
     /// * `token_id` - Unique token identifier
     /// * `amount`   - Amount of tokens to recall
     /// * `memo`     - Memo describing the recall
-    /// * `account`  - Account from which tokens are recalled
-    recall: func(token-id: u32, amount: decimal, memo: string, account: string) -> result<_, error>;
+    /// * `creditor` - Account that credited the tokens
+    /// * `debitor`  - Account that received the credit
+    recall-shared: func(token-id: u32, amount: decimal, memo: string, creditor: string, debitor: string) -> result<_, error>;
 
     /// Mint new tokens into existence.
     ///

--- a/packages/user/Tokens/service/src/lib.rs
+++ b/packages/user/Tokens/service/src/lib.rs
@@ -266,9 +266,7 @@ pub mod service {
         memo: Memo,
         sub_account: Option<String>,
     ) {
-        let mut token = Token::get_assert(token_id);
-
-        token.recall(amount, from, sub_account);
+        Token::get_assert(token_id).recall(amount, from, sub_account);
         emit_recall(token_id, from, amount, memo);
     }
 
@@ -290,9 +288,7 @@ pub mod service {
         amount: Quantity,
         memo: Memo,
     ) {
-        let mut token = Token::get_assert(token_id);
-
-        token.recall_shared(amount, creditor, debitor);
+        Token::get_assert(token_id).recall_shared(amount, creditor, debitor);
         emit_recall(token_id, creditor, amount, memo);
     }
 

--- a/packages/user/Tokens/service/src/lib.rs
+++ b/packages/user/Tokens/service/src/lib.rs
@@ -248,21 +248,55 @@ pub mod service {
         SharedBalance::get_or_new(creditor, debitor, token_id).balance
     }
 
-    /// Recalls an amount of tokens from a user's balance and burns them
+    /// Recalls an amount of tokens from a user's primary or sub-account balance and burns them
+    ///
+    /// Only the token owner can recall tokens, and only if the token is not marked as unrecallable.
+    ///
+    /// # Arguments
+    /// * `token_id`    - Unique token identifier
+    /// * `from`        - User account from which to recall
+    /// * `amount`      - Amount of tokens to recall
+    /// * `memo`        - Memo
+    /// * `sub_account` - If specified, recall from this sub-account of `from`
+    #[action]
+    fn recall(
+        token_id: TID,
+        from: AccountNumber,
+        amount: Quantity,
+        memo: Memo,
+        sub_account: Option<String>,
+    ) {
+        let mut token = Token::get_assert(token_id);
+
+        token.recall(amount, from, sub_account);
+        emit_recall(token_id, from, amount, memo);
+    }
+
+    /// Recalls an amount of tokens from a shared balance and burns them
     ///
     /// Only the token owner can recall tokens, and only if the token is not marked as unrecallable.
     ///
     /// # Arguments
     /// * `token_id` - Unique token identifier
-    /// * `from`     - User account from which to recall
+    /// * `creditor` - Account that credited the tokens
+    /// * `debitor`  - Account that received the credit
     /// * `amount`   - Amount of tokens to recall
     /// * `memo`     - Memo
     #[action]
-    fn recall(token_id: TID, from: AccountNumber, amount: Quantity, memo: Memo) {
+    fn recallShared(
+        token_id: TID,
+        creditor: AccountNumber,
+        debitor: AccountNumber,
+        amount: Quantity,
+        memo: Memo,
+    ) {
         let mut token = Token::get_assert(token_id);
 
-        token.recall(amount, from);
+        token.recall_shared(amount, creditor, debitor);
+        emit_recall(token_id, creditor, amount, memo);
+    }
 
+    fn emit_recall(token_id: TID, from: AccountNumber, amount: Quantity, memo: Memo) {
         let actor = get_sender();
         let recalled = "recalled".to_string();
         let amount = fmt_amount(token_id, amount);
@@ -274,7 +308,7 @@ pub mod service {
             actor, // In this exceptional case, the actor is the counterparty
             recalled.clone(),
             amount.clone(),
-            memo.clone(),
+            memo,
         );
 
         event.supplyChanged(

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -197,7 +197,11 @@ pub mod tables {
         }
 
         pub fn burn(&mut self, amount: Quantity) {
-            self.burn_supply(amount, get_sender());
+            assert!(amount.value > 0, "burn quantity must be greater than 0");
+
+            Balance::get_or_new(get_sender(), self.id).sub_balance(amount);
+            self.burned_supply = self.burned_supply + amount;
+            self.save();
         }
 
         fn check_can_recall(&self) {
@@ -238,14 +242,6 @@ pub mod tables {
 
             SharedBalance::get_assert(creditor, debitor, self.id).recall(amount);
 
-            self.burned_supply = self.burned_supply + amount;
-            self.save();
-        }
-
-        fn burn_supply(&mut self, amount: Quantity, from: AccountNumber) {
-            assert!(amount.value > 0, "burn quantity must be greater than 0");
-
-            Balance::get_or_new(from, self.id).sub_balance(amount);
             self.burned_supply = self.burned_supply + amount;
             self.save();
         }

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -1,12 +1,12 @@
 #[psibase::service_tables]
 pub mod tables {
-    use crate::service::{fmt_amount, TID};
+    use crate::service::{TID, fmt_amount};
     use async_graphql::{ComplexObject, SimpleObject};
     use psibase::services::accounts::Wrapper as Accounts;
-    use psibase::services::nft::{Wrapper as Nfts, NID};
+    use psibase::services::nft::{NID, Wrapper as Nfts};
     use psibase::services::tokens::{Decimal, Precision, Quantity};
-    use psibase::{abort_message, get_sender, AccountNumber, Memo, ServiceWrapper, TableRecord};
-    use psibase::{define_flags, Flags};
+    use psibase::{AccountNumber, Memo, ServiceWrapper, TableRecord, abort_message, get_sender};
+    use psibase::{Flags, define_flags};
     use psibase::{Fracpack, Table, ToSchema};
     use serde::{Deserialize, Serialize};
 
@@ -200,15 +200,46 @@ pub mod tables {
             self.burn_supply(amount, get_sender());
         }
 
-        pub fn recall(&mut self, amount: Quantity, from: AccountNumber) {
+        fn check_can_recall(&self) {
             self.check_is_owner(get_sender());
-
             assert!(
                 !self.get_flag(TokenFlags::UNRECALLABLE),
                 "Token unrecallable",
             );
+        }
 
-            self.burn_supply(amount, from);
+        pub fn recall(
+            &mut self,
+            amount: Quantity,
+            from: AccountNumber,
+            sub_account: Option<String>,
+        ) {
+            self.check_can_recall();
+            assert!(amount.value > 0, "burn quantity must be greater than 0");
+
+            if let Some(sub) = sub_account {
+                SubAccount::get_assert(from, sub).recall_balance(self.id, amount);
+            } else {
+                Balance::get_or_new(from, self.id).sub_balance(amount);
+            }
+
+            self.burned_supply = self.burned_supply + amount;
+            self.save();
+        }
+
+        pub fn recall_shared(
+            &mut self,
+            amount: Quantity,
+            creditor: AccountNumber,
+            debitor: AccountNumber,
+        ) {
+            self.check_can_recall();
+            assert!(amount.value > 0, "burn quantity must be greater than 0");
+
+            SharedBalance::get_assert(creditor, debitor, self.id).recall(amount);
+
+            self.burned_supply = self.burned_supply + amount;
+            self.save();
         }
 
         fn burn_supply(&mut self, amount: Quantity, from: AccountNumber) {
@@ -524,6 +555,10 @@ pub mod tables {
 
             self.sub_balance(quantity);
             Balance::get_or_new(self.debitor, self.token_id).add_balance(quantity);
+        }
+
+        pub fn recall(&mut self, quantity: Quantity) {
+            self.sub_balance(quantity);
         }
 
         pub fn reject(&mut self, memo: Memo) {
@@ -902,8 +937,16 @@ pub mod tables {
         pub fn sub_balance(&mut self, token_id: TID, quantity: Quantity) {
             let remaining = SubAccountBalance::get_assert(self.id, token_id).sub_balance(quantity);
             Balance::get_or_new(self.account, token_id).add_balance(quantity);
+            self.maybe_autodelete(remaining);
+        }
 
-            if remaining.value == 0 && !self.manual_deletion {
+        pub fn recall_balance(&mut self, token_id: TID, quantity: Quantity) {
+            let remaining = SubAccountBalance::get_assert(self.id, token_id).sub_balance(quantity);
+            self.maybe_autodelete(remaining);
+        }
+
+        fn maybe_autodelete(&mut self, remaining_for_token: Quantity) {
+            if remaining_for_token.value == 0 && !self.manual_deletion {
                 let keep = SubAccountBalanceTable::read()
                     .get_index_pk()
                     .range((self.id, 0)..(self.id, u32::MAX))

--- a/packages/user/Tokens/service/src/tests.rs
+++ b/packages/user/Tokens/service/src/tests.rs
@@ -2,8 +2,8 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::helpers::to_fixed;
     use crate::Wrapper;
+    use crate::helpers::to_fixed;
     use psibase::services::http_server;
     use psibase::services::tokens::{Decimal, Precision, Quantity, TokensError};
     use psibase::*;
@@ -139,6 +139,145 @@ mod tests {
         b.reject(tid, alice, memo.clone());
         assert_eq!(100, a.getBalance(tid, alice).get()?.value);
         assert_eq!(0, b.getBalance(tid, bob).get()?.value);
+
+        Ok(())
+    }
+
+    #[psibase::test_case(packages("Tokens"))]
+    fn test_recall(chain: psibase::Chain) -> Result<(), psibase::Error> {
+        Wrapper::push(&chain).init();
+
+        let alice = account!("alice");
+        chain.new_account(alice).unwrap();
+        let a = Wrapper::push_from(&chain, alice);
+
+        let bob = account!("bob");
+        chain.new_account(bob).unwrap();
+        let b = Wrapper::push_from(&chain, bob);
+
+        let carol = account!("carol");
+        chain.new_account(carol).unwrap();
+        let c = Wrapper::push_from(&chain, carol);
+
+        enable_nft_auto_debit(&chain, alice);
+
+        let memo = Memo::new("memo".to_string()).unwrap();
+        let savings = "savings".to_string();
+        let checking = "checking".to_string();
+
+        let issue = |amount: u64| -> Result<u32, psibase::Error> {
+            let tid = a.create(4.try_into().unwrap(), 1_000_0000.into()).get()?;
+            a.mint(tid, amount.into(), memo.clone()).get()?;
+            a.credit(tid, bob, amount.into(), memo.clone()).get()?;
+            b.debit(tid, alice, amount.into(), memo.clone()).get()?;
+            Ok(tid)
+        };
+
+        // Recall from primary balance
+        let tid = issue(100)?;
+        a.recall(tid, bob, 100.into(), memo.clone(), None).get()?;
+        assert_eq!(0, b.getBalance(tid, bob).get()?.value);
+
+        // Tokens in a sub-account are not recalled from the primary balance
+        let tid = issue(100)?;
+        b.toSub(tid, savings.clone(), 100.into()).get()?;
+        assert_error(
+            a.recall(tid, bob, 100.into(), memo.clone(), None),
+            "insufficient balance",
+        );
+        assert_eq!(
+            Some(Quantity::from(100u64)),
+            b.getSubBal(tid, savings.clone()).get()?
+        );
+
+        // Recall from a sub-account; auto-created sub-account is deleted
+        a.recall(tid, bob, 100.into(), memo.clone(), Some(savings.clone()))
+            .get()?;
+        assert_eq!(0, b.getBalance(tid, bob).get()?.value);
+        assert_eq!(None, b.getSubBal(tid, savings.clone()).get()?);
+
+        // Burn still uses primary only
+        let tid = issue(100)?;
+        b.toSub(tid, savings.clone(), 100.into()).get()?;
+        assert_error(b.burn(tid, 1.into(), memo.clone()), "insufficient balance");
+        a.recall(tid, bob, 100.into(), memo.clone(), Some(savings.clone()))
+            .get()?;
+
+        // Outstanding credits are not recalled from the primary balance
+        let tid = issue(100)?;
+        b.credit(tid, carol, 100.into(), memo.clone()).get()?;
+        assert_eq!(100, get_shared_balance(&chain, tid, bob, carol).value);
+        assert_error(
+            a.recall(tid, bob, 100.into(), memo.clone(), None),
+            "insufficient balance",
+        );
+
+        // Recall from a shared balance
+        a.recallShared(tid, bob, carol, 100.into(), memo.clone())
+            .get()?;
+        assert_eq!(0, b.getBalance(tid, bob).get()?.value);
+        assert_eq!(0, get_shared_balance(&chain, tid, bob, carol).value);
+        assert_eq!(0, c.getBalance(tid, carol).get()?.value);
+
+        // Incoming undebited credits are not the debitor's to recall
+        let tid = issue(100)?;
+        b.credit(tid, carol, 100.into(), memo.clone()).get()?;
+        assert_error(
+            a.recallShared(tid, carol, bob, 100.into(), memo.clone()),
+            "Shared balance does not exist",
+        );
+        assert_eq!(100, get_shared_balance(&chain, tid, bob, carol).value);
+
+        // Partial shared-balance recall
+        a.recallShared(tid, bob, carol, 40.into(), memo.clone())
+            .get()?;
+        assert_eq!(60, get_shared_balance(&chain, tid, bob, carol).value);
+        assert_error(
+            a.recallShared(tid, bob, carol, 61.into(), memo.clone()),
+            "Insufficient shared balance",
+        );
+
+        // Manual sub-account is kept after a full recall of its balance
+        let tid = issue(50)?;
+        b.createSub(savings.clone()).get()?;
+        b.toSub(tid, savings.clone(), 50.into()).get()?;
+        a.recall(tid, bob, 50.into(), memo.clone(), Some(savings.clone()))
+            .get()?;
+        assert_eq!(
+            Some(Quantity::from(0u64)),
+            b.getSubBal(tid, savings.clone()).get()?
+        );
+        b.deleteSub(savings.clone()).get()?;
+
+        // Other tokens in the same sub-account are left alone
+        let tid = issue(80)?;
+        let tid2 = issue(30)?;
+        b.toSub(tid, savings.clone(), 80.into()).get()?;
+        b.toSub(tid2, savings.clone(), 30.into()).get()?;
+        a.recall(tid, bob, 80.into(), memo.clone(), Some(savings.clone()))
+            .get()?;
+        assert_eq!(
+            Some(Quantity::from(0u64)),
+            b.getSubBal(tid, savings.clone()).get()?
+        );
+        assert_eq!(
+            Some(Quantity::from(30u64)),
+            b.getSubBal(tid2, savings.clone()).get()?
+        );
+        b.fromSub(tid2, savings.clone(), 30.into()).get()?;
+        assert_eq!(None, b.getSubBal(tid2, savings.clone()).get()?);
+
+        // Recalling one sub-account leaves another
+        let tid = issue(100)?;
+        b.toSub(tid, savings.clone(), 40.into()).get()?;
+        b.toSub(tid, checking.clone(), 60.into()).get()?;
+        a.recall(tid, bob, 40.into(), memo.clone(), Some(savings.clone()))
+            .get()?;
+        assert_eq!(None, b.getSubBal(tid, savings.clone()).get()?);
+        assert_eq!(
+            Some(Quantity::from(60u64)),
+            b.getSubBal(tid, checking.clone()).get()?
+        );
 
         Ok(())
     }

--- a/packages/user/Tokens/service/src/tests.rs
+++ b/packages/user/Tokens/service/src/tests.rs
@@ -219,7 +219,7 @@ mod tests {
         assert_eq!(0, get_shared_balance(&chain, tid, bob, carol).value);
         assert_eq!(0, c.getBalance(tid, carol).get()?.value);
 
-        // Incoming undebited credits are not the debitor's to recall
+        // Issuer cannot recall tokens from the reversed creditor/debitor pair
         let tid = issue(100)?;
         b.credit(tid, carol, 100.into(), memo.clone()).get()?;
         assert_error(

--- a/packages/user/Tokens/test/src/Tokens-test.cpp
+++ b/packages/user/Tokens/test/src/Tokens-test.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_all.hpp>
+#include <optional>
 #include <psibase/DefaultTestChain.hpp>
 #include <psibase/MethodNumber.hpp>
 #include <psibase/checkSchema.hpp>
@@ -226,7 +227,7 @@ SCENARIO("Recalling tokens")
       }
       THEN("Alice can recall Bob's tokens")
       {
-         auto recall = a.recall(tokenId, bob, 1'000e4, memo);
+         auto recall = a.recall(tokenId, bob, 1'000e4, memo, std::nullopt);
          CHECK(recall.succeeded());
 
          AND_THEN("Bob's token balance has decreased")
@@ -246,11 +247,55 @@ SCENARIO("Recalling tokens")
 
          AND_THEN("Alice may not recall Bob's tokens")
          {
-            CHECK(a.recall(tokenId, bob, 1'000e4, memo).failed(tokenUnrecallable));
+            CHECK(a.recall(tokenId, bob, 1'000e4, memo, std::nullopt).failed(tokenUnrecallable));
          }
          AND_THEN("The token issuer may not re-enable recallability")
          {
             CHECK(a.setTokenConf(tokenId, Tokens::unrecallable, false).failed(invalidConfigUpdate));
+         }
+      }
+      WHEN("Bob moves his tokens into a sub-account")
+      {
+         CHECK(b.toSub(tokenId, "savings", 1'000e4).succeeded());
+         CHECK(a.getBalance(tokenId, bob).returnVal().value == 0);
+
+         THEN("Alice cannot recall them from Bob's primary balance")
+         {
+            CHECK(a.recall(tokenId, bob, 1'000e4, memo, std::nullopt).failed(insufficientBalance));
+         }
+         THEN("Alice can recall them from the sub-account")
+         {
+            CHECK(a.recall(tokenId, bob, 1'000e4, memo, std::string{"savings"}).succeeded());
+            CHECK(a.getBalance(tokenId, bob).returnVal().value == 0);
+            CHECK(not b.getSubBal(tokenId, "savings").returnVal().has_value());
+         }
+         THEN("Bob may not burn tokens that sit only in a sub-account")
+         {
+            CHECK(b.burn(tokenId, 1e4, memo).failed(insufficientBalance));
+         }
+      }
+      WHEN("Bob credits Carol, who does not auto-debit")
+      {
+         auto carol = t.from(t.addAccount("carol"_a));
+         auto c     = carol.to<Tokens>();
+         CHECK(b.credit(tokenId, carol, 1'000e4, memo).succeeded());
+         CHECK(b.getSharedBal(tokenId, bob, carol).returnVal().value == 1'000e4);
+
+         THEN("Alice cannot recall them from Bob's primary balance")
+         {
+            CHECK(a.recall(tokenId, bob, 1'000e4, memo, std::nullopt).failed(insufficientBalance));
+         }
+         THEN("Alice can recall them from the shared balance")
+         {
+            CHECK(a.recallShared(tokenId, bob, carol, 1'000e4, memo).succeeded());
+            CHECK(a.getBalance(tokenId, bob).returnVal().value == 0);
+            CHECK(b.getSharedBal(tokenId, bob, carol).returnVal().value == 0);
+            CHECK(c.getBalance(tokenId, carol).returnVal().value == 0);
+         }
+         THEN("Alice recalling Carol as creditor does not take Bob's in-flight credit")
+         {
+            CHECK(a.recallShared(tokenId, carol, bob, 1'000e4, memo).failed(missingSharedBalance));
+            CHECK(b.getSharedBal(tokenId, bob, carol).returnVal().value == 1'000e4);
          }
       }
    }
@@ -308,14 +353,14 @@ SCENARIO("Interactions with the Issuer NFT")
          THEN("Alice may not recall Bob's tokens")
          {
             b.mint(tokenId, 1'000e4, memo);
-            CHECK(a.recall(tokenId, bob, 1'000e4, memo).failed(missingRequiredAuth));
+            CHECK(a.recall(tokenId, bob, 1'000e4, memo, std::nullopt).failed(missingRequiredAuth));
          }
          THEN("Bob may recall Alice's tokens")
          {
             Quantity q{1'000e4};
             b.mint(tokenId, q, memo);
             b.credit(tokenId, alice, q, memo);
-            CHECK(b.recall(tokenId, alice, q, memo).succeeded());
+            CHECK(b.recall(tokenId, alice, q, memo, std::nullopt).succeeded());
          }
       }
       WHEN("Alice burns the issuer NFT")
@@ -335,7 +380,7 @@ SCENARIO("Interactions with the Issuer NFT")
          }
          THEN("Alice may not recall Bob's tokens")
          {
-            CHECK(a.recall(tokenId, bob, quantity, memo).failed(nftBurned));
+            CHECK(a.recall(tokenId, bob, quantity, memo, std::nullopt).failed(nftBurned));
          }
          THEN("Alice may not update the token inflation")
          {  //

--- a/packages/user/Tokens/test/src/Tokens-test.cpp
+++ b/packages/user/Tokens/test/src/Tokens-test.cpp
@@ -254,50 +254,6 @@ SCENARIO("Recalling tokens")
             CHECK(a.setTokenConf(tokenId, Tokens::unrecallable, false).failed(invalidConfigUpdate));
          }
       }
-      WHEN("Bob moves his tokens into a sub-account")
-      {
-         CHECK(b.toSub(tokenId, "savings", 1'000e4).succeeded());
-         CHECK(a.getBalance(tokenId, bob).returnVal().value == 0);
-
-         THEN("Alice cannot recall them from Bob's primary balance")
-         {
-            CHECK(a.recall(tokenId, bob, 1'000e4, memo, std::nullopt).failed(insufficientBalance));
-         }
-         THEN("Alice can recall them from the sub-account")
-         {
-            CHECK(a.recall(tokenId, bob, 1'000e4, memo, std::string{"savings"}).succeeded());
-            CHECK(a.getBalance(tokenId, bob).returnVal().value == 0);
-            CHECK(not b.getSubBal(tokenId, "savings").returnVal().has_value());
-         }
-         THEN("Bob may not burn tokens that sit only in a sub-account")
-         {
-            CHECK(b.burn(tokenId, 1e4, memo).failed(insufficientBalance));
-         }
-      }
-      WHEN("Bob credits Carol, who does not auto-debit")
-      {
-         auto carol = t.from(t.addAccount("carol"_a));
-         auto c     = carol.to<Tokens>();
-         CHECK(b.credit(tokenId, carol, 1'000e4, memo).succeeded());
-         CHECK(b.getSharedBal(tokenId, bob, carol).returnVal().value == 1'000e4);
-
-         THEN("Alice cannot recall them from Bob's primary balance")
-         {
-            CHECK(a.recall(tokenId, bob, 1'000e4, memo, std::nullopt).failed(insufficientBalance));
-         }
-         THEN("Alice can recall them from the shared balance")
-         {
-            CHECK(a.recallShared(tokenId, bob, carol, 1'000e4, memo).succeeded());
-            CHECK(a.getBalance(tokenId, bob).returnVal().value == 0);
-            CHECK(b.getSharedBal(tokenId, bob, carol).returnVal().value == 0);
-            CHECK(c.getBalance(tokenId, carol).returnVal().value == 0);
-         }
-         THEN("Alice recalling Carol as creditor does not take Bob's in-flight credit")
-         {
-            CHECK(a.recallShared(tokenId, carol, bob, 1'000e4, memo).failed(missingSharedBalance));
-            CHECK(b.getSharedBal(tokenId, bob, carol).returnVal().value == 1'000e4);
-         }
-      }
    }
 }
 

--- a/rust/psibase/src/services/tokens/mod.rs
+++ b/rust/psibase/src/services/tokens/mod.rs
@@ -188,17 +188,45 @@ mod service {
         unimplemented!()
     }
 
-    /// Recalls an amount of tokens from a user's balance and burns them
+    /// Recalls an amount of tokens from a user's primary or sub-account balance and burns them
+    ///
+    /// Only the token owner can recall tokens, and only if the token is not marked as unrecallable.
+    ///
+    /// # Arguments
+    /// * `token_id`    - Unique token identifier
+    /// * `from`        - User account from which to recall
+    /// * `amount`      - Amount of tokens to recall
+    /// * `memo`        - Memo
+    /// * `sub_account` - If specified, recall from this sub-account of `from`
+    #[action]
+    fn recall(
+        token_id: TID,
+        from: AccountNumber,
+        amount: Quantity,
+        memo: Memo,
+        sub_account: Option<String>,
+    ) {
+        unimplemented!()
+    }
+
+    /// Recalls an amount of tokens from a shared balance and burns them
     ///
     /// Only the token owner can recall tokens, and only if the token is not marked as unrecallable.
     ///
     /// # Arguments
     /// * `token_id` - Unique token identifier
-    /// * `from`     - User account from which to recall
+    /// * `creditor` - Account that credited the tokens
+    /// * `debitor`  - Account that received the credit
     /// * `amount`   - Amount of tokens to recall
     /// * `memo`     - Memo
     #[action]
-    fn recall(token_id: TID, from: AccountNumber, amount: Quantity, memo: Memo) {
+    fn recallShared(
+        token_id: TID,
+        creditor: AccountNumber,
+        debitor: AccountNumber,
+        amount: Quantity,
+        memo: Memo,
+    ) {
         unimplemented!()
     }
 


### PR DESCRIPTION
Awkwardness around `recall` as it was only able to recall from root balances, anyone could prevent their tokens from being recalled by simply storing them in either a sub balance or a shared balance. 