### PR TITLE
Fix fractal token distribution and paid occupations

### DIFF
--- a/packages/user/FractalCore/plugin/src/lib.rs
+++ b/packages/user/FractalCore/plugin/src/lib.rs
@@ -50,6 +50,7 @@ define_trust! {
             - Creating a new guild
             - Mapping a governance role to a guild
             - Setting a role's occupation service
+            - Setting paid occupations for token distribution
             - Setting the guild evaluation schedule
             - Setting guild display name, bio, and description
             - Setting ranked guilds and rank ordering threshold
@@ -61,7 +62,7 @@ define_trust! {
         None => [get_group_users],
         Low => [close_eval, dist_token, start_eval],
         Medium => [apply_guild, claim_rewards, join_fractal, delete_guild_invite, invite_member, attest_membership_app, get_proposal, register, register_candidacy, unregister],
-        High => [attest, set_role_mapping, create_guild, set_role_occupation, exile_member, init_token, propose, remove_guild_rep, resign_guild_rep, set_bio, set_description, set_display_name, set_dist_interval, set_guild_rep, set_min_scorers, set_rank_ordering_threshold, set_ranked_guilds, set_schedule],
+        High => [attest, set_role_mapping, create_guild, set_role_occupation, set_paid_occupations, exile_member, init_token, propose, remove_guild_rep, resign_guild_rep, set_bio, set_description, set_display_name, set_dist_interval, set_guild_rep, set_min_scorers, set_rank_ordering_threshold, set_ranked_guilds, set_schedule],
     }
 }
 
@@ -101,6 +102,13 @@ impl AdminFractal for FractalCorePlugin {
         propose::fractal()?;
 
         FractalsPlugin::admin_fractal::set_role_occupation(role_id, &occupation)
+    }
+
+    fn set_paid_occupations(occupations: Vec<String>) -> Result<(), Error> {
+        assert_authorized(FunctionName::set_paid_occupations)?;
+        propose::fractal()?;
+
+        FractalsPlugin::admin_fractal::set_paid_occupations(occupations.as_slice())
     }
 
     fn init_token() -> Result<(), Error> {

--- a/packages/user/FractalCore/plugin/wit/world.wit
+++ b/packages/user/FractalCore/plugin/wit/world.wit
@@ -10,6 +10,7 @@ interface admin-fractal {
     set-ranked-guilds: func(guilds: list<string>) -> result<_, error>;
 
     set-role-occupation: func(role-id: u8, occupation: string) -> result<_, error>;
+    set-paid-occupations: func(occupations: list<string>) -> result<_, error>;
 
     set-role-mapping: func(role-id: u8, guild: string) -> result<_, error>;
 

--- a/packages/user/FractalCore/ui/src/lib/plugin.ts
+++ b/packages/user/FractalCore/ui/src/lib/plugin.ts
@@ -36,6 +36,10 @@ class AdminFractal extends PluginInterface {
         return this._call<[roleId: number, occupation: string]>("setRoleOccupation")
     }
 
+    get setPaidOccupations() {
+        return this._call<[occupations: string[]]>("setPaidOccupations");
+    }
+
 
 
     get migrateGuilds() {

--- a/packages/user/Fractals/plugin/src/lib.rs
+++ b/packages/user/Fractals/plugin/src/lib.rs
@@ -31,7 +31,10 @@ impl TrustConfig for FractallyPlugin {
                 "Creating a new fractal",
                 "Claiming accrued fractal token rewards",
             ],
-            high: &["Setting the occupation service for a fractal role"],
+            high: &[
+                "Setting the occupation service for a fractal role",
+                "Setting paid occupations for token distribution",
+            ],
         }
     }
 }
@@ -82,12 +85,25 @@ impl AdminFractal for FractallyPlugin {
         set_role_occ(Judiciary.into());
         set_role_occ(Executive.into());
         set_role_occ(Recruitment.into());
+
+        Fractals::add_to_tx().set_paid_occ(vec![account!("guilds")]);
         Ok(())
     }
 
     #[psibase_plugin::authorized(High)]
     fn set_role_occupation(role_id: u8, occupation: String) -> Result<(), Error> {
         Fractals::add_to_tx().set_r_occ(role_id, occupation.parse().unwrap());
+        Ok(())
+    }
+
+    #[psibase_plugin::authorized(High)]
+    fn set_paid_occupations(occupations: Vec<String>) -> Result<(), Error> {
+        Fractals::add_to_tx().set_paid_occ(
+            occupations
+                .into_iter()
+                .map(|occupation| occupation.parse().unwrap())
+                .collect(),
+        );
         Ok(())
     }
 

--- a/packages/user/Fractals/plugin/src/lib.rs
+++ b/packages/user/Fractals/plugin/src/lib.rs
@@ -5,7 +5,7 @@ use bindings::exports::fractals::plugin::admin_fractal::Guest as AdminFractal;
 use bindings::exports::fractals::plugin::queries::Guest as Queries;
 use bindings::exports::fractals::plugin::user_fractal::Guest as UserFractal;
 
-use psibase::account;
+use psibase::services::guilds::SERVICE as GUILDS_SERVICE;
 use psibase_plugin::{trust::*, *};
 
 use fractals::Wrapper as Fractals;
