### PR TITLE
Token swap touches

### DIFF
--- a/packages/user/TokenSwap/service/src/helpers.rs
+++ b/packages/user/TokenSwap/service/src/helpers.rs
@@ -17,6 +17,7 @@ pub fn sqrt(n: u128) -> u128 {
 }
 
 pub fn mul_div(a: Quantity, b: Quantity, c: Quantity) -> Quantity {
+    assert!(c.value > 0, "mul_div division by zero");
     let res = (a.value as u128 * b.value as u128) / (c.value as u128);
-    (res as u64).into()
+    u64::try_from(res).expect("mul_div overflow").into()
 }

--- a/packages/user/TokenSwap/service/src/lib.rs
+++ b/packages/user/TokenSwap/service/src/lib.rs
@@ -55,7 +55,7 @@ pub mod service {
     /// * `token_b` - Token ID of the second deposit.
     /// * `token_a_amount` - Amount of the first deposit.
     /// * `token_b_amount` - Amount of the second deposit.
-    /// * `nft_id`  - Optional administration NFT ID for the pool. If not provided, a new NFT is minted and credited to the sender.
+    /// * `nft_id`  - Optional administration NFT ID for the pool. If not provided, a new NFT is minted and credited to the sender. If provided, the caller must own it and it must not already administer another pool.
     ///
     /// # Returns
     /// (TID of Liquidity token / Pool ID, Administration NFT ID of pool)
@@ -74,6 +74,7 @@ pub mod service {
     /// Set the administration NFT ID for an existing pool.
     ///
     /// Only the current owner of the existing administration NFT is allowed to change it.
+    /// The caller must also own the new NFT, and it must not already administer another pool.
     ///
     /// # Arguments
     /// * `pool_id` - Liquidity token ID that identifies the pool

--- a/packages/user/TokenSwap/service/src/lib.rs
+++ b/packages/user/TokenSwap/service/src/lib.rs
@@ -55,7 +55,7 @@ pub mod service {
     /// * `token_b` - Token ID of the second deposit.
     /// * `token_a_amount` - Amount of the first deposit.
     /// * `token_b_amount` - Amount of the second deposit.
-    /// * `nft_id`  - Optional administration NFT ID for the pool. If not provided, a new NFT is minted and credited to the sender. If provided, the caller must own it.
+    /// * `nft_id`  - Optional administration NFT ID for the pool. If not provided, a new NFT is minted and credited to the sender. If provided, the NFT must exist.
     ///
     /// # Returns
     /// (TID of Liquidity token / Pool ID, Administration NFT ID of pool)
@@ -74,7 +74,7 @@ pub mod service {
     /// Set the administration NFT ID for an existing pool.
     ///
     /// Only the current owner of the existing administration NFT is allowed to change it.
-    /// The caller must also own the new NFT.
+    /// The new NFT must exist.
     ///
     /// # Arguments
     /// * `pool_id` - Liquidity token ID that identifies the pool

--- a/packages/user/TokenSwap/service/src/lib.rs
+++ b/packages/user/TokenSwap/service/src/lib.rs
@@ -55,7 +55,7 @@ pub mod service {
     /// * `token_b` - Token ID of the second deposit.
     /// * `token_a_amount` - Amount of the first deposit.
     /// * `token_b_amount` - Amount of the second deposit.
-    /// * `nft_id`  - Optional administration NFT ID for the pool. If not provided, a new NFT is minted and credited to the sender. If provided, the caller must own it and it must not already administer another pool.
+    /// * `nft_id`  - Optional administration NFT ID for the pool. If not provided, a new NFT is minted and credited to the sender. If provided, the caller must own it.
     ///
     /// # Returns
     /// (TID of Liquidity token / Pool ID, Administration NFT ID of pool)
@@ -74,7 +74,7 @@ pub mod service {
     /// Set the administration NFT ID for an existing pool.
     ///
     /// Only the current owner of the existing administration NFT is allowed to change it.
-    /// The caller must also own the new NFT, and it must not already administer another pool.
+    /// The caller must also own the new NFT.
     ///
     /// # Arguments
     /// * `pool_id` - Liquidity token ID that identifies the pool

--- a/packages/user/TokenSwap/service/src/tables.rs
+++ b/packages/user/TokenSwap/service/src/tables.rs
@@ -188,9 +188,11 @@ pub mod tables {
                 .expect(format!("pool does not exist, liquidity id: {}", liquidity_token).as_str())
         }
 
-        fn assert_usable_admin_nft(nft_id: NID) {
-            let record = psibase::services::nft::Wrapper::call().getNft(nft_id);
-            assert_eq!(record.owner, get_sender(), "Must own administration NFT");
+        fn assert_admin_nft_exists(nft_id: NID) {
+            assert!(
+                psibase::services::nft::Wrapper::call().exists(nft_id),
+                "admin NFT does not exist",
+            );
         }
 
         pub fn administration_nft_owner(&self) -> AccountNumber {
@@ -205,7 +207,7 @@ pub mod tables {
                 self.administration_nft_owner(),
                 "Must own administration NFT to set new administration NFT",
             );
-            Self::assert_usable_admin_nft(nft_id);
+            Self::assert_admin_nft_exists(nft_id);
             self.admin_nft = nft_id;
             self.save();
         }
@@ -230,7 +232,7 @@ pub mod tables {
             tokens.getToken(token_b_id);
 
             if let Some(id) = nft_id {
-                Self::assert_usable_admin_nft(id);
+                Self::assert_admin_nft_exists(id);
             }
 
             let nft = psibase::services::nft::Wrapper::call();

--- a/packages/user/TokenSwap/service/src/tables.rs
+++ b/packages/user/TokenSwap/service/src/tables.rs
@@ -179,11 +179,6 @@ pub mod tables {
     }
 
     impl Pool {
-        #[secondary_key(1)]
-        fn by_admin_nft(&self) -> NID {
-            self.admin_nft
-        }
-
         pub fn get(id: u32) -> Option<Self> {
             PoolTable::read().get_index_pk().get(&id)
         }
@@ -193,19 +188,9 @@ pub mod tables {
                 .expect(format!("pool does not exist, liquidity id: {}", liquidity_token).as_str())
         }
 
-        fn get_by_admin_nft(nft_id: NID) -> Option<Self> {
-            PoolTable::read().get_index_by_admin_nft().get(&nft_id)
-        }
-
-        fn assert_usable_admin_nft(nft_id: NID, current_pool: Option<TID>) {
+        fn assert_usable_admin_nft(nft_id: NID) {
             let record = psibase::services::nft::Wrapper::call().getNft(nft_id);
             assert_eq!(record.owner, get_sender(), "Must own administration NFT");
-            if let Some(existing) = Self::get_by_admin_nft(nft_id) {
-                assert!(
-                    Some(existing.liquidity_token) == current_pool,
-                    "NFT already administers a pool",
-                );
-            }
         }
 
         pub fn administration_nft_owner(&self) -> AccountNumber {
@@ -220,7 +205,7 @@ pub mod tables {
                 self.administration_nft_owner(),
                 "Must own administration NFT to set new administration NFT",
             );
-            Self::assert_usable_admin_nft(nft_id, Some(self.liquidity_token));
+            Self::assert_usable_admin_nft(nft_id);
             self.admin_nft = nft_id;
             self.save();
         }
@@ -245,7 +230,7 @@ pub mod tables {
             tokens.getToken(token_b_id);
 
             if let Some(id) = nft_id {
-                Self::assert_usable_admin_nft(id, None);
+                Self::assert_usable_admin_nft(id);
             }
 
             let nft = psibase::services::nft::Wrapper::call();

--- a/packages/user/TokenSwap/service/src/tables.rs
+++ b/packages/user/TokenSwap/service/src/tables.rs
@@ -3,10 +3,10 @@ pub mod tables {
 
     use async_graphql::{ComplexObject, SimpleObject};
     use psibase::services::nft::NID;
-    use psibase::services::token_swap::{swap, Wrapper as TokenSwap, PPM};
-    use psibase::services::tokens::{Decimal, Quantity, TokenRecord, Wrapper as Tokens, TID};
+    use psibase::services::token_swap::{PPM, Wrapper as TokenSwap, swap};
+    use psibase::services::tokens::{Decimal, Quantity, TID, TokenRecord, Wrapper as Tokens};
     use psibase::{
-        abort_message, get_sender, AccountNumber, Fracpack, Memo, ServiceWrapper, Table, ToSchema,
+        AccountNumber, Fracpack, Memo, ServiceWrapper, Table, ToSchema, abort_message, get_sender,
     };
 
     use crate::helpers::{mul_div, sqrt};
@@ -179,6 +179,11 @@ pub mod tables {
     }
 
     impl Pool {
+        #[secondary_key(1)]
+        fn by_admin_nft(&self) -> NID {
+            self.admin_nft
+        }
+
         pub fn get(id: u32) -> Option<Self> {
             PoolTable::read().get_index_pk().get(&id)
         }
@@ -186,6 +191,21 @@ pub mod tables {
         pub fn get_assert(liquidity_token: u32) -> Self {
             Self::get(liquidity_token)
                 .expect(format!("pool does not exist, liquidity id: {}", liquidity_token).as_str())
+        }
+
+        fn get_by_admin_nft(nft_id: NID) -> Option<Self> {
+            PoolTable::read().get_index_by_admin_nft().get(&nft_id)
+        }
+
+        fn assert_usable_admin_nft(nft_id: NID, current_pool: Option<TID>) {
+            let record = psibase::services::nft::Wrapper::call().getNft(nft_id);
+            assert_eq!(record.owner, get_sender(), "Must own administration NFT");
+            if let Some(existing) = Self::get_by_admin_nft(nft_id) {
+                assert!(
+                    Some(existing.liquidity_token) == current_pool,
+                    "NFT already administers a pool",
+                );
+            }
         }
 
         pub fn administration_nft_owner(&self) -> AccountNumber {
@@ -200,10 +220,7 @@ pub mod tables {
                 self.administration_nft_owner(),
                 "Must own administration NFT to set new administration NFT",
             );
-            assert!(
-                psibase::services::nft::Wrapper::call().exists(nft_id),
-                "new NFT does not exist",
-            );
+            Self::assert_usable_admin_nft(nft_id, Some(self.liquidity_token));
             self.admin_nft = nft_id;
             self.save();
         }
@@ -226,6 +243,10 @@ pub mod tables {
             let tokens = psibase::services::tokens::Wrapper::call();
             tokens.getToken(token_a_id);
             tokens.getToken(token_b_id);
+
+            if let Some(id) = nft_id {
+                Self::assert_usable_admin_nft(id, None);
+            }
 
             let nft = psibase::services::nft::Wrapper::call();
             let sender = get_sender();
@@ -490,7 +511,7 @@ pub mod tables {
             PoolTable::read_write().put(&self).unwrap();
         }
 
-        pub fn swap(&mut self, incoming_token: TID, incoming_amount: Quantity) -> (TID, Quantity) {
+        pub fn swap(&self, incoming_token: TID, incoming_amount: Quantity) -> (TID, Quantity) {
             let (incoming_reserve, outgoing_reserve) = self.reserves_with_first(incoming_token);
 
             let outgoing_amount = swap(
@@ -503,7 +524,6 @@ pub mod tables {
 
             incoming_reserve.deposit_into_reserve(incoming_amount);
             outgoing_reserve.withdraw_from_reserve(outgoing_amount);
-            self.save();
             (outgoing_reserve.token_id, outgoing_amount)
         }
     }


### PR DESCRIPTION
Throw on any form of overflow returning to `u64` in `mul_div`
If someone specifies an administrative NFT ID, make sure it exists. 
Remove `self.save()` use on swap because all mutations are just being done with tokens `credit` `debit` and sub balances actions. 