### PR TITLE
Rename clio to psio

### DIFF
--- a/libraries/psibase/common/include/psibase/Memo.hpp
+++ b/libraries/psibase/common/include/psibase/Memo.hpp
@@ -57,21 +57,21 @@ namespace psibase
       to_json(s.contents, stream);
    }
 
-   inline std::string& clio_unwrap_packable(Memo& s)
+   inline std::string& psio_unwrap_packable(Memo& s)
    {
       return s.contents;
    }
-   inline const std::string& clio_unwrap_packable(const Memo& s)
+   inline const std::string& psio_unwrap_packable(const Memo& s)
    {
       return s.contents;
    }
 
-   inline bool clio_validate_packable(const Memo& str)
+   inline bool psio_validate_packable(const Memo& str)
    {
       return Memo::validate(str.contents);
    }
 
-   inline bool clio_validate_packable(psio::view<const Memo> str)
+   inline bool psio_validate_packable(psio::view<const Memo> str)
    {
       return Memo::validate(str.contents());
    }

--- a/libraries/psio/include/psio/fracpack.hpp
+++ b/libraries/psio/include/psio/fracpack.hpp
@@ -14,14 +14,14 @@
 
 namespace psio
 {
-   // If a type T supports the expressions `clio_unwrap_packable(T&)`,
-   // which returns a `T2&`, and `clio_unwrap_packable(const T&)`, which
+   // If a type T supports the expressions `psio_unwrap_packable(T&)`,
+   // which returns a `T2&`, and `psio_unwrap_packable(const T&)`, which
    // returns `const T2&`, then packing or unpacking T packs or unpacks
    // the returned reference instead.
    template <typename T>
    concept PackableWrapper = requires(T& x, const T& cx) {
-      clio_unwrap_packable(x);
-      clio_unwrap_packable(cx);
+      psio_unwrap_packable(x);
+      psio_unwrap_packable(cx);
    };
 
    template <typename T, bool Reflected>
@@ -46,14 +46,14 @@ namespace psio
    concept Packable = Reflected<T> || is_packable<T>::value;
 
    template <typename T>
-   concept PackableValidatedObject = requires(T& x) { clio_validate_packable(x); };
+   concept PackableValidatedObject = requires(T& x) { psio_validate_packable(x); };
 
    template <typename T>
       requires Packable<std::remove_cv_t<T>>
    class view;
 
    template <typename T>
-   concept PackableValidatedView = requires(view<const T>& p) { clio_validate_packable(p); };
+   concept PackableValidatedView = requires(view<const T>& p) { psio_validate_packable(p); };
 
    template <typename T>
    concept PackableNumeric =            //
@@ -334,7 +334,7 @@ namespace psio
    template <PackableWrapper T>
    struct is_packable<T> : std::bool_constant<true>
    {
-      using inner = std::remove_cvref_t<decltype(clio_unwrap_packable(std::declval<T&>()))>;
+      using inner = std::remove_cvref_t<decltype(psio_unwrap_packable(std::declval<T&>()))>;
       using is_p  = is_packable<inner>;
 
       static constexpr uint32_t fixed_size        = is_p::fixed_size;
@@ -342,7 +342,7 @@ namespace psio
       static constexpr bool     is_optional       = is_p::is_optional;
       static constexpr bool     supports_0_offset = is_p::supports_0_offset;
 
-      static bool has_value(const T& value) { return is_p::has_value(clio_unwrap_packable(value)); }
+      static bool has_value(const T& value) { return is_p::has_value(psio_unwrap_packable(value)); }
       template <bool Verify>
       static bool has_value(const char* src, uint32_t pos, uint32_t end_pos)
       {
@@ -353,7 +353,7 @@ namespace psio
       static inner* ptr(T* value)
       {
          if constexpr (Unpack)
-            return &clio_unwrap_packable(*value);
+            return &psio_unwrap_packable(*value);
          else
             return nullptr;
       }
@@ -361,12 +361,12 @@ namespace psio
       template <typename S>
       static void pack(const T& value, S& stream)
       {
-         return is_p::pack(clio_unwrap_packable(value), stream);
+         return is_p::pack(psio_unwrap_packable(value), stream);
       }
 
       static bool is_empty_container(const T& value)
       {
-         return is_p::is_empty_container(clio_unwrap_packable(value));
+         return is_p::is_empty_container(psio_unwrap_packable(value));
       }
       static bool is_empty_container(const char* src, uint32_t pos, uint32_t end_pos)
       {
@@ -376,7 +376,7 @@ namespace psio
       template <typename S>
       static void embedded_fixed_pack(const T& value, S& stream)
       {
-         return is_p::embedded_fixed_pack(clio_unwrap_packable(value), stream);
+         return is_p::embedded_fixed_pack(psio_unwrap_packable(value), stream);
       }
 
       template <typename S>
@@ -385,14 +385,14 @@ namespace psio
                                         uint32_t heap_pos,
                                         S&       stream)
       {
-         return is_p::embedded_fixed_repack(clio_unwrap_packable(value), fixed_pos, heap_pos,
+         return is_p::embedded_fixed_repack(psio_unwrap_packable(value), fixed_pos, heap_pos,
                                             stream);
       }
 
       template <typename S>
       static void embedded_variable_pack(const T& value, S& stream)
       {
-         return is_p::embedded_variable_pack(clio_unwrap_packable(value), stream);
+         return is_p::embedded_variable_pack(psio_unwrap_packable(value), stream);
       }
 
       template <bool Unpack, bool Verify>
@@ -1488,18 +1488,18 @@ namespace psio
    {
       if constexpr (Unpack && PackableValidatedObject<T>)
       {
-         return clio_validate_packable(*value);
+         return psio_validate_packable(*value);
       }
       else if constexpr (!Pointer)
       {
-         return clio_validate_packable(view<const T>{prevalidated{src + orig_pos}});
+         return psio_validate_packable(view<const T>{prevalidated{src + orig_pos}});
       }
       else
       {
          std::uint32_t offset;
          std::uint32_t tmp = orig_pos;
          (void)unpack_numeric<false>(&offset, src, tmp, tmp + 4);
-         return clio_validate_packable(view<const T>{prevalidated{src + orig_pos + offset}});
+         return psio_validate_packable(view<const T>{prevalidated{src + orig_pos + offset}});
       }
    }
 

--- a/libraries/psio/include/psio/from_json.hpp
+++ b/libraries/psio/include/psio/from_json.hpp
@@ -560,7 +560,7 @@ namespace psio
 
    template <typename T>
    concept PackValidatable = requires(T obj) {
-      { clio_validate_packable(obj) } -> std::same_as<bool>;
+      { psio_validate_packable(obj) } -> std::same_as<bool>;
    };
 
    /// \output_section Parse JSON (Reflected Objects)
@@ -584,7 +584,7 @@ namespace psio
 
          if constexpr (PackValidatable<T>)
          {
-            if (!clio_validate_packable(obj))
+            if (!psio_validate_packable(obj))
             {
                check(false, std::string(psio::reflect<T>::name) + " failed unpack validation.");
             }

--- a/libraries/psio/include/psio/schema.hpp
+++ b/libraries/psio/include/psio/schema.hpp
@@ -141,13 +141,13 @@ namespace psio
       }
 
       template <typename T>
-      T& clio_unwrap_packable(Box<T>& box)
+      T& psio_unwrap_packable(Box<T>& box)
       {
          return *box;
       }
 
       template <typename T>
-      const T& clio_unwrap_packable(const Box<T>& box)
+      const T& psio_unwrap_packable(const Box<T>& box)
       {
          return *box;
       }
@@ -176,12 +176,12 @@ namespace psio
          from_json(schema.types, stream);
       }
 
-      inline auto& clio_unwrap_packable(Schema& schema)
+      inline auto& psio_unwrap_packable(Schema& schema)
       {
          return schema.types;
       }
 
-      inline const auto& clio_unwrap_packable(const Schema& schema)
+      inline const auto& psio_unwrap_packable(const Schema& schema)
       {
          return schema.types;
       }
@@ -207,12 +207,12 @@ namespace psio
          from_json_members(type.members, stream);
       }
 
-      inline auto& clio_unwrap_packable(Object& type)
+      inline auto& psio_unwrap_packable(Object& type)
       {
          return type.members;
       }
 
-      inline auto& clio_unwrap_packable(const Object& type)
+      inline auto& psio_unwrap_packable(const Object& type)
       {
          return type.members;
       }
@@ -232,12 +232,12 @@ namespace psio
          from_json_members(type.members, stream);
       }
 
-      inline auto& clio_unwrap_packable(Struct& type)
+      inline auto& psio_unwrap_packable(Struct& type)
       {
          return type.members;
       }
 
-      inline auto& clio_unwrap_packable(const Struct& type)
+      inline auto& psio_unwrap_packable(const Struct& type)
       {
          return type.members;
       }
@@ -264,11 +264,11 @@ namespace psio
          from_json(*type.type, stream);
       }
 