@@ -78,7 +78,7 @@ impl AdminFractal for FractallyPlugin {
         Guilds::admin_fractal::set_auto_join_fractal(true)?;
 
         let set_role_occ = |role_id: u8| {
-            Fractals::add_to_tx().set_r_occ(role_id, account!("guilds"));
+            Fractals::add_to_tx().set_r_occ(role_id, GUILDS_SERVICE);
         };
 
         set_role_occ(Legislature.into());
@@ -86,7 +86,7 @@ impl AdminFractal for FractallyPlugin {
         set_role_occ(Executive.into());
         set_role_occ(Recruitment.into());
 
-        Fractals::add_to_tx().set_paid_occ(vec![account!("guilds")]);
+        Fractals::add_to_tx().set_paid_occ(vec![GUILDS_SERVICE]);
         Ok(())
     }
 

--- a/packages/user/Fractals/plugin/wit/world.wit
+++ b/packages/user/Fractals/plugin/wit/world.wit
@@ -9,6 +9,7 @@ interface admin-fractal {
     init-token: func() -> result<_, error>;
 
     set-role-occupation: func(role-id: u8, occupation: string) -> result<_, error>;
+    set-paid-occupations: func(occupations: list<string>) -> result<_, error>;
 }
 
 

--- a/packages/user/Fractals/service/src/constants.rs
+++ b/packages/user/Fractals/service/src/constants.rs
@@ -22,3 +22,6 @@ pub const MAX_FRACTAL_DISTRIBUTION_INTERVAL_SECONDS: u32 = ONE_WEEK * 8;
 pub const DEFAULT_FRACTAL_DISTRIBUTION_INTERVAL: u32 = ONE_WEEK;
 pub const DEFAULT_MEMBER_DISTRIBUTION_INTERVAL: u32 = ONE_DAY;
 pub const DEFAULT_RECRUITMENT_PPM: u32 = 50_000; // 5%
+
+// Simple limitation + also related to fibonacci function limit.
+pub const MAX_PAID_OCCUPATIONS: u8 = 25;

--- a/packages/user/Fractals/service/src/tables/fractal.rs
+++ b/packages/user/Fractals/service/src/tables/fractal.rs
@@ -101,6 +101,8 @@ impl Fractal {
         create_role(executive, Executive);
         create_role(recruitment, Recruitment);
 
+        Occupation::set_ordered_occupations(fractal, vec![defacto_service]);
+
         create_managed_account(fractal, || {
             sites::Wrapper::call_as(fractal).setProxy(account!("fractal-cr"));
         });

--- a/packages/user/Fractals/service/src/tables/fractal_member.rs
+++ b/packages/user/Fractals/service/src/tables/fractal_member.rs
@@ -1,5 +1,3 @@
-use std::u64;
-
 use psibase::{AccountNumber, ServiceWrapper, Table};
 
 use crate::{
@@ -36,7 +34,7 @@ impl FractalMember {
     pub fn get_all(fractal: AccountNumber) -> Vec<Self> {
         FractalMemberTable::read()
             .get_index_pk()
-            .range(&(fractal, AccountNumber::from(0))..&(fractal, AccountNumber::from(u64::MAX)))
+            .range((fractal, AccountNumber::MIN)..=(fractal, AccountNumber::MAX))
             .collect()
     }
 

--- a/packages/user/Fractals/service/src/tables/occupation.rs
+++ b/packages/user/Fractals/service/src/tables/occupation.rs
@@ -3,6 +3,7 @@ use psibase::{
     AccountNumber, Table,
 };
 
+use crate::constants::MAX_PAID_OCCUPATIONS;
 use crate::tables::tables::{Occupation, OccupationTable};
 use psibase::services::fractals::weighted_normalization::HasScore;
 
@@ -39,7 +40,7 @@ impl Occupation {
         let occupations_length = new_occupations.len();
 
         assert!(
-            occupations_length <= u8::MAX as usize,
+            occupations_length <= MAX_PAID_OCCUPATIONS as usize,
             "too many occupations",
         );
 

--- a/packages/user/Fractals/service/src/tables/reward_stream.rs
+++ b/packages/user/Fractals/service/src/tables/reward_stream.rs
@@ -8,16 +8,19 @@ use crate::tables::tables::{Fractal, Levy, RewardStream, RewardStreamTable};
 use psibase::services::tokens::{Quantity, TID};
 use psibase::services::transact::Wrapper as TransactSvc;
 
+use psibase::services::nft::Wrapper as Nft;
 use psibase::services::token_stream::Wrapper as TokenStream;
 use psibase::services::tokens::Wrapper as Tokens;
 
 impl RewardStream {
     fn new(fractal: AccountNumber, owner: AccountNumber, token_id: TID, half_life: u32) -> Self {
         let now = TransactSvc::call().currentBlock().time.seconds();
+        let stream_id = TokenStream::call().create(half_life, token_id);
+        Nft::call().debit(stream_id, "Redeemer NFT of stream".into());
 
         Self {
             owner,
-            stream_id: TokenStream::call().create(half_life, token_id),
+            stream_id,
             last_distributed: now,
             fractal,
         }


### PR DESCRIPTION
- Debit TokenStream redeemer NFTs on stream create so `dist_token` and `claim_rew` can actually withdraw. 
- Default paid occupations on fractal create as we are still pushing new fractals directly into Guilds. 
- Cap 25 occupations, must be restricted somewhere given the fibbonaci function limitations. 