### PR TITLE
Remove unused Identity, Evaluations, and TokenSwap types

### DIFF
--- a/packages/user/Evaluations/query-service/src/lib.rs
+++ b/packages/user/Evaluations/query-service/src/lib.rs
@@ -34,13 +34,6 @@ mod service {
     }
 
     #[derive(Deserialize, SimpleObject)]
-    struct EvaluationStart {
-        owner: AccountNumber,
-        #[serde(deserialize_with = "deserialize_number_from_string")]
-        evaluation_id: u32,
-    }
-
-    #[derive(Deserialize, SimpleObject)]
     struct NewGroup {
         owner: AccountNumber,
         #[serde(deserialize_with = "deserialize_number_from_string")]

--- a/packages/user/Identity/plugin/src/lib.rs
+++ b/packages/user/Identity/plugin/src/lib.rs
@@ -10,7 +10,7 @@ use bindings::host::types::types as HostTypes;
 use bindings::transact::plugin::intf as Transact;
 use psibase::fracpack::Pack;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 mod errors;
 use crate::trust::*;
@@ -32,13 +32,6 @@ psibase::define_trust! {
 }
 
 struct IdentityPlugin;
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Attestation {
-    subject: String,
-    attestation_type: String,
-    score: f32,
-}
 
 impl Api for IdentityPlugin {
     fn attest_identity_claim(subject: String, score: f32) -> Result<(), HostTypes::Error> {

--- a/packages/user/TokenSwap/query-service/src/lib.rs
+++ b/packages/user/TokenSwap/query-service/src/lib.rs
@@ -3,14 +3,7 @@
 mod service {
     use async_graphql::{connection::Connection, *};
     use psibase::{services::tokens::TID, *};
-    use serde::Deserialize;
     use token_swap::tables::tables::{Pool, PoolTable, Reserve, ReserveTable};
-
-    #[derive(Deserialize, SimpleObject)]
-    struct CreatedPool {
-        token_a: String,
-        token_b: String,
-    }
 
     struct Query;
 


### PR DESCRIPTION
Eliminates a few build warnings
