### PR TITLE
Fix min account name length bug

### DIFF
--- a/packages/user/Fractals/plugin/src/errors.rs
+++ b/packages/user/Fractals/plugin/src/errors.rs
@@ -5,6 +5,6 @@ pub enum ErrorType {
     QueryResponseParseError(String),
     #[error("Invalid account number")]
     InvalidAccountNumber,
-    #[error("Account name {0} invalid, must be at least 10 characters")]
-    AccountNameTooShort(String),
+    #[error("Account name {0} invalid, must be at least {1} characters")]
+    AccountNameTooShort(String, usize),
 }

--- a/packages/user/Fractals/plugin/src/helpers.rs
+++ b/packages/user/Fractals/plugin/src/helpers.rs
@@ -1,11 +1,9 @@
 use std::str::FromStr;
 
 use crate::errors::ErrorType::*;
+use psibase::services::accounts::MIN_ALLOWED_ACCOUNT_LENGTH;
 use psibase::AccountNumber;
 use psibase_plugin::{host::client as Client, Error};
-
-/// Free account names are 8-10 characters; shorter names must be purchased.
-pub const MIN_FREE_ACCOUNT_NAME_LENGTH: usize = 8;
 
 pub fn get_sender_app() -> Result<AccountNumber, Error> {
     let sender_string = Client::get_sender();
@@ -13,10 +11,9 @@ pub fn get_sender_app() -> Result<AccountNumber, Error> {
 }
 
 pub fn validate_account_name(account_name: &str) -> Result<(), Error> {
-    if account_name.len() < MIN_FREE_ACCOUNT_NAME_LENGTH {
-        return Err(
-            AccountNameTooShort(account_name.to_string(), MIN_FREE_ACCOUNT_NAME_LENGTH).into(),
-        );
+    let min_len: usize = MIN_ALLOWED_ACCOUNT_LENGTH.into();
+    if account_name.len() < min_len {
+        return Err(AccountNameTooShort(account_name.to_string(), min_len).into());
     }
     Ok(())
 }

--- a/packages/user/Fractals/plugin/src/helpers.rs
+++ b/packages/user/Fractals/plugin/src/helpers.rs
@@ -4,14 +4,19 @@ use crate::errors::ErrorType::*;
 use psibase::AccountNumber;
 use psibase_plugin::{host::client as Client, Error};
 
+/// Free account names are 8-10 characters; shorter names must be purchased.
+pub const MIN_FREE_ACCOUNT_NAME_LENGTH: usize = 8;
+
 pub fn get_sender_app() -> Result<AccountNumber, Error> {
     let sender_string = Client::get_sender();
     AccountNumber::from_str(&sender_string).map_err(|_| InvalidAccountNumber.into())
 }
 
 pub fn validate_account_name(account_name: &str) -> Result<(), Error> {
-    if account_name.len() < 10 {
-        return Err(AccountNameTooShort(account_name.to_string()).into());
+    if account_name.len() < MIN_FREE_ACCOUNT_NAME_LENGTH {
+        return Err(
+            AccountNameTooShort(account_name.to_string(), MIN_FREE_ACCOUNT_NAME_LENGTH).into(),
+        );
     }
     Ok(())
 }

--- a/packages/user/Fractals/ui/src/components/create-fractal-modal.tsx
+++ b/packages/user/Fractals/ui/src/components/create-fractal-modal.tsx
@@ -34,6 +34,7 @@ export const CreateFractalModal = ({
     const form = useAppForm({
         defaultValues: {
             fractalAccount: "",
+            guildAccount: "",
             mission: "",
             name: "",
         },

--- a/packages/user/Fractals/ui/src/hooks/fractals/use-create-fractal.ts
+++ b/packages/user/Fractals/ui/src/hooks/fractals/use-create-fractal.ts
@@ -5,15 +5,15 @@ import QueryKey from "@/lib/query-keys";
 
 import { FRACTALS_SERVICE } from "@shared/domains/fractal/lib/constants";
 import { queryClient } from "@shared/lib/query-client";
-import { zAccount } from "@shared/lib/schemas/account";
+import { zAccountFree } from "@shared/lib/schemas/account";
 import { supervisor } from "@shared/lib/supervisor";
 import { toast } from "@shared/shadcn/ui/sonner";
 
 import { zAccountNameStatus } from "../use-account-status";
 
 export const zParams = z.object({
-    fractalAccount: zAccount,
-    guildAccount: zAccount,
+    fractalAccount: zAccountFree,
+    guildAccount: zAccountFree,
     name: z.string().min(1, { message: "Name is required." }),
     mission: z.string().min(1, { message: "Mission is required." }),
 });


### PR DESCRIPTION
Fractals plugin would throw if the account name length was less than 10 instead of 8. 