### PR TITLE
Simplify routing messages

### DIFF
--- a/libraries/net/include/psibase/shortest_path_routing.hpp
+++ b/libraries/net/include/psibase/shortest_path_routing.hpp
@@ -83,7 +83,7 @@ namespace psibase::net
       producer_id               producer;
       SequenceNumber            seqno;
       RouteMetric               metric;
-      std::optional<RouterId>   router;
+      RouterId                  router;
       std::string               to_string() const
       {
          return "route update: " + producer.str() + " seqno=" + std::to_string(seqno.value) +
@@ -495,7 +495,7 @@ namespace psibase::net
                 << "Ignoring route because " << msg.producer.str() << " is not an active producer";
             return;
          }
-         auto routeKey = RouteKey{msg.producer, msg.router.value_or(0), peer};
+         auto routeKey = RouteKey{msg.producer, msg.router, peer};
          auto iter     = routeTable.find(routeKey);
          if (iter == routeTable.end())
          {


### PR DESCRIPTION
The router field is only optional to preserve compatibility. We don't care about that yet, and it's always present so there's no reason for it to be optional.