-      inline auto& clio_unwrap_packable(List& type)
+      inline auto& psio_unwrap_packable(List& type)
       {
          return *type.type;
       }
-      inline auto& clio_unwrap_packable(const List& type)
+      inline auto& psio_unwrap_packable(const List& type)
       {
          return *type.type;
       }
@@ -288,11 +288,11 @@ namespace psio
          from_json(*type.type, stream);
       }
 
-      inline auto& clio_unwrap_packable(Option& type)
+      inline auto& psio_unwrap_packable(Option& type)
       {
          return *type.type;
       }
-      inline auto& clio_unwrap_packable(const Option& type)
+      inline auto& psio_unwrap_packable(const Option& type)
       {
          return *type.type;
       }
@@ -335,12 +335,12 @@ namespace psio
          from_json_members(type.members, stream);
       }
 
-      inline auto& clio_unwrap_packable(Variant& type)
+      inline auto& psio_unwrap_packable(Variant& type)
       {
          return type.members;
       }
 
-      inline auto& clio_unwrap_packable(const Variant& type)
+      inline auto& psio_unwrap_packable(const Variant& type)
       {
          return type.members;
       }
@@ -360,12 +360,12 @@ namespace psio
          from_json(type.members, stream);
       }
 
-      inline auto& clio_unwrap_packable(Tuple& type)
+      inline auto& psio_unwrap_packable(Tuple& type)
       {
          return type.members;
       }
 
