### PR TITLE
Tokens emit amount actually uncredited, not requested

### DIFF
--- a/packages/user/Tokens/service/src/lib.rs
+++ b/packages/user/Tokens/service/src/lib.rs
@@ -388,18 +388,7 @@ pub mod service {
     /// * `memo`     - Memo
     #[action]
     fn uncredit(token_id: TID, debitor: AccountNumber, amount: Quantity, memo: Memo) {
-        let creditor = get_sender();
-
-        SharedBalance::get_assert(creditor, debitor, token_id).uncredit(amount);
-
-        Wrapper::emit().history().balChanged(
-            token_id,
-            creditor,
-            debitor,
-            "uncredited".to_string(),
-            fmt_amount(token_id, amount),
-            memo,
-        );
+        SharedBalance::get_assert(get_sender(), debitor, token_id).uncredit(amount, memo);
     }
 
     /// Debit tokens that were credited into a shared balance

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -500,14 +500,25 @@ pub mod tables {
             }
         }
 
-        pub fn uncredit(&mut self, quantity: Quantity) {
+        pub fn uncredit(&mut self, quantity: Quantity, memo: Memo) {
             assert!(
                 quantity.value > 0,
                 "uncredit quantity must be greater than 0"
             );
             let quantity = quantity.min(self.balance);
+            if quantity.value == 0 {
+                return;
+            }
             self.sub_balance(quantity);
             Balance::get_or_new(self.creditor, self.token_id).add_balance(quantity);
+            crate::Wrapper::emit().history().balChanged(
+                self.token_id,
+                self.creditor,
+                self.debitor,
+                "uncredited".to_string(),
+                fmt_amount(self.token_id, quantity),
+                memo,
+            );
         }
 
         pub fn debit(&mut self, quantity: Quantity, memo: Memo) {


### PR DESCRIPTION
Previously the uncredit action emitted `balChanged` with the amount the caller **requested**. `SharedBalance::uncredit` only moves `min(requested, shared balance)`, so the event could report more than was actually returned.

Emit from the method after that clamp so the history amount matches the transfer. 
If the shared balance is already 0, return without emitting.