### PR TITLE
Fractals - update defacto scores

### DIFF
--- a/packages/user/Fractals/de-facto/src/lib.rs
+++ b/packages/user/Fractals/de-facto/src/lib.rs
@@ -1,16 +1,28 @@
 #[psibase::service(name = "fractals+2")]
 pub mod service {
     use psibase::{
-        services::auth_dyn::{self, policy::DynamicAuthPolicy},
+        services::{
+            auth_dyn::{self, policy::DynamicAuthPolicy},
+            fractals::constants::PPM,
+        },
         *,
     };
 
     #[action]
     fn get_scores(fractal: AccountNumber) -> Vec<(AccountNumber, u32)> {
-        ::fractals::tables::tables::FractalMemberTable::read()
+        let members: Vec<_> = ::fractals::tables::tables::FractalMemberTable::read()
             .get_index_pk()
-            .range((fractal, AccountNumber::new(0))..=(fractal, AccountNumber::new(u64::MAX)))
-            .map(|account| (account.account, 1))
+            .range((fractal, AccountNumber::MIN)..=(fractal, AccountNumber::MAX))
+            .collect();
+
+        if members.is_empty() {
+            return vec![];
+        }
+
+        let share = PPM / members.len() as u32;
+        members
+            .into_iter()
+            .map(|member| (member.account, share))
             .collect()
     }
 

--- a/rust/psibase/src/services/fractals/mod.rs
+++ b/rust/psibase/src/services/fractals/mod.rs
@@ -59,6 +59,7 @@ pub mod Occupation {
     /// Get scores for a fractal
     ///
     /// Returns a vector of accounts and their corresponding scores for a fractal.
+    /// Scores are PPM shares (parts per million) and must not sum to more than 1,000,000.
     /// These scores are used by the Fractals service to determine distribution amounts for each member.
     ///
     /// # Arguments


### PR DESCRIPTION
`get_scores` is expected to return peoples share of rewards in ppm, the failure to do so results in Fractals issuing tiny rewards and recycling the rest as dust. 