-      inline auto& clio_unwrap_packable(const Tuple& type)
+      inline auto& psio_unwrap_packable(const Tuple& type)
       {
          return type.members;
       }
@@ -385,11 +385,11 @@ namespace psio
          from_json(type.type, stream);
       }
 
-      inline auto& clio_unwrap_packable(FracPack& type)
+      inline auto& psio_unwrap_packable(FracPack& type)
       {
          return *type.type;
       }
-      inline auto& clio_unwrap_packable(const FracPack& type)
+      inline auto& psio_unwrap_packable(const FracPack& type)
       {
          return *type.type;
       }
@@ -413,11 +413,11 @@ namespace psio
          from_json(type.type, stream);
       }
 
-      inline auto& clio_unwrap_packable(Type& type)
+      inline auto& psio_unwrap_packable(Type& type)
       {
          return type.type;
       }
-      inline auto& clio_unwrap_packable(const Type& type)
+      inline auto& psio_unwrap_packable(const Type& type)
       {
          return type.type;
       }
@@ -465,12 +465,12 @@ namespace psio
       {
          from_json(type.value, stream);
       }
-      inline auto& clio_unwrap_packable(AnyType& type)
+      inline auto& psio_unwrap_packable(AnyType& type)
       {
          return type.value;
       }
       template <std::same_as<AnyType> T>
-      auto& clio_unwrap_packable(const T& type)
+      auto& psio_unwrap_packable(const T& type)
       {
          return type.value;
       }
@@ -1813,7 +1813,7 @@ namespace psio
                }
                else if constexpr (PackableWrapper<T>)
                {
-                  schema.insert(name, insert<std::remove_cvref_t<decltype(clio_unwrap_packable(
+                  schema.insert(name, insert<std::remove_cvref_t<decltype(psio_unwrap_packable(
                                           std::declval<T&>()))>>());
                }
                else if constexpr (is_nested_wrapper_v<T>)

--- a/libraries/psio/include/psio/view.hpp
+++ b/libraries/psio/include/psio/view.hpp
@@ -137,7 +137,7 @@ namespace psio
    concept SimplePackableWrapper =
        Reflected<T> && PackableWrapper<T> &&
        is_simple_packable_wrapper<
-           std::remove_cvref_t<decltype(clio_unwrap_packable(std::declval<T&>()))>,
+           std::remove_cvref_t<decltype(psio_unwrap_packable(std::declval<T&>()))>,
            typename reflect<T>::data_members>;
 
    template <typename Ch>

--- a/libraries/psio/tests/generate_test_data.cpp
+++ b/libraries/psio/tests/generate_test_data.cpp
@@ -135,11 +135,11 @@ struct V1
    std::uint8_t v0;
 };
 PSIO_REFLECT_TYPENAME(V1)
-auto& clio_unwrap_packable(V1& v1)
+auto& psio_unwrap_packable(V1& v1)
 {
    return v1.v0;
 }
-auto& clio_unwrap_packable(const V1& v1)
+auto& psio_unwrap_packable(const V1& v1)
 {
    return v1.v0;
 }
@@ -261,11 +261,11 @@ struct Untagged
    std::string value;
 };
 PSIO_REFLECT_TYPENAME(Untagged)
-auto& clio_unwrap_packable(Untagged& obj)
+auto& psio_unwrap_packable(Untagged& obj)
 {
    return obj.value;
 }
-auto& clio_unwrap_packable(const Untagged& obj)
+auto& psio_unwrap_packable(const Untagged& obj)
 {
    return obj.value;
 }

--- a/libraries/psio/tests/test_fracpack.hpp
+++ b/libraries/psio/tests/test_fracpack.hpp
@@ -296,12 +296,12 @@ struct packable_wrapper
 template <typename T>
 packable_wrapper(T) -> packable_wrapper<T>;
 template <typename T>
-const T& clio_unwrap_packable(const packable_wrapper<T>& wrapper)
+const T& psio_unwrap_packable(const packable_wrapper<T>& wrapper)
 {
    return wrapper.value;
 }
 template <typename T>
-T& clio_unwrap_packable(packable_wrapper<T>& wrapper)
+T& psio_unwrap_packable(packable_wrapper<T>& wrapper)
 {
    return wrapper.value;
 }

--- a/packages/local/XAdmin/include/services/local/XAdmin.hpp
+++ b/packages/local/XAdmin/include/services/local/XAdmin.hpp
@@ -35,11 +35,11 @@ namespace LocalService
          psibase::AccountNumber value;
       };
       PSIO_REFLECT_TYPENAME(Account)
