### PR TITLE
fix redirection after peering

### DIFF
--- a/packages/local/XAdmin/ui/src/components/forms/smart-connect-form.tsx
+++ b/packages/local/XAdmin/ui/src/components/forms/smart-connect-form.tsx
@@ -1,7 +1,3 @@
-import { queryKeys } from "@/lib/query-keys";
-
-import { queryClient } from "@shared/lib/query-client";
-
 import { Schema, UrlForm } from "../../components/forms/url";
 import { useToast } from "../../components/ui/use-toast";
 import { useConnect } from "../../hooks/use-connect";
@@ -16,7 +12,6 @@ export const SmartConnectForm = ({ onConnection }: Props) => {
 
     const onSubmit = async (data: Schema) => {
         const res = await connect(data);
-        queryClient.invalidateQueries({ queryKey: queryKeys.config });
         toast({
             title: "Success",
             description: `Connected to ${res.urls[0] || res.endpoint}.`,

--- a/packages/local/XAdmin/ui/src/hooks/use-connect.ts
+++ b/packages/local/XAdmin/ui/src/hooks/use-connect.ts
@@ -20,4 +20,9 @@ export const useConnect = () =>
                 throw new Error("Failed connecting to node");
             }
         },
+        onSuccess: (_data, _variables, _onMutateResult, context) => {
+            context.client.invalidateQueries({ queryKey: queryKeys.statuses });
+            context.client.invalidateQueries({ queryKey: queryKeys.config });
+            context.client.invalidateQueries({ queryKey: queryKeys.peers });
+        },
     });

--- a/packages/local/XAdmin/ui/src/pages/join-page.tsx
+++ b/packages/local/XAdmin/ui/src/pages/join-page.tsx
@@ -19,7 +19,7 @@ export const JoinPage = () => {
             title: "Success",
             description: `Connected to ${res.urls[0] || res.endpoint}.`,
         });
-        navigate("/");
+        navigate("/dashboard");
     };
 
     return (


### PR DESCRIPTION
After successfully peering, the redirect was going to `/`, which was then redirecting to the node setup wizard because of a cached `needgenesis`.

This fixes that so that after peering we redirect to the xadmin dashboard.