### PR TITLE
Fix build with gcc 16

### DIFF
--- a/rust/cargo-psibase/Cargo.toml
+++ b/rust/cargo-psibase/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-wasm-opt = "0.116.0"
+wasm-opt = { version = "0.116.0", default-features = false }
 cargo_metadata = "0.18.1"
 clap.workspace = true
 console = "0.15.2"


### PR DESCRIPTION
DWARF support in binaryen is broken with gcc 16. This is fixed in binaryen 129, but the rust wrapper is still stuck at 116. cargo-psibase doesn't have debug builds so we don't need dwarf support.