### PR TITLE
Increase timeout in routing tests

### DIFF
--- a/programs/psinode/tests/test_routing.py
+++ b/programs/psinode/tests/test_routing.py
@@ -64,7 +64,7 @@ class TestRouting(unittest.TestCase):
         # Each node is a adjacent to two others. With 7 nodes, consensus
         # requires 4 nodes, so this test will time out if messages are not routed
         (a, b, c, d, e, f, g) = cluster.ring('a', 'b', 'c', 'd', 'e', 'f', 'g')
-        testutil.boot_with_producers([a, b, c, d, e, f, g, 'h', 'i', 'j', 'k', 'l', 'm'], packages=['Minimal', 'Explorer'])
+        testutil.boot_with_producers([a, b, c, d, e, f, g, 'h', 'i', 'j', 'k', 'l', 'm'], packages=['Minimal', 'Explorer'], timeout=15)
 
         # wait for irreversibility to advance
         a.wait(new_block())
@@ -124,7 +124,7 @@ class TestRouting(unittest.TestCase):
     @testutil.psinode_test
     def test_bft_min_nodes(self, cluster):
         (a, b, c, d, e, f, g) = cluster.ring('a', 'b', 'c', 'd', 'e', 'f', 'g')
-        testutil.boot_with_producers([a, b, c, d, e, f, g, 'h', 'i', 'j'], 'bft', packages=['Minimal', 'Explorer'])
+        testutil.boot_with_producers([a, b, c, d, e, f, g, 'h', 'i', 'j'], 'bft', packages=['Minimal', 'Explorer'], timeout=15)
 
         # wait for irreversibility to advance
         a.wait(new_block())


### PR DESCRIPTION
With a debug build added to the fact that these tests have a lot of producers and no fault tolerance, they can take a bit longer to get started.