### PR TITLE
Hide reflection in docs

### DIFF
--- a/rust/gen-cpp-doc/src/main.rs
+++ b/rust/gen-cpp-doc/src/main.rs
@@ -101,6 +101,11 @@ fn convert_children<'a, 'tu>(items: &'a mut Vec<Item<'tu>>, current: usize, enti
 }
 
 fn include_docs<'tu>(entity: &Entity<'tu>) -> bool {
+    if let Some(name) = entity.get_name() {
+        if name.as_str() == "psio_get_reflect_impl" {
+            return false;
+        }
+    }
     let doc_str = convert_doc_str(&entity.get_parsed_comment());
     !doc_str.contains("[[doc(hidden)]]")
 }


### PR DESCRIPTION
`psio_get_reflect_impl` is an implementation detail of `PSIO_REFLECT`.