### PR TITLE
Fix psibase on new CI image

### DIFF
--- a/packages/.pnp.cjs
+++ b/packages/.pnp.cjs
@@ -2158,7 +2158,7 @@ const RAW_RUNTIME_STATE =
           ["@rushstack/ts-command-line", "npm:5.3.10"],\
           ["diff", "npm:8.0.4"],\
           ["minimatch", "npm:10.2.3"],\
-          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"],\
+          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"],\
           ["semver", "npm:7.7.4"],\
           ["source-map", "npm:0.6.1"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
@@ -2195,7 +2195,7 @@ const RAW_RUNTIME_STATE =
           ["@microsoft/tsdoc-config", "npm:0.18.1"],\
           ["ajv", "npm:8.18.0"],\
           ["jju", "npm:1.4.0"],\
-          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"]\
+          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -5993,7 +5993,7 @@ const RAW_RUNTIME_STATE =
           ["fs-extra", "npm:11.3.5"],\
           ["import-lazy", "npm:4.0.0"],\
           ["jju", "npm:1.4.0"],\
-          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"],\
+          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"],\
           ["semver", "npm:7.7.4"]\
         ],\
         "packagePeers": [\
@@ -6028,7 +6028,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@rushstack/rig-package", "npm:0.7.3"],\
           ["jju", "npm:1.4.0"],\
-          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"]\
+          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -8521,10 +8521,23 @@ const RAW_RUNTIME_STATE =
       ["npm:2.4.28", {\
         "packageLocation": "../.caches/yarn/@volar-typescript-npm-2.4.28-0b79b39aaa-075c890b9e.zip/node_modules/@volar/typescript/",\
         "packageDependencies": [\
+          ["@volar/typescript", "npm:2.4.28"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:40b8c9cc0016c823d95ee1398a08d7c4cc0a5763094fe497a86a3b949e450ffd8cb510cca602d5e805546d1f7f6692d4ad865a425baa81eb49dd72721e6a2bc1#npm:2.4.28", {\
+        "packageLocation": "./.yarn/__virtual__/@volar-typescript-virtual-47a1c0b0d4/2/.caches/yarn/@volar-typescript-npm-2.4.28-0b79b39aaa-075c890b9e.zip/node_modules/@volar/typescript/",\
+        "packageDependencies": [\
+          ["@types/typescript", null],\
           ["@volar/language-core", "npm:2.4.28"],\
-          ["@volar/typescript", "npm:2.4.28"],\
+          ["@volar/typescript", "virtual:40b8c9cc0016c823d95ee1398a08d7c4cc0a5763094fe497a86a3b949e450ffd8cb510cca602d5e805546d1f7f6692d4ad865a425baa81eb49dd72721e6a2bc1#npm:2.4.28"],\
           ["path-browserify", "npm:1.0.1"],\
+          ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
           ["vscode-uri", "npm:3.1.0"]\
+        ],\
+        "packagePeers": [\
+          "@types/typescript",\
+          "typescript"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -11251,7 +11264,7 @@ const RAW_RUNTIME_STATE =
           ["debug", "virtual:6222a0508ef2c103024170ee3be03c9c728dff2c8e115217d5ea37bc4e62e9204a2675e296dba444b3b9f309e70e3e1fbeb3ef177862ab12d9b84dda1becc476#npm:3.2.7"],\
           ["eslint-import-resolver-node", "npm:0.3.10"],\
           ["is-core-module", "npm:2.16.2"],\
-          ["resolve", "patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=c3c19d"]\
+          ["resolve", "patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=9bd1a5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -14713,7 +14726,7 @@ const RAW_RUNTIME_STATE =
           ["postcss-import", "virtual:413012276f6163a51df090be5a956a421a802740bc70e111322dff62c659f4c0f4848f59c7bdabe1bbe58669e14430e54403ab8d289083fb590db38cd4e73250#npm:15.1.0"],\
           ["postcss-value-parser", "npm:4.2.0"],\
           ["read-cache", "npm:1.0.0"],\
-          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"]\
+          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"]\
         ],\
         "packagePeers": [\
           "@types/postcss",\
@@ -14729,7 +14742,7 @@ const RAW_RUNTIME_STATE =
           ["postcss-import", "virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:16.1.1"],\
           ["postcss-value-parser", "npm:4.2.0"],\
           ["read-cache", "npm:1.0.0"],\
-          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"]\
+          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"]\
         ],\
         "packagePeers": [\
           "@types/postcss",\
@@ -16051,26 +16064,26 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["resolve", [\
-      ["patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d", {\
-        "packageLocation": "../.caches/yarn/resolve-patch-2234730f98-fc6519984a.zip/node_modules/resolve/",\
+      ["patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5", {\
+        "packageLocation": "../.caches/yarn/resolve-patch-46fcdcd77a-e12af106e1.zip/node_modules/resolve/",\
         "packageDependencies": [\
           ["es-errors", "npm:1.3.0"],\
           ["is-core-module", "npm:2.16.2"],\
           ["path-parse", "npm:1.0.7"],\
-          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"],\
+          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"],\
           ["supports-preserve-symlinks-flag", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
       }],\
-      ["patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=c3c19d", {\
-        "packageLocation": "../.caches/yarn/resolve-patch-6da7209cef-6bb6f1d8a1.zip/node_modules/resolve/",\
+      ["patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=9bd1a5", {\
+        "packageLocation": "../.caches/yarn/resolve-patch-21866f7849-911e8321c6.zip/node_modules/resolve/",\
         "packageDependencies": [\
           ["es-errors", "npm:1.3.0"],\
           ["is-core-module", "npm:2.16.2"],\
           ["node-exports-info", "npm:1.6.0"],\
           ["object-keys", "npm:1.1.1"],\
           ["path-parse", "npm:1.0.7"],\
-          ["resolve", "patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=c3c19d"],\
+          ["resolve", "patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=9bd1a5"],\
           ["supports-preserve-symlinks-flag", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
@@ -17149,7 +17162,7 @@ const RAW_RUNTIME_STATE =
           ["postcss-load-config", "virtual:413012276f6163a51df090be5a956a421a802740bc70e111322dff62c659f4c0f4848f59c7bdabe1bbe58669e14430e54403ab8d289083fb590db38cd4e73250#npm:6.0.1"],\
           ["postcss-nested", "virtual:413012276f6163a51df090be5a956a421a802740bc70e111322dff62c659f4c0f4848f59c7bdabe1bbe58669e14430e54403ab8d289083fb590db38cd4e73250#npm:6.2.0"],\
           ["postcss-selector-parser", "npm:6.1.4"],\
-          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"],\
+          ["resolve", "patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"],\
           ["sucrase", "npm:3.35.1"],\
           ["tailwindcss", "npm:3.4.19"]\
         ],\
@@ -18092,7 +18105,7 @@ const RAW_RUNTIME_STATE =
           ["@rollup/pluginutils", "virtual:40b8c9cc0016c823d95ee1398a08d7c4cc0a5763094fe497a86a3b949e450ffd8cb510cca602d5e805546d1f7f6692d4ad865a425baa81eb49dd72721e6a2bc1#npm:5.4.0"],\
           ["@types/typescript", null],\
           ["@types/vite", null],\
-          ["@volar/typescript", "npm:2.4.28"],\
+          ["@volar/typescript", "virtual:40b8c9cc0016c823d95ee1398a08d7c4cc0a5763094fe497a86a3b949e450ffd8cb510cca602d5e805546d1f7f6692d4ad865a425baa81eb49dd72721e6a2bc1#npm:2.4.28"],\
           ["@vue/language-core", "virtual:40b8c9cc0016c823d95ee1398a08d7c4cc0a5763094fe497a86a3b949e450ffd8cb510cca602d5e805546d1f7f6692d4ad865a425baa81eb49dd72721e6a2bc1#npm:2.2.0"],\
           ["compare-versions", "npm:6.1.1"],\
           ["debug", "virtual:428f325a939c2653ad822eb3d75efb02ac311523dd0d4f9645afc39ea00bd86eceac35a9d59c9b6977d76b670a4ef0ae057ea572338a44729aa592711a8c05a3#npm:4.4.3"],\
@@ -18846,16 +18859,16 @@ function convertToBigIntStats(stats) {
     if (Object.hasOwn(stats, key)) {
       const element = stats[key];
       if (typeof element === `number`) {
-        bigintStats[key] = BigInt(element);
+        bigintStats[key] = BigInt(Math.floor(element));
       } else if (nodeUtils__namespace.types.isDate(element)) {
         bigintStats[key] = new Date(element);
       }
     }
   }
-  bigintStats.atimeNs = bigintStats.atimeMs * BigInt(1e6);
-  bigintStats.mtimeNs = bigintStats.mtimeMs * BigInt(1e6);
-  bigintStats.ctimeNs = bigintStats.ctimeMs * BigInt(1e6);
-  bigintStats.birthtimeNs = bigintStats.birthtimeMs * BigInt(1e6);
+  bigintStats.atimeNs = bigintStats.atimeMs * BigInt(1e6) + BigInt(Math.floor(stats.atimeMs % 1 * 1e3)) * BigInt(1e3);
+  bigintStats.mtimeNs = bigintStats.mtimeMs * BigInt(1e6) + BigInt(Math.floor(stats.mtimeMs % 1 * 1e3)) * BigInt(1e3);
+  bigintStats.ctimeNs = bigintStats.ctimeMs * BigInt(1e6) + BigInt(Math.floor(stats.ctimeMs % 1 * 1e3)) * BigInt(1e3);
+  bigintStats.birthtimeNs = bigintStats.birthtimeMs * BigInt(1e6) + BigInt(Math.floor(stats.birthtimeMs % 1 * 1e3)) * BigInt(1e3);
   return bigintStats;
 }
 function areStatsEqual(a, b) {
@@ -21533,28 +21546,40 @@ class FileHandle {
   sync() {
     throw new Error(`Method not implemented.`);
   }
-  async read(bufferOrOptions, offset, length, position) {
+  async read(bufferOrOptions, offsetOrOptions, length, position) {
     try {
       this[kRef](this.read);
       let buffer;
-      if (!Buffer.isBuffer(bufferOrOptions)) {
-        bufferOrOptions ??= {};
-        buffer = bufferOrOptions.buffer ?? Buffer.alloc(16384);
-        offset = bufferOrOptions.offset || 0;
-        length = bufferOrOptions.length ?? buffer.byteLength;
-        position = bufferOrOptions.position ?? null;
+      let offset;
+      if (!ArrayBuffer.isView(bufferOrOptions)) {
+        buffer = bufferOrOptions?.buffer ?? Buffer.alloc(16384);
+        offset = bufferOrOptions?.offset ?? 0;
+        length = bufferOrOptions?.length ?? buffer.byteLength - offset;
+        position = bufferOrOptions?.position ?? null;
+      } else if (typeof offsetOrOptions === `object` && offsetOrOptions !== null) {
+        buffer = bufferOrOptions;
+        offset = offsetOrOptions?.offset ?? 0;
+        length = offsetOrOptions?.length ?? buffer.byteLength - offset;
+        position = offsetOrOptions?.position ?? null;
       } else {
         buffer = bufferOrOptions;
+        offset = offsetOrOptions ?? 0;
+        length ??= 0;
       }
-      offset ??= 0;
-      length ??= 0;
       if (length === 0) {
         return {
           bytesRead: length,
           buffer
         };
       }
-      const bytesRead = await this[kBaseFs].readPromise(this.fd, buffer, offset, length, position);
+      const bytesRead = await this[kBaseFs].readPromise(
+        this.fd,
+        // FIXME: FakeFS should support ArrayBufferViews directly
+        Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength),
+        offset,
+        length,
+        position
+      );
       return {
         bytesRead,
         buffer
@@ -23949,7 +23974,8 @@ class ZipFS extends BasePortableFakeFS {
         const entries = Array.from(directoryListing, (name) => {
           return Object.assign(this.statImpl(`lstat`, ppath.join(p, name)), {
             name,
-            path: PortablePath.dot
+            path: PortablePath.dot,
+            parentPath: PortablePath.dot
           });
         });
         for (const entry of entries) {
@@ -23960,7 +23986,8 @@ class ZipFS extends BasePortableFakeFS {
           for (const child of subListing) {
             entries.push(Object.assign(this.statImpl(`lstat`, ppath.join(p, subPath, child)), {
               name: child,
-              path: subPath
+              path: subPath,
+              parentPath: subPath
             }));
           }
         }
@@ -23981,7 +24008,8 @@ class ZipFS extends BasePortableFakeFS {
       return Array.from(directoryListing, (name) => {
         return Object.assign(this.statImpl(`lstat`, ppath.join(p, name)), {
           name,
-          path: void 0
+          path: void 0,
+          parentPath: void 0
         });
       });
     } else {
@@ -24328,7 +24356,7 @@ function getPathForDisplay(p) {
   return npath.normalize(npath.fromPortablePath(p));
 }
 
-const [major, minor] = process.versions.node.split(`.`).map((value) => parseInt(value, 10));
+const [major, minor, patch] = process.versions.node.split(`.`).map((value) => parseInt(value, 10));
 const WATCH_MODE_MESSAGE_USES_ARRAYS = major > 19 || major === 19 && minor >= 2 || major === 18 && minor >= 13;
 
 function readPackageScope(checkPath) {
@@ -24363,9 +24391,9 @@ Instead change the require of ${basename} in ${parentPath} to a dynamic import()
   err.code = `ERR_REQUIRE_ESM`;
   return err;
 }
-function reportRequiredFilesToWatchMode(files) {
+function reportRequiredFilesToWatchMode(paths) {
   if (process.env.WATCH_REPORT_DEPENDENCIES && process.send) {
-    files = files.map((filename) => npath.fromPortablePath(VirtualFS.resolveVirtual(npath.toPortablePath(filename))));
+    const files = paths.map((filename) => npath.fromPortablePath(VirtualFS.resolveVirtual(filename)));
     if (WATCH_MODE_MESSAGE_USES_ARRAYS) {
       process.send({ "watch:require": files });
     } else {
@@ -24456,6 +24484,7 @@ function applyPatch(pnpapi, opts) {
       const optionNames = new Set(Object.keys(options));
       optionNames.delete(`paths`);
       optionNames.delete(`plugnplay`);
+      optionNames.delete(`conditions`);
       if (optionNames.size > 0) {
         throw makeError(
           ErrorCode.UNSUPPORTED,
@@ -24484,11 +24513,15 @@ function applyPatch(pnpapi, opts) {
       const issuerApi = apiPath !== null ? opts.manager.getApiEntry(apiPath, true).instance : null;
       try {
         if (issuerApi !== null) {
-          resolution = issuerApi.resolveRequest(request, path !== null ? `${path}/` : null);
+          resolution = issuerApi.resolveRequest(request, path !== null ? `${path}/` : null, {
+            conditions: options?.conditions
+          });
         } else {
           if (path === null)
             throw new Error(`Assertion failed: Expected the path to be set`);
-          resolution = originalModuleResolveFilename.call(require$$0.Module, request, module || makeFakeParent(path), isMain);
+          resolution = originalModuleResolveFilename.call(require$$0.Module, request, module || makeFakeParent(path), isMain, {
+            conditions: options?.conditions
+          });
         }
       } catch (error) {
         firstError = firstError || error;
@@ -26003,9 +26036,10 @@ Required by: ${issuerLocator.name}@${issuerLocator.reference} (via ${issuerForDi
     const candidates = [];
     const qualifiedPath = applyNodeExtensionResolution(unqualifiedPath, candidates, { extensions });
     if (qualifiedPath) {
+      reportRequiredFilesToWatchMode([qualifiedPath]);
       return ppath.normalize(qualifiedPath);
     } else {
-      reportRequiredFilesToWatchMode(candidates.map((candidate) => npath.fromPortablePath(candidate)));
+      reportRequiredFilesToWatchMode(candidates);
       const unqualifiedPathForDisplay = getPathForDisplay(unqualifiedPath);
       const containingPackage = findPackageLocator(unqualifiedPath);
       if (containingPackage) {

--- a/packages/.pnp.loader.mjs
+++ b/packages/.pnp.loader.mjs
@@ -1428,11 +1428,12 @@ class VirtualFS extends ProxiedFS {
 
 const URL = Number(process.versions.node.split('.', 1)[0]) < 20 ? URL$1 : globalThis.URL;
 
-const [major, minor] = process.versions.node.split(`.`).map((value) => parseInt(value, 10));
+const [major, minor, patch] = process.versions.node.split(`.`).map((value) => parseInt(value, 10));
 const WATCH_MODE_MESSAGE_USES_ARRAYS = major > 19 || major === 19 && minor >= 2 || major === 18 && minor >= 13;
 const HAS_LAZY_LOADED_TRANSLATORS = major === 20 && minor < 6 || major === 19 && minor >= 3;
 const SUPPORTS_IMPORT_ATTRIBUTES = major >= 21 || major === 20 && minor >= 10 || major === 18 && minor >= 20;
 const SUPPORTS_IMPORT_ATTRIBUTES_ONLY = major >= 22;
+const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major === 26 && minor < 1 || major === 25 && minor >= 7 || major === 24 && minor === 15 || major === 22 && (minor > 22 || minor === 22 && patch >= 3);
 
 function readPackageScope(checkPath) {
   const rootSeparatorIndex = checkPath.indexOf(npath.sep);
@@ -1549,9 +1550,11 @@ async function load$1(urlString, context, nextLoad) {
       "watch:import": WATCH_MODE_MESSAGE_USES_ARRAYS ? [pathToSend] : pathToSend
     });
   }
+  const shouldReadSource = format === `commonjs` && HAS_BROKEN_FSTAT_FOR_ZIP_FDS && filePath.includes(`.zip/`);
+  const source = format !== `commonjs` || shouldReadSource ? await fs.promises.readFile(filePath, `utf8`) : void 0;
   return {
     format,
-    source: format === `commonjs` ? void 0 : await fs.promises.readFile(filePath, `utf8`),
+    source,
     shortCircuit: true
   };
 }
@@ -1976,7 +1979,7 @@ function packageImportsResolve({ name, base, conditions, readFileSyncFn }) {
 let findPnpApi = esmModule.findPnpApi;
 if (!findPnpApi) {
   const require = createRequire(import.meta.url);
-  const pnpApi = require(`./.pnp.cjs`);
+  const pnpApi = require(structuredClone(`./.pnp.cjs`));
   pnpApi.setup();
   findPnpApi = esmModule.findPnpApi;
 }

--- a/packages/.yarnrc.yml
+++ b/packages/.yarnrc.yml
@@ -1,17 +1,24 @@
+approvedGitRepositories:
+    - "**"
+
 cacheFolder: ../.caches/yarn
 
 enableGlobalCache: false
 
 enableMirror: true
 
+enableScripts: true
+
 globalFolder: ../.caches/yarn
 
 nodeLinker: pnp
 
+npmMinimalAgeGate: 0
+
 packageExtensions:
-  typescript@*:
-    dependencies:
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      rollup: ^4.40.0
-      typescript: ^5.7.3
+    typescript@*:
+        dependencies:
+            react: ^18.2.0
+            react-dom: ^18.2.0
+            rollup: ^4.40.0
+            typescript: ^5.7.3

--- a/packages/package.json
+++ b/packages/package.json
@@ -131,7 +131,7 @@
         "vite-tsconfig-paths": "^4.3.2"
     },
     "noHoist": [],
-    "packageManager": "yarn@4.9.1",
+    "packageManager": "yarn@4.18.0",
     "dependenciesMeta": {
         "@trivago/prettier-plugin-sort-imports@5.2.2": {
             "unplugged": true

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@alloc/quick-lru@npm:^5.2.0":
@@ -12129,7 +12129,7 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
   version: 1.22.12
-  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"
   dependencies:
     es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
@@ -12137,13 +12137,13 @@ __metadata:
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
+  checksum: 10c0/e12af106e16e652bd83060e8afacece4ee3dcbd0f4cf028e3d9ad178e6ced9ecb1c87ee60158b239582313902a717f8adc57a9b76ea54b1994141ba15f420c65
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^2.0.0-next.6#optional!builtin<compat/resolve>":
   version: 2.0.0-next.7
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=9bd1a5"
   dependencies:
     es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.2"
@@ -12153,7 +12153,7 @@ __metadata:
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/6bb6f1d8a1789f7a5b4e35d950e76bc0ba632ff7d51fe86b6f34fb5f41e1ce0f7b884ec166828cfc0728ddffeaee49527711d752d12398297f90c51acd22195e
+  checksum: 10c0/911e8321c64ec2a723247dbeabfcb7663577adf52af642bfda61ddee686fbef2255ad529ff57ee8e3884ee23186b85b2637988bfafc0a9a3a81a98bd4af1e2fc
   languageName: node
   linkType: hard
 

--- a/rust/cargo-psibase/service_wasi_polyfill/src/lib.rs
+++ b/rust/cargo-psibase/service_wasi_polyfill/src/lib.rs
@@ -1,7 +1,8 @@
 use std::ptr::{null, null_mut};
 use wasi::{
-    Ciovec, Exitcode, Fd, Fdflags, Filedelta, Filesize, Lookupflags, Oflags, Prestat, Rights, Size,
-    ERRNO_BADF, ERRNO_INVAL, PREOPENTYPE_DIR,
+    Ciovec, Exitcode, Fd, Fdflags, Fdstat, Filedelta, Filesize, Lookupflags, Oflags, Prestat,
+    Rights, Size, ERRNO_BADF, ERRNO_INVAL, FDFLAGS_APPEND, FILETYPE_CHARACTER_DEVICE,
+    PREOPENTYPE_DIR, RIGHTS_FD_READ, RIGHTS_FD_WRITE,
 };
 
 type Errno = u16;
@@ -68,6 +69,17 @@ pub unsafe extern "C" fn fd_prestat_dir_name(fd: Fd, path: *mut u8, path_len: Si
         return 0;
     }
     ERRNO_BADF.raw()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn fd_fdstat_get(_fd: Fd, stat: *mut Fdstat) -> Errno {
+    *stat = Fdstat {
+        fs_filetype: FILETYPE_CHARACTER_DEVICE,
+        fs_flags: FDFLAGS_APPEND,
+        fs_rights_base: RIGHTS_FD_READ | RIGHTS_FD_WRITE,
+        fs_rights_inheriting: 0,
+    };
+    0
 }
 
 #[no_mangle]

--- a/rust/cargo-psibase/service_wasi_polyfill/src/lib.rs
+++ b/rust/cargo-psibase/service_wasi_polyfill/src/lib.rs
@@ -8,6 +8,7 @@ type Errno = u16;
 
 const POLYFILL_ROOT_DIR_FD: u32 = 3;
 
+#[link(wasm_import_module = "env")]
 extern "C" {
     pub fn writeConsole(message: *const u8, len: usize);
     pub fn abortMessage(message: *const u8, len: usize) -> !;
@@ -32,7 +33,7 @@ pub unsafe extern "C" fn environ_get(_environ: *mut *mut u8, _environ_buf: *mut 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn clock_time_get(id: u32, precision: u64, time: *mut u64) -> Errno {
+pub unsafe extern "C" fn clock_time_get(id: u32, _precision: u64, time: *mut u64) -> Errno {
     clockTimeGet(id, time) as Errno
 }
 
@@ -70,31 +71,31 @@ pub unsafe extern "C" fn fd_prestat_dir_name(fd: Fd, path: *mut u8, path_len: Si
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn path_unlink_file(arg0: i32, arg1: i32, arg2: i32) -> Errno {
+pub unsafe extern "C" fn path_unlink_file(_arg0: i32, _arg1: i32, _arg2: i32) -> Errno {
     ERRNO_INVAL.raw()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn path_open(
-    fd: Fd,
-    dirflags: Lookupflags,
-    path: *const u8,
-    path_len: Size,
-    oflags: Oflags,
-    fs_rights_base: Rights,
-    fs_rights_inherting: Rights,
-    fdflags: Fdflags,
-    opened_fd: *mut Fd,
+    _fd: Fd,
+    _dirflags: Lookupflags,
+    _path: *const u8,
+    _path_len: Size,
+    _oflags: Oflags,
+    _fs_rights_base: Rights,
+    _fs_rights_inherting: Rights,
+    _fdflags: Fdflags,
+    _opened_fd: *mut Fd,
 ) -> Errno {
     ERRNO_INVAL.raw()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn fd_seek(
-    fd: Fd,
-    offset: Filedelta,
-    whence: u8,
-    newoffset: *mut Filesize,
+    _fd: Fd,
+    _offset: Filedelta,
+    _whence: u8,
+    _newoffset: *mut Filesize,
 ) -> Errno {
     ERRNO_INVAL.raw()
 }
@@ -124,7 +125,7 @@ pub unsafe extern "C" fn fd_write(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn fd_close(fd: Fd) -> Errno {
+pub unsafe extern "C" fn fd_close(_fd: Fd) -> Errno {
     ERRNO_BADF.raw()
 }
 

--- a/rust/cargo-psibase/src/link.rs
+++ b/rust/cargo-psibase/src/link.rs
@@ -763,6 +763,100 @@ pub fn link_module(source: &Module, dest: &mut Module) -> Result<(), anyhow::Err
     Ok(())
 }
 
+struct RetargetCalls {
+    from: FunctionId,
+    to: FunctionId,
+}
+
+impl walrus::ir::VisitorMut for RetargetCalls {
+    fn visit_function_id_mut(&mut self, function: &mut FunctionId) {
+        if *function == self.from {
+            *function = self.to;
+        }
+    }
+}
+
+fn retarget(module: &mut Module, from: FunctionId, to: FunctionId) {
+    let mut visitor = RetargetCalls { from, to };
+    for (_, local) in module.funcs.iter_local_mut() {
+        let entry = local.entry_block();
+        walrus::ir::dfs_pre_order_mut(&mut visitor, local, entry);
+    }
+    if module.start == Some(from) {
+        module.start = Some(to);
+    }
+    for elem in module.elements.iter_mut() {
+        if let walrus::ElementKind::Active {
+            offset: walrus::InitExpr::RefFunc(fid),
+            ..
+        } = &mut elem.kind
+        {
+            if *fid == from {
+                *fid = to;
+            }
+        }
+        for member in &mut elem.members {
+            if *member == Some(from) {
+                *member = Some(to);
+            }
+        }
+    }
+    for export in module.exports.iter_mut() {
+        if let walrus::ExportItem::Function(fid) = &mut export.item {
+            if *fid == from {
+                *fid = to;
+            }
+        }
+    }
+}
+
+/// Bind `env` imports to local exports of the same name.
+///
+/// psitest does not provide `env.*`; the tester polyfill does.
+pub fn bind_env(module: &mut Module) -> Result<(), anyhow::Error> {
+    let mut replacements = Vec::new();
+    for import in module.imports.iter() {
+        if import.module != "env" {
+            continue;
+        }
+        let walrus::ImportKind::Function(import_fid) = import.kind else {
+            continue;
+        };
+        let import_fid = import_fid;
+        let Ok(export_fid) = module.exports.get_func(&import.name) else {
+            continue;
+        };
+        if import_fid == export_fid {
+            continue;
+        }
+        if !matches!(module.funcs.get(export_fid).kind, FunctionKind::Local(_)) {
+            continue;
+        }
+        if module.func_type(import_fid) != module.func_type(export_fid) {
+            return Err(anyhow!(
+                "Destination import {} matches local export by name but not by type.",
+                import.name
+            ));
+        }
+        replacements.push((import_fid, export_fid, import.id()));
+    }
+
+    if replacements.is_empty() {
+        return Ok(());
+    }
+
+    for (from, to, import_id) in replacements {
+        retarget(module, from, to);
+        module.imports.delete(import_id);
+    }
+
+    walrus::passes::gc::run(module);
+    new_validator()
+        .validate_all(&module.emit_wasm())
+        .map_err(|e| anyhow!("[Wasm linker error] {}", e))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Error;
@@ -953,6 +1047,41 @@ mod tests {
         assert!(
             post_imports[0].name == "testerClose",
             "Postfill import name incorrect"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_env() -> Result<(), Error> {
+        let path = &rel_to_manifest("/test-data/env-local-override.wat");
+        let mut module = wat(path)?;
+
+        let before = get_import_funcs(&module);
+        assert_eq!(before.len(), 2, "Unexpected imports before satisfy");
+        assert!(
+            before
+                .iter()
+                .any(|i| i.module == "env" && i.name == "kvOpenAt"),
+            "Missing env.kvOpenAt import"
+        );
+        assert!(
+            before
+                .iter()
+                .any(|i| i.module == "psibase" && i.name == "other"),
+            "Missing psibase.other import"
+        );
+
+        bind_env(&mut module)?;
+        print_wat(&suffix(path, "-filled"), &module.emit_wasm())?;
+
+        let after = get_import_funcs(&module);
+        assert_eq!(after.len(), 1, "Unexpected imports after satisfy");
+        assert_eq!(after[0].module, "psibase");
+        assert_eq!(after[0].name, "other");
+        assert!(
+            module.exports.get_func("kvOpenAt").is_ok(),
+            "Local kvOpenAt export should remain"
         );
 
         Ok(())

--- a/rust/cargo-psibase/src/link.rs
+++ b/rust/cargo-psibase/src/link.rs
@@ -763,27 +763,32 @@ pub fn link_module(source: &Module, dest: &mut Module) -> Result<(), anyhow::Err
     Ok(())
 }
 
-struct RetargetCalls {
-    from: FunctionId,
-    to: FunctionId,
+struct RetargetCalls<'a> {
+    map: &'a HashMap<FunctionId, FunctionId>,
 }
 
-impl walrus::ir::VisitorMut for RetargetCalls {
-    fn visit_function_id_mut(&mut self, function: &mut FunctionId) {
-        if *function == self.from {
-            *function = self.to;
+impl RetargetCalls<'_> {
+    fn rewrite(&self, fid: &mut FunctionId) {
+        if let Some(&to) = self.map.get(fid) {
+            *fid = to;
         }
     }
 }
 
-fn retarget(module: &mut Module, from: FunctionId, to: FunctionId) {
-    let mut visitor = RetargetCalls { from, to };
+impl walrus::ir::VisitorMut for RetargetCalls<'_> {
+    fn visit_function_id_mut(&mut self, function: &mut FunctionId) {
+        self.rewrite(function);
+    }
+}
+
+fn retarget(module: &mut Module, map: &HashMap<FunctionId, FunctionId>) {
+    let mut visitor = RetargetCalls { map };
     for (_, local) in module.funcs.iter_local_mut() {
         let entry = local.entry_block();
         walrus::ir::dfs_pre_order_mut(&mut visitor, local, entry);
     }
-    if module.start == Some(from) {
-        module.start = Some(to);
+    if let Some(start) = &mut module.start {
+        visitor.rewrite(start);
     }
     for elem in module.elements.iter_mut() {
         if let walrus::ElementKind::Active {
@@ -791,13 +796,11 @@ fn retarget(module: &mut Module, from: FunctionId, to: FunctionId) {
             ..
         } = &mut elem.kind
         {
-            if *fid == from {
-                *fid = to;
-            }
+            visitor.rewrite(fid);
         }
         for member in &mut elem.members {
-            if *member == Some(from) {
-                *member = Some(to);
+            if let Some(fid) = member {
+                visitor.rewrite(fid);
             }
         }
     }
@@ -806,16 +809,12 @@ fn retarget(module: &mut Module, from: FunctionId, to: FunctionId) {
         if let walrus::GlobalKind::Local(walrus::InitExpr::RefFunc(fid)) =
             &mut module.globals.get_mut(id).kind
         {
-            if *fid == from {
-                *fid = to;
-            }
+            visitor.rewrite(fid);
         }
     }
     for export in module.exports.iter_mut() {
         if let walrus::ExportItem::Function(fid) = &mut export.item {
-            if *fid == from {
-                *fid = to;
-            }
+            visitor.rewrite(fid);
         }
     }
 }
@@ -824,7 +823,8 @@ fn retarget(module: &mut Module, from: FunctionId, to: FunctionId) {
 ///
 /// psitest does not provide `env.*`; the tester polyfill does.
 pub fn bind_env(module: &mut Module) -> Result<(), anyhow::Error> {
-    let mut replacements = Vec::new();
+    let mut map = HashMap::new();
+    let mut import_ids = Vec::new();
     for import in module.imports.iter() {
         if import.module != "env" {
             continue;
@@ -850,15 +850,16 @@ pub fn bind_env(module: &mut Module) -> Result<(), anyhow::Error> {
                 import.name
             ));
         }
-        replacements.push((import_fid, export_fid, import.id()));
+        map.insert(import_fid, export_fid);
+        import_ids.push(import.id());
     }
 
-    if replacements.is_empty() {
+    if map.is_empty() {
         return Ok(());
     }
 
-    for (from, to, import_id) in replacements {
-        retarget(module, from, to);
+    retarget(module, &map);
+    for import_id in import_ids {
         module.imports.delete(import_id);
     }
 

--- a/rust/cargo-psibase/src/link.rs
+++ b/rust/cargo-psibase/src/link.rs
@@ -801,6 +801,16 @@ fn retarget(module: &mut Module, from: FunctionId, to: FunctionId) {
             }
         }
     }
+    let global_ids: Vec<_> = module.globals.iter().map(|g| g.id()).collect();
+    for id in global_ids {
+        if let walrus::GlobalKind::Local(walrus::InitExpr::RefFunc(fid)) =
+            &mut module.globals.get_mut(id).kind
+        {
+            if *fid == from {
+                *fid = to;
+            }
+        }
+    }
     for export in module.exports.iter_mut() {
         if let walrus::ExportItem::Function(fid) = &mut export.item {
             if *fid == from {
@@ -822,7 +832,6 @@ pub fn bind_env(module: &mut Module) -> Result<(), anyhow::Error> {
         let walrus::ImportKind::Function(import_fid) = import.kind else {
             continue;
         };
-        let import_fid = import_fid;
         let Ok(export_fid) = module.exports.get_func(&import.name) else {
             continue;
         };
@@ -830,7 +839,10 @@ pub fn bind_env(module: &mut Module) -> Result<(), anyhow::Error> {
             continue;
         }
         if !matches!(module.funcs.get(export_fid).kind, FunctionKind::Local(_)) {
-            continue;
+            return Err(anyhow!(
+                "Destination import {} matches an export by name, but that export is not a local function.",
+                import.name
+            ));
         }
         if module.func_type(import_fid) != module.func_type(export_fid) {
             return Err(anyhow!(

--- a/rust/cargo-psibase/src/main.rs
+++ b/rust/cargo-psibase/src/main.rs
@@ -27,7 +27,7 @@ use walrus::{ExportItem, Module};
 use wasm_opt::OptimizationOptions;
 
 mod link;
-use link::link_module;
+use link::{bind_env, link_module};
 mod package;
 use package::*;
 
@@ -327,6 +327,7 @@ fn process(
         let polyfill_source_module = config.parse(polyfill)?;
         link_module(&polyfill_source_module, &mut dest_module)?;
     }
+    bind_env(&mut dest_module)?;
 
     strip(&mut dest_module, exports)?;
 

--- a/rust/cargo-psibase/test-data/.gitignore
+++ b/rust/cargo-psibase/test-data/.gitignore
@@ -1,3 +1,4 @@
 !*.wasm
 !import.wat
 !reexport.wat
+!env-local-override.wat

--- a/rust/cargo-psibase/test-data/env-local-override.wat
+++ b/rust/cargo-psibase/test-data/env-local-override.wat
@@ -1,0 +1,14 @@
+(module
+  (type $t (func (param i32) (result i32)))
+  (import "env" "kvOpenAt" (func $imported (type $t)))
+  (import "psibase" "other" (func $keep (type $t)))
+  (func $local (type $t) (param i32) (result i32)
+    local.get 0
+  )
+  (export "kvOpenAt" (func $local))
+  (func (export "user") (param i32) (result i32)
+    local.get 0
+    call $imported
+    call $keep
+  )
+)

--- a/rust/psibase/src/native.rs
+++ b/rust/psibase/src/native.rs
@@ -143,6 +143,7 @@ pub struct KvHandle(native_raw::KvHandle);
 pub use native_raw::KvMode;
 
 // The tester needs a different implementation from services
+#[link(wasm_import_module = "env")]
 extern "C" {
     pub fn psibase_proxy_kv_open(
         db: DbId,

--- a/rust/psibase/src/native_raw.rs
+++ b/rust/psibase/src/native_raw.rs
@@ -23,6 +23,7 @@ pub enum KvMode {
     ReadWrite = 3,
 }
 
+#[link(wasm_import_module = "env")]
 extern "C" {
     /// Copy `min(dest_size, resultSize - offset)` bytes from
     /// `result + offset` into `dest` and return `resultSize`

--- a/rust/psibase_macros/psibase-macros-derive/tests/authorized/result_incompatible_error.stderr
+++ b/rust/psibase_macros/psibase-macros-derive/tests/authorized/result_incompatible_error.stderr
@@ -8,11 +8,10 @@ error[E0277]: `?` couldn't convert the error to `i32`
   |     this can't be annotated with `?` because it has type `Result<_, String>`
   |
   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-  = help: the following other types implement trait `From<T>`:
-            `i32` implements `From<bool>`
-            `i32` implements `From<i16>`
-            `i32` implements `From<i8>`
-            `i32` implements `From<u16>`
-            `i32` implements `From<u8>`
-  = note: required for `Result<(), i32>` to implement `FromResidual<Result<Infallible, String>>`
+  = help: `i32` implements trait `From<T>`:
+            From<bool>
+            From<i16>
+            From<i8>
+            From<u16>
+            From<u8>
   = note: this error originates in the attribute macro `authorized` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
# Background

https://github.com/gofractally/psibase/pull/2048 uses a new builder image for psibase CI. The new image has an upgraded yarn, npm, and rust. This PR fixes various issues that surfaced from making those upgrades.

# `bind_env`

On 1.86, a bare `extern "C"`  (e.g. `extern "C" { fn writeConsole(...); }`) on wasm32-wasip1 was an unresolved C symbol. rust-lld’s wasm default:
 1. turned those into `env` imports, and
 2. if a `#[no_mangle]` of the same name existed, bound the reference to that local function instead

On 1.98, that target links `wasi-libc`. A bare extern "C" is a normal C symbol, not a wasm import. Link fails with e.g. `undefined symbol: writeConsole`

`#[link(wasm_import_module = "env")]` is the explicit form needed for those functions to be considered wasm imports. In production that's all that's needed, but the import is now no longer bound to a local `#[no_mangle]` which is needed for tests. Therefore we also need `bind_env` in the cargo-psibase post-processing. `bind_env` will bind those wasi-imports to the same-named local exports and drop the import.

# missing polyfill

 `fd_fdstat_get` is needed for rust services, was already in cpp.
 
# updated error text 

The error text asserted in the `authorized` trybuild test was updated at some point, this updates the snapshot to the latest expected text.

# workspace yarn

- Bump the Yarn workspace to 4.18.0
- `enableScripts`, `approvedGitRepositories`, `npmMinimalAgeGate` were added to keep existing Yarn 4.9 behavior with default changes in latest yarn version
 