### PR TITLE
Remove EventTrace

### DIFF
--- a/libraries/psibase/common/include/psibase/trace.hpp
+++ b/libraries/psibase/common/include/psibase/trace.hpp
@@ -19,14 +19,6 @@ namespace psibase
    };
    PSIO_REFLECT(ActionTrace, action, rawRetval, innerTraces, totalTime, error)
 
-   // TODO: need event definitions in ABI
-   struct EventTrace
-   {
-      std::string       name;
-      std::vector<char> data;
-   };
-   PSIO_REFLECT(EventTrace, name, data)
-
    struct ConsoleTrace
    {
       std::string console;
@@ -35,7 +27,7 @@ namespace psibase
 
    struct InnerTrace
    {
-      std::variant<ConsoleTrace, EventTrace, ActionTrace> inner;
+      std::variant<ConsoleTrace, ActionTrace> inner;
    };
    PSIO_REFLECT(InnerTrace, inner)
 
@@ -62,10 +54,6 @@ namespace psibase
                            const ConsoleTrace& t,
                            const GetSchemaFn&  schemas = NoSchema{},
                            const std::string&  indent  = "");
-   void        prettyTrace(std::string&       dest,
-                           const EventTrace&  t,
-                           const GetSchemaFn& schemas = NoSchema{},
-                           const std::string& indent  = "");
    void        prettyTrace(std::string&       dest,
                            const ActionTrace& atrace,
                            const GetSchemaFn& schemas = NoSchema{},

--- a/libraries/psibase/common/src/trace.cpp
+++ b/libraries/psibase/common/src/trace.cpp
@@ -121,10 +121,6 @@ namespace psibase
       {
          return false;
       }
-      bool hideTrace(const EventTrace& trace)
-      {
-         return false;
-      }
 
       struct PrettyServiceMethod
       {
@@ -301,14 +297,6 @@ namespace psibase
    {
       dest += indent + "console:    ";
       prettyTrace(dest, t.console, indent + "            ");
-   }
-
-   void prettyTrace(std::string&       dest,
-                    const EventTrace&  t,
-                    const GetSchemaFn& schemas,
-                    const std::string& indent)
-   {
-      dest += indent + "event\n";
    }
 
    void prettyTrace(std::string&       dest,

--- a/libraries/psibase/native/src/log.cpp
+++ b/libraries/psibase/native/src/log.cpp
@@ -2693,7 +2693,6 @@ namespace psibase::loggers
          };
       };
 
-      void print_trace_console(boost::log::formatting_ostream& os, const EventTrace& trace) {}
       void print_trace_console(boost::log::formatting_ostream& os, const ConsoleTrace& trace)
       {
          os << trace.console;

--- a/packages/local/XAdmin/ui/src/lib/action-stack.ts
+++ b/packages/local/XAdmin/ui/src/lib/action-stack.ts
@@ -9,7 +9,6 @@ interface Action {
 interface InnerTrace {
     ActionTrace?: ActionTrace;
     ConsoleTrace?: any;
-    EventTrace?: any;
 }
 
 interface ActionTrace {

--- a/packages/system/Transact/src/RTransact.cpp
+++ b/packages/system/Transact/src/RTransact.cpp
@@ -176,13 +176,6 @@ namespace
       };
       PSIO_REFLECT(ActionTrace, action, rawRetval, innerTraces, totalTime, error)
 
-      struct EventTrace
-      {
-         std::string_view      name;
-         std::span<const char> data;
-      };
-      PSIO_REFLECT(EventTrace, name, data)
-
       struct ConsoleTrace
       {
          std::string_view console;
@@ -191,7 +184,7 @@ namespace
 
       struct InnerTrace
       {
-         std::variant<ConsoleTrace, EventTrace, ActionTrace> inner;
+         std::variant<ConsoleTrace, ActionTrace> inner;
       };
       PSIO_REFLECT(InnerTrace, inner)
 
@@ -204,7 +197,6 @@ namespace
    }  // namespace refs
    using ActionRef           = refs::Action;
    using ActionTraceRef      = refs::ActionTrace;
-   using EventTraceRef       = refs::EventTrace;
    using ConsoleTraceRef     = refs::ConsoleTrace;
    using InnerTraceRef       = refs::InnerTrace;
    using TransactionTraceRef = refs::TransactionTrace;
@@ -235,10 +227,6 @@ namespace
       auto operator()(psio::view<const ConsoleTrace> trace)
       {
          return ConsoleTraceRef{trace.console()};
-      }
-      auto operator()(psio::view<const EventTrace> trace)
-      {
-         return EventTraceRef{trace.name(), trace.data()};
       }
       auto operator()(psio::view<const ActionTrace> at)
       {

--- a/rust/psibase/src/trace.rs
+++ b/rust/psibase/src/trace.rs
@@ -41,14 +41,6 @@ impl fmt::Display for ActionTrace {
 #[derive(Debug, Clone, Pack, Unpack, Serialize, Deserialize)]
 #[fracpack(fracpack_mod = "fracpack")]
 #[serde(rename_all = "camelCase")]
-pub struct EventTrace {
-    pub name: String,
-    pub data: Hex<Vec<u8>>,
-}
-
-#[derive(Debug, Clone, Pack, Unpack, Serialize, Deserialize)]
-#[fracpack(fracpack_mod = "fracpack")]
-#[serde(rename_all = "camelCase")]
 pub struct ConsoleTrace {
     pub console: String,
 }
@@ -57,7 +49,6 @@ pub struct ConsoleTrace {
 #[fracpack(fracpack_mod = "fracpack")]
 pub enum InnerTraceEnum {
     ConsoleTrace(ConsoleTrace),
-    EventTrace(EventTrace),
     ActionTrace(ActionTrace),
 }
 
@@ -165,7 +156,6 @@ fn write_action_console(atrace: &ActionTrace, f: &mut fmt::Formatter<'_>) -> fmt
     for inner in &atrace.inner_traces {
         match &inner.inner {
             InnerTraceEnum::ConsoleTrace(c) => write!(f, "{}", &c.console)?,
-            InnerTraceEnum::EventTrace(_) => {}
             InnerTraceEnum::ActionTrace(a) => write_action_console(a, f)?,
         }
     }
@@ -187,10 +177,6 @@ fn format_console(c: &ConsoleTrace, indent: usize, f: &mut fmt::Formatter<'_>) -
     write!(f, "{:indent$}console:    ", "")?;
     format_string(&c.console, indent + 12, f)?;
     writeln!(f)
-}
-
-fn format_event(_: &EventTrace, indent: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    writeln!(f, "{:indent$}event", "")
 }
 
 fn hide_action(action: &Action) -> bool {
@@ -270,7 +256,6 @@ fn format_action_trace(
     for inner in &atrace.inner_traces {
         match &inner.inner {
             InnerTraceEnum::ConsoleTrace(c) => format_console(c, indent + 4, f)?,
-            InnerTraceEnum::EventTrace(e) => format_event(e, indent + 4, f)?,
             InnerTraceEnum::ActionTrace(a) => format_action_trace(schemas, a, indent + 4, f)?,
         }
     }
@@ -481,7 +466,6 @@ fn format_error_stack<T: std::fmt::Write>(
         for inner in &atrace.inner_traces {
             match &inner.inner {
                 InnerTraceEnum::ConsoleTrace(_) => (),
-                InnerTraceEnum::EventTrace(_) => (),
                 InnerTraceEnum::ActionTrace(a) => format_error_stack(schemas, a, f)?,
             }
         }
@@ -608,9 +592,6 @@ impl<'a, F: SchemaFetcher + 'a> ActionFormatter<'a, F> {
         }
         Ok(())
     }
-    pub async fn prepare_event_trace(&self, _etrace: &EventTrace) -> Result<(), anyhow::Error> {
-        Ok(())
-    }
     pub async fn prepare_action_impl<'b>(
         &self,
         act: SharedAction<'b>,
@@ -675,7 +656,6 @@ impl<'a, F: SchemaFetcher + 'a> ActionFormatter<'a, F> {
         }
         for inner in &atrace.inner_traces {
             match &inner.inner {
-                InnerTraceEnum::EventTrace(e) => res = res.and(self.prepare_event_trace(e).await),
                 InnerTraceEnum::ActionTrace(a) => {
                     res = res.and(Box::pin(self.prepare_action_trace(a)).await)
                 }
@@ -944,9 +924,6 @@ impl<'a, 'b> Serialize for UnpackedTrace<'a, &'b InnerTraceEnum> {
         match self.value {
             InnerTraceEnum::ConsoleTrace(trace) => {
                 serializer.serialize_newtype_variant("InnerTraceEnum", 0, "ConsoleTrace", trace)
-            }
-            InnerTraceEnum::EventTrace(trace) => {
-                serializer.serialize_newtype_variant("InnerTraceEnum", 1, "EventTrace", trace)
             }
             InnerTraceEnum::ActionTrace(trace) => serializer.serialize_newtype_variant(
                 "InnerTraceEnum",


### PR DESCRIPTION
It was never used even when native events were a thing. Now that events are implemented in wasm, it won't be used ever.