### PR TITLE
Pin Nix Node 24.20.0 and Yarn 4.18.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,17 +185,17 @@
     },
     "nixpkgs-nodejs": {
       "locked": {
-        "lastModified": 1705033200,
-        "narHash": "sha256-g2ctv18BjQl7VvaUtdm7/l1y1C2mgITOFkw3t+RBvNo=",
+        "lastModified": 1787765859,
+        "narHash": "sha256-d6ZPPsB3sadCl1BDfbMG8zSRDPjsWjOBHGS1yf0CZSc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fea57dc5b57285d33918813d2f3695024d8fc9e8",
+        "rev": "aefbfa796e0203f83584422979d2a7e7558fa820",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fea57dc5b57285d33918813d2f3695024d8fc9e8",
+        "rev": "aefbfa796e0203f83584422979d2a7e7558fa820",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,8 @@
     #   mdbook-pagetoc 0.2.0 — DIVERGES from psibase-contributor (0.2.2): no nixpkgs rev
     #   ships 0.2.2 while keeping mdbook 0.4.x compatibility (0.3.0 breaks mdbook 0.4.x).
     nixpkgs-mdbook-pagetoc.url = "github:NixOS/nixpkgs/ac62194c3917d5f474c1a844b6fd6da2db95077d";
-    #   nodejs 20.11.0
-    nixpkgs-nodejs.url = "github:NixOS/nixpkgs/fea57dc5b57285d33918813d2f3695024d8fc9e8";
+    #   nodejs 24.20.0
+    nixpkgs-nodejs.url = "github:NixOS/nixpkgs/aefbfa796e0203f83584422979d2a7e7558fa820";
   };
 
   outputs = { self, nixpkgs, flake-utils, fenix, nixpkgs-cargo-component, nixpkgs-cargo-generate, nixpkgs-cursor-cli, nixpkgs-mdbook, nixpkgs-mdbook-mermaid, nixpkgs-mdbook-plugins, nixpkgs-mdbook-linkcheck, nixpkgs-mdbook-pagetoc, nixpkgs-nodejs }:
@@ -69,7 +69,7 @@
         mdbookLinkcheck = (import nixpkgs-mdbook-linkcheck { inherit system; }).mdbook-linkcheck;
         mdbookPagetoc = (import nixpkgs-mdbook-pagetoc { inherit system; }).mdbook-pagetoc;
         wasmPack = (import nixpkgs-mdbook { inherit system; }).wasm-pack;
-        nodejs20 = (import nixpkgs-nodejs { inherit system; }).nodejs_20;
+        nodejs24 = (import nixpkgs-nodejs { inherit system; }).nodejs_24;
 
         # Rust 1.86.0 toolchain with WASM targets (see nix/rust-toolchain.toml)
         rustToolchain = fenix.packages.${system}.fromToolchainFile {
@@ -150,13 +150,13 @@
 
         yarnBerry = pkgs.stdenv.mkDerivation rec {
           pname = "yarn-berry";
-          version = "4.9.1";
+          version = "4.18.0";
 
           src = pkgs.fetchFromGitHub {
             owner = "yarnpkg";
             repo = "berry";
             rev = "@yarnpkg/cli/${version}";
-            sha256 = "sha256-znxB827TFLAEfCeHrwBsmRlkZz1LVWsBFhjZANiIW/4=";
+            sha256 = "sha256-pO89wh17cW9/RGKjo70yiefr+9nlJAQs4ZEdUnzdgQM=";
           };
 
           nativeBuildInputs = [ pkgs.makeWrapper ];
@@ -168,7 +168,7 @@
             runHook preInstall
             mkdir -p $out/lib/yarn $out/bin
             cp -r . $out/lib/yarn/
-            makeWrapper ${nodejs20}/bin/node $out/bin/yarn \
+            makeWrapper ${nodejs24}/bin/node $out/bin/yarn \
               --add-flags "$out/lib/yarn/packages/yarnpkg-cli/bin/yarn.js"
             runHook postInstall
           '';
@@ -205,7 +205,7 @@
           wabt
           wasmPack
           wasmTools
-          nodejs20
+          nodejs24
           yarnBerry
           eslint
           prettier

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     };
 
     # Fragile cargo tools, each pinned to the exact nixpkgs revision that packages
-    # the required version (chosen for Rust 1.86.0 / psibase compatibility). These
+    # the required version (chosen for Rust 1.98.0 / psibase compatibility). These
     # MUST stay at their pinned versions, so they deliberately do NOT `follow`
     # nixpkgs — the frozen revision is the whole point. No single nixpkgs rev
     # carries all required versions at once, hence one input per tool (cargo-generate
@@ -71,10 +71,10 @@
         wasmPack = (import nixpkgs-mdbook { inherit system; }).wasm-pack;
         nodejs24 = (import nixpkgs-nodejs { inherit system; }).nodejs_24;
 
-        # Rust 1.86.0 toolchain with WASM targets (see nix/rust-toolchain.toml)
+        # Rust 1.98.0 toolchain with WASM targets (see nix/rust-toolchain.toml)
         rustToolchain = fenix.packages.${system}.fromToolchainFile {
           file = ./nix/rust-toolchain.toml;
-          sha256 = "sha256-X/4ZBHO3iW0fOenQ3foEvscgAPJYl2abspaBThDOukI=";
+          sha256 = "sha256-P30Tm3O7vQAE725YtDCDHGjNrSsfZO4us11UwJGZSJo=";
         };
 
         # DIVERGES from psibase-contributor (wasi-sdk 24 embedded in llvm-18): standalone

--- a/nix/README.md
+++ b/nix/README.md
@@ -11,7 +11,7 @@ The Nix configuration includes
 - **C++**: GCC (native), LLVM/Clang 18 (WASM, clangd), Boost, CMake
 - **Rust**: 1.86.0 (pinned) with WASM targets (`wasm32-unknown-unknown`, `wasm32-wasip1`)
 - **WebAssembly**: WASI SDK 29, wasm-pack, wasm-tools, binaryen
-- **JavaScript**: Node.js 20, Yarn
+- **JavaScript**: Node.js 24.20.0, Yarn 4.18.0
 - **Tools**: clangd, gdb, direnv, mkcert, SoftHSM2, gh, cursor-agent (cursor-cli)
 - **Docs**: mdbook with plugins
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -9,7 +9,7 @@ Not (yet) supported: macOS
 The Nix configuration includes
 
 - **C++**: GCC (native), LLVM/Clang 18 (WASM, clangd), Boost, CMake
-- **Rust**: 1.86.0 (pinned) with WASM targets (`wasm32-unknown-unknown`, `wasm32-wasip1`)
+- **Rust**: 1.98.0 (pinned) with WASM targets (`wasm32-unknown-unknown`, `wasm32-wasip1`)
 - **WebAssembly**: WASI SDK 29, wasm-pack, wasm-tools, binaryen
 - **JavaScript**: Node.js 24.20.0, Yarn 4.18.0
 - **Tools**: clangd, gdb, direnv, mkcert, SoftHSM2, gh, cursor-agent (cursor-cli)

--- a/nix/rust-toolchain.toml
+++ b/nix/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.98.0"
 components = ["cargo", "clippy", "rust-analyzer", "rust-src", "rustc", "rustfmt", "llvm-tools"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]


### PR DESCRIPTION
- Pin the Nix flake to Node.js 24.20.0 and Yarn 4.18.0 to match the updated builder image.
- Update `nix/README.md` to the same versions.