-      inline auto& clio_unwrap_packable(Account& obj)
+      inline auto& psio_unwrap_packable(Account& obj)
       {
          return obj.value;
       }
-      inline const auto& clio_unwrap_packable(const Account& obj)
+      inline const auto& psio_unwrap_packable(const Account& obj)
       {
          return obj.value;
       }
@@ -49,11 +49,11 @@ namespace LocalService
          std::string value;
       };
       PSIO_REFLECT_TYPENAME(LocalUsername)
-      inline auto& clio_unwrap_packable(LocalUsername& obj)
+      inline auto& psio_unwrap_packable(LocalUsername& obj)
       {
          return obj.value;
       }
-      inline const auto& clio_unwrap_packable(const LocalUsername& obj)
+      inline const auto& psio_unwrap_packable(const LocalUsername& obj)
       {
          return obj.value;
       }

--- a/packages/system/AuthSig/include/services/system/Spki.hpp
+++ b/packages/system/AuthSig/include/services/system/Spki.hpp
@@ -26,15 +26,15 @@ namespace SystemService
 
       PSIBASE_REFLECT_KEY_TRANSFORM(&SubjectPublicKeyInfo::fingerprint, "sha256-key-fingerprint")
 
-      inline std::vector<unsigned char>& clio_unwrap_packable(SubjectPublicKeyInfo& obj)
+      inline std::vector<unsigned char>& psio_unwrap_packable(SubjectPublicKeyInfo& obj)
       {
          return obj.data;
       }
-      inline const std::vector<unsigned char>& clio_unwrap_packable(const SubjectPublicKeyInfo& obj)
+      inline const std::vector<unsigned char>& psio_unwrap_packable(const SubjectPublicKeyInfo& obj)
       {
          return obj.data;
       }
-      inline bool clio_validate_packable(const SubjectPublicKeyInfo& obj)
+      inline bool psio_validate_packable(const SubjectPublicKeyInfo& obj)
       {
          return SubjectPublicKeyInfo::validate(obj.data);
       }

--- a/packages/user/Tokens/include/services/user/tokenTypes.hpp
+++ b/packages/user/Tokens/include/services/user/tokenTypes.hpp
@@ -41,21 +41,21 @@ namespace UserService
       PSIO_REFLECT(Precision, value);
    };
 
-   inline uint8_t& clio_unwrap_packable(Precision& s)
+   inline uint8_t& psio_unwrap_packable(Precision& s)
    {
       return s.value;
    }
-   inline const uint8_t& clio_unwrap_packable(const Precision& s)
+   inline const uint8_t& psio_unwrap_packable(const Precision& s)
    {
       return s.value;
    }
 
-   inline bool clio_validate_packable(const Precision& p)
+   inline bool psio_validate_packable(const Precision& p)
    {
       return Precision::validate(p.value);
    }
 
-   inline bool clio_validate_packable(psio::view<const Precision> p)
+   inline bool psio_validate_packable(psio::view<const Precision> p)
    {
       return Precision::validate(p.value());
    }

--- a/rust/test_fracpack/tests/test.hpp
+++ b/rust/test_fracpack/tests/test.hpp
@@ -32,11 +32,11 @@
       using psio::from_json;                                      \
       from_json(obj.value, stream);                               \
    }                                                              \
-   inline auto& clio_unwrap_packable(Name& obj)                   \
+   inline auto& psio_unwrap_packable(Name& obj)                   \
    {                                                              \
       return obj.value;                                           \
    }                                                              \
-   inline const auto& clio_unwrap_packable(const Name& obj)       \
+   inline const auto& psio_unwrap_packable(const Name& obj)       \
    {                                                              \
       return obj.value;                                           \
    }


### PR DESCRIPTION
clio is a very old name that predates psibase.