### PR TITLE
csp(#2016): route tokens/namemarket/vserver UI reads via plugins

### DIFF
--- a/packages/shared-ui/hooks/use-billing-config.ts
+++ b/packages/shared-ui/hooks/use-billing-config.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { GraphQLUrlOptions, graphql } from "@shared/lib/graphql";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
 import QueryKey from "@shared/lib/query-keys";
+import { vserver } from "@shared/lib/plugins";
 
 interface BillingConfigResponse {
     getBillingConfig: {
@@ -10,7 +11,7 @@ interface BillingConfigResponse {
     } | null;
 }
 
-export const useBillingConfig = (options: GraphQLUrlOptions = {}) => {
+export const useBillingConfig = () => {
     return useQuery({
         queryKey: QueryKey.billingConfig(),
         queryFn: async () => {
@@ -22,10 +23,10 @@ export const useBillingConfig = (options: GraphQLUrlOptions = {}) => {
                     }
                 }
             `;
-            const res = await graphql<BillingConfigResponse>(query, {
-                service: "vserver",
-                ...options,
-            });
+            const res = await authorizedPluginGraphql<BillingConfigResponse>(
+                vserver.authorized.graphql,
+                query,
+            );
 
             if (!res.getBillingConfig) {
                 return { feeReceiver: null, enabled: false };

--- a/packages/shared-ui/hooks/use-system-token.ts
+++ b/packages/shared-ui/hooks/use-system-token.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { GraphQLUrlOptions, graphql } from "@shared/lib/graphql";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
 import QueryKey from "@shared/lib/query-keys";
+import { tokens } from "@shared/lib/plugins";
 
 export interface SystemTokenInfo {
     id: string;
@@ -26,7 +27,7 @@ interface TokenResponse {
     } | null;
 }
 
-export const useSystemToken = (opts: GraphQLUrlOptions = {}) => {
+export const useSystemToken = () => {
     return useQuery<SystemTokenInfo | null>({
         queryKey: QueryKey.systemToken(),
         queryFn: async (): Promise<SystemTokenInfo | null> => {
@@ -38,10 +39,10 @@ export const useSystemToken = (opts: GraphQLUrlOptions = {}) => {
                     }
                 `;
 
-            const configRes = await graphql<ConfigResponse>(configQuery, {
-                service: "tokens",
-                ...opts,
-            });
+            const configRes = await authorizedPluginGraphql<ConfigResponse>(
+                tokens.authorized.graphql,
+                configQuery,
+            );
 
             if (!configRes.config?.sysTid) {
                 return null;
@@ -58,10 +59,10 @@ export const useSystemToken = (opts: GraphQLUrlOptions = {}) => {
                     }
                 `;
 
-            const tokenRes = await graphql<TokenResponse>(tokenQuery, {
-                service: "tokens",
-                ...opts,
-            });
+            const tokenRes = await authorizedPluginGraphql<TokenResponse>(
+                tokens.authorized.graphql,
+                tokenQuery,
+            );
 
             if (!tokenRes.token) {
                 return null;

--- a/packages/shared-ui/lib/graphql/authorized-plugin.ts
+++ b/packages/shared-ui/lib/graphql/authorized-plugin.ts
@@ -1,0 +1,23 @@
+import {
+    type PluginCall,
+    callPluginFunction,
+} from "@shared/lib/plugins/lib/call-plugin-function";
+
+type AuthorizedGraphqlResponse<T> = {
+    data: T;
+    errors?: Array<{ message: string }>;
+};
+
+export async function authorizedPluginGraphql<T>(
+    call: PluginCall<[query: string], string>,
+    query: string,
+): Promise<T> {
+    const result = await callPluginFunction(call, [query]);
+    const response = JSON.parse(result) as AuthorizedGraphqlResponse<T>;
+    if (response.errors?.length) {
+        throw new Error(
+            response.errors[0]?.message ?? "GraphQL query failed",
+        );
+    }
+    return response.data;
+}

--- a/packages/shared-ui/lib/graphql/namemarket.ts
+++ b/packages/shared-ui/lib/graphql/namemarket.ts
@@ -1,4 +1,4 @@
-import { graphql } from "@shared/lib/graphql";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
 import { nameMarket } from "@shared/lib/plugins";
 import {
     type AccountMarketOverviewRow,
@@ -8,7 +8,8 @@ import {
 } from "@shared/lib/schemas/account-markets";
 
 export async function fetchCurrentPrices() {
-    const raw = await graphql(
+    const raw = await authorizedPluginGraphql(
+        nameMarket.authorized.graphql,
         `
             query {
                 currentPrices {
@@ -17,7 +18,6 @@ export async function fetchCurrentPrices() {
                 }
             }
         `,
-        { service: nameMarket.service },
     );
 
     const { currentPrices } = zCurrentPricesData.parse(raw);
@@ -32,7 +32,8 @@ export const fetchCurrentPriceForLength = async (length: number) => {
 export async function fetchAccountMarketsOverview(): Promise<
     AccountMarketOverviewRow[]
 > {
-    const raw = await graphql(
+    const raw = await authorizedPluginGraphql(
+        nameMarket.authorized.graphql,
         `
             query {
                 marketParams {
@@ -45,7 +46,6 @@ export async function fetchAccountMarketsOverview(): Promise<
                 }
             }
         `,
-        { service: nameMarket.service },
     );
 
     const { marketParams, currentPrices } =

--- a/packages/shared-ui/lib/graphql/tokens.ts
+++ b/packages/shared-ui/lib/graphql/tokens.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-import { callPluginFunction, tokens } from "@shared/lib/plugins";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
+import { tokens } from "@shared/lib/plugins";
 import { zAccount } from "@shared/lib/schemas/account";
 
 const userTokenBalancesQuery = (username: string) => `
@@ -31,26 +32,12 @@ const zUserTokenBalanceSchema = z.object({
 
 export type UserTokenBalanceNode = z.infer<typeof zUserTokenBalanceNodeSchema>;
 
-type AuthorizedGraphqlResponse<T> = {
-    data: T;
-    errors?: Array<{ message: string }>;
-};
-
-function parseAuthorizedGraphqlResponse<T>(result: string): T {
-    const response = JSON.parse(result) as AuthorizedGraphqlResponse<T>;
-    if (response.errors?.length) {
-        throw new Error(response.errors[0].message);
-    }
-    return response.data;
-}
-
 export const fetchUserTokenBalances = async (username: string) => {
     const parsedUsername = zAccount.parse(username);
     const query = `{${userTokenBalancesQuery(parsedUsername)}}`;
-    const result = await callPluginFunction(tokens.authorized.graphql, [query]);
-    const data = parseAuthorizedGraphqlResponse<
+    const data = await authorizedPluginGraphql<
         z.infer<typeof zUserTokenBalanceSchema>
-    >(result);
+    >(tokens.authorized.graphql, query);
     const parsed = zUserTokenBalanceSchema.parse(data);
     return parsed.userBalances.nodes;
 };

--- a/packages/shared-ui/lib/plugins/index.ts
+++ b/packages/shared-ui/lib/plugins/index.ts
@@ -10,6 +10,7 @@ import { Plugin as Packages } from "./packages";
 import { Plugin as Profiles } from "./profiles";
 import { Plugin as TokenSwap } from "./token-swap";
 import { Plugin as Tokens } from "./tokens";
+import { Plugin as VirtualServer } from "./vserver";
 
 const accounts = new Accounts("accounts");
 const config = new Config("config");
@@ -19,6 +20,7 @@ const nameMarket = new NameMarket("namemarket");
 const tokenSwap = new TokenSwap("token-swap");
 const tokens = new Tokens("tokens");
 const profiles = new Profiles("profiles");
+const vserver = new VirtualServer("vserver");
 
 export {
     accounts,
@@ -29,6 +31,7 @@ export {
     tokenSwap,
     tokens,
     profiles,
+    vserver,
     callPluginFunction,
     usePluginFunctionMutation,
     usePluginFunctionQuery,

--- a/packages/shared-ui/lib/plugins/vserver.ts
+++ b/packages/shared-ui/lib/plugins/vserver.ts
@@ -1,0 +1,19 @@
+import { PluginInterface } from "@shared/hooks/plugin-function";
+import { Account } from "@shared/lib/schemas/account";
+
+class Authorized extends PluginInterface {
+    protected override readonly _intf = "authorized" as const;
+
+    get graphql() {
+        return this._call<[query: string], string>("graphql");
+    }
+}
+
+export class Plugin {
+    readonly authorized: Authorized;
+
+    constructor(readonly service: Account) {
+        this.authorized = new Authorized();
+        Object.assign(this.authorized, { _service: service });
+    }
+}

--- a/packages/user/Config/postinstall.json
+++ b/packages/user/Config/postinstall.json
@@ -11,7 +11,7 @@
     "method": "setcsp",
     "data": {
       "path": "*",
-      "csp": "default-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: profiles.{{root}}/avatar/ branding.{{root}};font-src 'self';connect-src 'self' producers.{{root}} sites.{{root}} staged-tx.{{root}} transact.{{root}} vserver.{{root}} tokens.{{root}} profiles.{{root}} x-admin.{{root}} packages.{{root}} namemarket.{{root}} http: https:;frame-src supervisor.{{root}};frame-ancestors 'self';base-uri 'none';form-action 'self';object-src 'none';"
+      "csp": "default-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: profiles.{{root}}/avatar/ branding.{{root}};font-src 'self';connect-src 'self' producers.{{root}} sites.{{root}} staged-tx.{{root}} transact.{{root}} profiles.{{root}} x-admin.{{root}} packages.{{root}} http: https:;frame-src supervisor.{{root}};frame-ancestors 'self';base-uri 'none';form-action 'self';object-src 'none';"
     }
   }
 ]

--- a/packages/user/Config/ui/src/hooks/name-markets/use-configured-markets.ts
+++ b/packages/user/Config/ui/src/hooks/name-markets/use-configured-markets.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
-import { graphql } from "@shared/lib/graphql";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
 import { nameMarket } from "@shared/lib/plugins";
 import {
     MAX_ACCOUNT_NAME_LENGTH,
@@ -49,7 +49,10 @@ export const useConfiguredNameMarkets = () =>
                     }
                 }
             `;
-            const raw = await graphql(query, { service: nameMarket.service });
+            const raw = await authorizedPluginGraphql(
+                nameMarket.authorized.graphql,
+                query,
+            );
             const parsed = zData.parse(raw);
             return parsed.marketParams;
         },

--- a/packages/user/Config/ui/src/hooks/use-resource-pricing.ts
+++ b/packages/user/Config/ui/src/hooks/use-resource-pricing.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 
 import QueryKey from "@/lib/query-keys";
 
-import { graphql } from "@shared/lib/graphql";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
+import { vserver } from "@shared/lib/plugins";
 
 const zThresholds = z.object({
     idlePct: z.string(),
@@ -70,7 +71,10 @@ export const useResourcePricing = () => {
                 }
             `;
 
-            const res = await graphql(query, { service: "vserver" });
+            const res = await authorizedPluginGraphql(
+                vserver.authorized.graphql,
+                query,
+            );
             const parsed = zPricingResponse.parse(res);
 
             if (!parsed.cpuPricing) {

--- a/packages/user/Config/ui/src/hooks/use-virtual-server-resources.ts
+++ b/packages/user/Config/ui/src/hooks/use-virtual-server-resources.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 
 import QueryKey from "@/lib/query-keys";
 
-import { graphql } from "@shared/lib/graphql";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
+import { vserver } from "@shared/lib/plugins";
 
 // import { CpuPricing, NetPricing } from "./use-resource-pricing";
 
@@ -77,7 +78,10 @@ export const useVirtualServerResources = () => {
                 }
             `;
 
-            const res = await graphql(query, { service: "vserver" });
+            const res = await authorizedPluginGraphql(
+                vserver.authorized.graphql,
+                query,
+            );
             const parsed = zResourcesResponse.parse(res);
             return {
                 serverSpecs: parsed.getServerSpecs,

--- a/packages/user/Explorer/postinstall.json
+++ b/packages/user/Explorer/postinstall.json
@@ -5,7 +5,7 @@
     "method": "setcsp",
     "data": {
       "path": "*",
-      "csp": "default-src 'self';script-src 'self' 'unsafe-inline';style-src 'self' 'unsafe-inline';img-src 'self' data: profiles.{{root}}/avatar/ branding.{{root}};font-src 'self';connect-src 'self' tokens.{{root}};frame-src supervisor.{{root}};frame-ancestors 'self';base-uri 'none';form-action 'self';object-src 'none';"
+      "csp": "default-src 'self';script-src 'self' 'unsafe-inline';style-src 'self' 'unsafe-inline';img-src 'self' data: profiles.{{root}}/avatar/ branding.{{root}};font-src 'self';connect-src 'self';frame-src supervisor.{{root}};frame-ancestors 'self';base-uri 'none';form-action 'self';object-src 'none';"
     }
   }
 ]

--- a/packages/user/Homepage/postinstall.json
+++ b/packages/user/Homepage/postinstall.json
@@ -13,7 +13,7 @@
         "method": "setcsp",
         "data": {
             "path": "*",
-            "csp": "default-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: profiles.{{root}}/avatar/ branding.{{root}};font-src 'self';connect-src 'self' invite.{{root}} tokens.{{root}} token-swap.{{root}} vserver.{{root}} producers.{{root}} profiles.{{root}} namemarket.{{root}};frame-src supervisor.{{root}};frame-ancestors 'self';base-uri 'none';form-action 'self';object-src 'none';"
+            "csp": "default-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: profiles.{{root}}/avatar/ branding.{{root}};font-src 'self';connect-src 'self' invite.{{root}} token-swap.{{root}} producers.{{root}} profiles.{{root}};frame-src supervisor.{{root}};frame-ancestors 'self';base-uri 'none';form-action 'self';object-src 'none';"
         }
     },
     {

--- a/packages/user/Homepage/ui/src/apps/accounts-marketplace/lib/graphql/namemarket-api.ts
+++ b/packages/user/Homepage/ui/src/apps/accounts-marketplace/lib/graphql/namemarket-api.ts
@@ -1,4 +1,5 @@
-import { callPluginFunction, nameMarket } from "@shared/lib/plugins";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
+import { nameMarket } from "@shared/lib/plugins";
 
 import {
     zNameEvent,
@@ -18,20 +19,7 @@ export type FetchNameEventsPageParams =
     | { last: number; before?: string };
 
 async function nameMarketAuthorizedGraphql<T>(query: string): Promise<T> {
-    const result = await callPluginFunction(nameMarket.authorized.graphql, [
-        query,
-    ]);
-
-    const response = JSON.parse(result) as {
-        data: T;
-        errors?: Array<{ message: string }>;
-    };
-
-    if (response.errors?.length) {
-        throw new Error(response.errors[0]?.message ?? "GraphQL query failed");
-    }
-
-    return response.data;
+    return authorizedPluginGraphql(nameMarket.authorized.graphql, query);
 }
 
 function mapNameEventEdges(edges: Array<{ cursor?: string; node?: unknown }>) {

--- a/packages/user/Homepage/ui/src/apps/token-swap/hooks/use-token.ts
+++ b/packages/user/Homepage/ui/src/apps/token-swap/hooks/use-token.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 
 import QueryKey from "@/lib/query-keys";
 
-import { graphql } from "@shared/lib/graphql";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
+import { tokens } from "@shared/lib/plugins";
 import { zAccount } from "@shared/lib/schemas/account";
 
 export const zToken = z.object({
@@ -12,7 +13,8 @@ export const zToken = z.object({
 });
 
 export const getToken = async (tokenId: number) => {
-    const token = await graphql(
+    const token = await authorizedPluginGraphql(
+        tokens.authorized.graphql,
         `
             {
                 token(tokenId: "${tokenId}") {
@@ -21,9 +23,6 @@ export const getToken = async (tokenId: number) => {
                 }
             }
         `,
-        {
-            service: "tokens",
-        },
     );
 
     const response = z

--- a/packages/user/Homepage/ui/src/apps/tokens/lib/graphql/ui.ts
+++ b/packages/user/Homepage/ui/src/apps/tokens/lib/graphql/ui.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-import { graphql } from "@shared/lib/graphql";
-import { callPluginFunction, tokens } from "@shared/lib/plugins";
+import { authorizedPluginGraphql } from "@shared/lib/graphql/authorized-plugin";
+import { tokens } from "@shared/lib/plugins";
 import { zAccount } from "@shared/lib/schemas/account";
 
 const qs = {
@@ -51,18 +51,6 @@ const qs = {
     `,
 };
 
-const graphqlViaPlugin = async <T>(query: string): Promise<T> => {
-    const result = await callPluginFunction(tokens.authorized.graphql, [query]);
-    const response = JSON.parse(result) as {
-        data: T;
-        errors?: Array<{ message: string }>;
-    };
-    if (response.errors?.length) {
-        throw new Error(response.errors[0].message);
-    }
-    return response.data;
-};
-
 const zUserSettingsSchema = z.object({
     userSettings: z.object({
         settings: z.object({
@@ -73,9 +61,9 @@ const zUserSettingsSchema = z.object({
 
 export const fetchUserSettings = async (username: string) => {
     const query = `{${qs.userSettings(username)}}`;
-    const res = await graphql<z.infer<typeof zUserSettingsSchema>>(query, {
-        service: "tokens",
-    });
+    const res = await authorizedPluginGraphql<
+        z.infer<typeof zUserSettingsSchema>
+    >(tokens.authorized.graphql, query);
     const parsed = zUserSettingsSchema.parse(res);
     return parsed.userSettings.settings;
 };
@@ -102,9 +90,9 @@ export type TokenMetaNode = z.infer<typeof zTokenMetaNodeSchema>;
 
 export const fetchTokenMeta = async (tokenId: string) => {
     const query = `{${qs.tokenMeta(tokenId)}}`;
-    const res = await graphql<z.infer<typeof zTokenMetaSchema>>(query, {
-        service: "tokens",
-    });
+    const res = await authorizedPluginGraphql<
+        z.infer<typeof zTokenMetaSchema>
+    >(tokens.authorized.graphql, query);
     const parsed = zTokenMetaSchema.parse(res);
     return parsed.token;
 };
@@ -135,8 +123,9 @@ export const fetchUserTokenBalanceChanges = async (
     tokenId: number,
 ) => {
     const query = `{${qs.userTokenBalanceChanges(username, tokenId)}}`;
-    const res =
-        await graphqlViaPlugin<z.infer<typeof zBalChangeResSchema>>(query);
+    const res = await authorizedPluginGraphql<
+        z.infer<typeof zBalChangeResSchema>
+    >(tokens.authorized.graphql, query);
     const parsed = zBalChangeResSchema.parse(res);
     return parsed.balChanges.nodes;
 };
@@ -177,10 +166,9 @@ export const fetchOpenLinesOfCredit = async (
         ${qs.userPending(username, tokenId)}
     }`;
 
-    const res =
-        await graphqlViaPlugin<z.infer<typeof zOpenLinesOfCreditResSchema>>(
-            query,
-        );
+    const res = await authorizedPluginGraphql<
+        z.infer<typeof zOpenLinesOfCreditResSchema>
+    >(tokens.authorized.graphql, query);
     return zOpenLinesOfCreditResSchema
         .parse(res)
         .userPending.nodes.map((node: PendingBalanceNode) => node.sharedBal);

--- a/packages/user/Tokens/plugin/src/lib.rs
+++ b/packages/user/Tokens/plugin/src/lib.rs
@@ -203,7 +203,7 @@ impl Admin for TokensPlugin {
 }
 
 impl Authorized for TokensPlugin {
-    #[psibase_plugin::authorized(High, whitelist = ["homepage", "accounts"])]
+    #[psibase_plugin::authorized(High, whitelist = ["homepage", "accounts", "config"])]
     fn graphql(query: String) -> Result<String, Error> {
         host::server::post_graphql_get_json(&query)
     }


### PR DESCRIPTION
## Summary
- First PR in a 3-part stack for [#2016](https://github.com/gofractally/psibase/issues/2016): migrate UI GraphQL that already has plugin `authorized::graphql` APIs (`tokens`, `namemarket`, `vserver`) off direct sibling `fetch`.
- Add shared `authorizedPluginGraphql` helper + `vserver` plugin client; point Homepage/Config/shared-ui call sites at those APIs.
- Trim `connect-src` for those services on Homepage/Config; drop Explorer’s unnecessary `tokens` connect-src (keeps `unsafe-inline` for scripts).
- One-line plugin tweak: whitelist `config` on `tokens:plugin/authorized::graphql` so Config can use the shared system-token hook.

## Follow-ups
- PR2: add query surfaces on the ~11 plugins that still need them (invite, token-swap, producers, guilds, …).
- PR3: Config packages/`x-admin`/`http:`/`https:` special case.

## Test plan
- [ ] Boot chain with updated packages; confirm Homepage loads settings (billing + system token) without CSP console errors for `tokens`/`vserver`/`namemarket`
- [ ] Config resources + billing + name markets pages load without those connect-src errors
- [ ] Homepage tokens balances / pending / history still work via `tokens:plugin/authorized`
- [ ] Accounts create prompt still resolves system token
- [ ] Explorer still loads (inline scripts) with tightened connect-src