### PR TITLE
Whitelisting packages in/for Sites upload

### DIFF
--- a/packages/user/Sites/plugin/src/lib.rs
+++ b/packages/user/Sites/plugin/src/lib.rs
@@ -62,7 +62,7 @@ impl Sites for SitesPlugin {
     fn upload(file: File, compression_quality: u8) -> Result<(), Error> {
         assert_authorized_with_whitelist(
             FunctionName::upload,
-            vec!["workshop".into(), "profiles".into()],
+            vec!["workshop".into(), "profiles".into(), "packages".into()],
         )?;
 
         validate_compression_quality(compression_quality)?;


### PR DESCRIPTION
This is fixing an issue on main that appears unrelated to my recent branch / work on CSP/Packages. I asked AI where this might have originated, and after exploring git history, it seems this has been around for a while on `main`.
TokenSwap required a whitelisting like this but was only applied to `upload_encoded`. This applies the same to `upload`

This solves the problem you (Brandon) saw on Workshop and TokenSwap but not the larger .psi packages (Docs, Evaluations, etc.)