### PR TITLE
Remove shutdownChain

### DIFF
--- a/libraries/psibase/tester/include/psibase/tester.hpp
+++ b/libraries/psibase/tester/include/psibase/tester.hpp
@@ -504,12 +504,6 @@ namespace psibase
       void boot(const std::vector<std::string>& names, bool installUI);
 
       /**
-       * Shuts down the chain to allow copying its state file. The chain's temporary path will
-       * live until this object destructs.
-       */
-      void shutdown();
-
-      /**
        * By default, the TestChain will automatically advance blocks.
        * When autoBlockStart is disabled, the the chain will only advance blocks manually.
        * To manually advance a block, you must call startBlock.

--- a/libraries/psibase/tester/include/psibase/testerApi.hpp
+++ b/libraries/psibase/tester/include/psibase/testerApi.hpp
@@ -48,7 +48,6 @@ namespace psibase::tester::raw
                             const char*   args_packed,
                             std::uint32_t args_packed_size);
    TESTER_NATIVE(socketRecv) std::uint32_t socketRecv(std::int32_t fd, std::size_t* size);
-   TESTER_NATIVE(shutdownChain) void shutdownChain(uint32_t chain);
    TESTER_NATIVE(startBlock)
    void startBlock(std::uint32_t chain_index,
                    std::int64_t  time_us,

--- a/libraries/psibase/tester/src/tester.cpp
+++ b/libraries/psibase/tester/src/tester.cpp
@@ -390,11 +390,6 @@ psibase::TestChain::~TestChain()
       selectedChain.reset();
 }
 
-void psibase::TestChain::shutdown()
-{
-   tester::raw::shutdownChain(id);
-}
-
 void psibase::TestChain::setAutoBlockStart(bool enable)
 {
    isAutoBlockStart = enable;

--- a/programs/psitest/main.cpp
+++ b/programs/psitest/main.cpp
@@ -1240,15 +1240,6 @@ struct callbacks
       }
    }
 
-   // TODO: may not be useful anymore; remove?
-   void testerShutdownChain(uint32_t chain)
-   {
-      auto& c = assert_chain(chain);
-      c.blockContext.reset();
-      c.sys.reset();
-      c.db = {};
-   }
-
    void testerStartBlock(uint32_t          chain_index,
                          int64_t           time_us,
                          uint64_t          producer,
@@ -1705,7 +1696,6 @@ void register_callbacks()
    rhf_t::add<&callbacks::testerCloneChain>("psibase", "cloneChain");
    rhf_t::add<&callbacks::testerGetFork>("psibase", "getFork");
    rhf_t::add<&callbacks::testerDestroyChain>("psibase", "destroyChain");
-   rhf_t::add<&callbacks::testerShutdownChain>("psibase", "shutdownChain");
    rhf_t::add<&callbacks::testerStartBlock>("psibase", "startBlock");
    rhf_t::add<&callbacks::testerFinishBlock>("psibase", "finishBlock");
    rhf_t::add<&callbacks::checkoutSubjective>("psibase", "checkoutSubjective");

--- a/rust/psibase/src/tester.rs
+++ b/rust/psibase/src/tester.rs
@@ -539,35 +539,6 @@ impl Chain {
         TransactionTrace::unpacked(&get_result_bytes(size)).unwrap()
     }
 
-    /// Copy database to `path`
-    ///
-    /// Runs the following shell command: `mkdir -p {path} && cp -a {src}/* {path}`,
-    /// where `{path}` is the passed-in argument and `{src}` is the chain's database.
-    ///
-    /// Returns shell exit status; 0 if successful
-    pub fn copy_database(&self, path: &str) -> i32 {
-        let src = unsafe { self.get_path() };
-        execute(&format! {"mkdir -p {path} && cp -a {src}/* {path}", src = src, path = path})
-    }
-
-    /// Get filesystem path of chain's database
-    ///
-    /// See [`copy_database`](Self::copy_database) for the most-common use case
-    ///
-    /// # Safety
-    ///
-    /// It is safe to copy the files to another location on the filesystem. However,
-    /// modifying the original files or launching `psinode` on the original files
-    /// will corrupt the database and likely crash the `psitest` process running this
-    /// wasm.
-    pub unsafe fn get_path(&self) -> String {
-        let size = tester_raw::getChainPath(self.chain_handle, null_mut(), 0);
-        let mut bytes = Vec::with_capacity(size);
-        tester_raw::getChainPath(self.chain_handle, bytes.as_mut_ptr(), size);
-        bytes.set_len(size);
-        String::from_utf8_unchecked(bytes)
-    }
-
     /// Select chain for database native functions
     ///
     /// After you call `select_chain`, the following functions will use

--- a/rust/psibase/src/tester_raw.rs
+++ b/rust/psibase/src/tester_raw.rs
@@ -35,16 +35,6 @@ extern "C" {
     /// This does nothing if a block isn't currently being produced.
     pub fn finishBlock(chain_handle: u32);
 
-    /// Get filesystem path of chain's database
-    ///
-    /// Stores up to `dest_size` bytes if the chain's path into `dest`. Returns
-    /// the path size. The path is UTF8.
-    ///
-    /// It is safe to copy the files to another location on the filesystem. However,
-    /// modifying the original files or launching `psinode` on the original files
-    /// will corrupt the database and likely crash the `psitest` process running this wasm.
-    pub fn getChainPath(chain_handle: u32, dest: *mut u8, dest_size: usize) -> usize;
-
     /// Push a transaction
     ///
     /// `chain_handle` identifies the chain to push to. `transaction/transaction_size`
@@ -56,15 +46,6 @@ extern "C" {
         transaction: *const u8,
         transaction_size: usize,
     ) -> u32;
-
-    /// Shutdown chain without deleting database
-    ///
-    /// This shuts down a chain, but doesn't destroy it or remove the
-    /// database. `chain_handle` still exists, but isn't usable except
-    /// with [`getChainPath`] and [`destroyChain`].
-    ///
-    /// TODO: `shutdownChain` probably isn't useful anymore; it might go away.
-    pub fn shutdownChain(chain_handle: u32);
 
     /// Start a new block
     ///


### PR DESCRIPTION
This was originally used to stop the chain and then copy it to a permanent location. This hasn't been usable for a while.

- A temporary chain does not have a path at all (it's either opened with O_TMPFILE or unlinked immediately), so there's no way to access it even if the chain is stopped
- A chain can be opened at a specific path, which satisfies the original use case

`getChainPath` was already removed but was still referenced by the rust tester
