### PR TITLE
auto select/unselect dependent packages in config

### DIFF
--- a/packages/local/XAdmin/ui/src/hooks/use-selected-rows.ts
+++ b/packages/local/XAdmin/ui/src/hooks/use-selected-rows.ts
@@ -6,6 +6,8 @@ import { getId } from "@/lib/get-id";
 import { getRequiredPackages } from "@/lib/get-required-packages";
 import { detectChange } from "@/lib/row-elements";
 
+import { transitivePkgDependants } from "@shared/lib/transitive-pkg-dependants";
+
 import { PackageInfo, PackageInfoSchema } from "../types";
 
 interface ChangeWarning {
@@ -18,45 +20,15 @@ const ChangeWarningSchema = z.object({
     removedPackage: PackageInfoSchema,
 });
 
-const getTransitiveDependants = (
-    removingPackageName: string,
-    selectedPackages: PackageInfo[],
-): PackageInfo[] => {
-    const reverseDeps = new Map<string, PackageInfo[]>();
-    for (const pack of selectedPackages) {
-        for (const dep of pack.depends) {
-            const list = reverseDeps.get(dep.name) ?? [];
-            list.push(pack);
-            reverseDeps.set(dep.name, list);
-        }
-    }
-
-    const dependants = new Map<string, PackageInfo>();
-    const queue = [removingPackageName];
-
-    while (queue.length > 0) {
-        const current = queue.shift()!;
-        for (const pack of reverseDeps.get(current) ?? []) {
-            if (
-                pack.name !== removingPackageName &&
-                !dependants.has(pack.name)
-            ) {
-                dependants.set(pack.name, pack);
-                queue.push(pack.name);
-            }
-        }
-    }
-
-    return [...dependants.values()];
-};
-
 const getChangeWarning = (
     removingPackagename: string,
     selectedPackages: PackageInfo[],
 ) => {
-    const dependants = getTransitiveDependants(
+    const dependants = transitivePkgDependants(
         removingPackagename,
         selectedPackages,
+        (pack) => pack.name,
+        (pack) => pack.depends.map((dep) => dep.name),
     );
 
     if (dependants.length > 0) {

--- a/packages/shared-ui/lib/transitive-pkg-dependants.ts
+++ b/packages/shared-ui/lib/transitive-pkg-dependants.ts
@@ -1,0 +1,29 @@
+export function transitivePkgDependants<T>(
+    name: string,
+    items: T[],
+    id: (item: T) => string,
+    depends: (item: T) => readonly string[],
+): T[] {
+    const reverse = new Map<string, T[]>();
+    for (const item of items) {
+        for (const dep of depends(item)) {
+            const list = reverse.get(dep) ?? [];
+            list.push(item);
+            reverse.set(dep, list);
+        }
+    }
+
+    const dependants = new Map<string, T>();
+    const queue = [name];
+    while (queue.length > 0) {
+        const current = queue.shift()!;
+        for (const item of reverse.get(current) ?? []) {
+            const itemId = id(item);
+            if (itemId !== name && !dependants.has(itemId)) {
+                dependants.set(itemId, item);
+                queue.push(itemId);
+            }
+        }
+    }
+    return [...dependants.values()];
+}

--- a/packages/user/Config/ui/src/hooks/use-install-packages.ts
+++ b/packages/user/Config/ui/src/hooks/use-install-packages.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import { z } from "zod";
 
 import { getArrayBuffer } from "@psibase/common-lib";
 
@@ -12,19 +13,38 @@ import { toast } from "@shared/shadcn/ui/sonner";
 
 import {
     PackageRepo,
-    PackageSchemaWithSha,
     getPackageIndex,
+    zPackageSchemaWithSha,
 } from "./use-available-packages";
 
-type PackageOp = {
-    old?: unknown;
-    new?: PackageSchemaWithSha;
-};
+const zPackageOp = z.object({
+    old: z.unknown().optional(),
+    new: zPackageSchemaWithSha.nullish(),
+});
+
+type PackageOp = z.infer<typeof zPackageOp>;
 
 type PackageInstallOp = {
     old?: unknown;
     new?: ArrayBuffer;
 };
+
+async function resolvePackageOps(
+    owner: string,
+    packages: string[],
+    requestPref: string,
+    nonRequestPref: string,
+): Promise<PackageOp[]> {
+    const index = flattenPackageIndex(await getPackageIndex(owner));
+    return zPackageOp.array().parse(
+        await supervisor.functionCall({
+            service: "packages",
+            intf: "privateApi",
+            method: "resolve",
+            params: [index, packages, requestPref, nonRequestPref],
+        }),
+    );
+}
 
 async function installPackages(
     owner: string,
@@ -32,13 +52,12 @@ async function installPackages(
     request_pref: string,
     non_request_pref: string,
 ) {
-    const index = flattenPackageIndex(await getPackageIndex(owner));
-    const resolved = (await supervisor.functionCall({
-        service: "packages",
-        intf: "privateApi",
-        method: "resolve",
-        params: [index, packages, request_pref, non_request_pref],
-    })) as PackageOp[];
+    const resolved = await resolvePackageOps(
+        owner,
+        packages,
+        request_pref,
+        non_request_pref,
+    );
     const ops = await loadPackages(resolved);
     const [data, install] = (await supervisor.functionCall({
         service: "packages",
@@ -71,6 +90,13 @@ function flattenPackageIndex(index: PackageRepo[]) {
             file: new URL(info.file, repo.baseUrl).toString(),
         })),
     );
+}
+
+export async function resolveRequiredPackageNames(
+    packages: string[],
+): Promise<string[]> {
+    const resolved = await resolvePackageOps("root", packages, "best", "current");
+    return [...new Set(resolved.flatMap((op) => (op.new ? [op.new.name] : [])))];
 }
 
 async function loadPackages(ops: PackageOp[]): Promise<PackageInstallOp[]> {

--- a/packages/user/Config/ui/src/hooks/use-selected-packages.ts
+++ b/packages/user/Config/ui/src/hooks/use-selected-packages.ts
@@ -1,0 +1,71 @@
+import { useState } from "react";
+
+import { transitiveDependants } from "@/lib/package-dependants";
+import { ProcessedPackage } from "@/lib/zod/common-package";
+
+import { toast } from "@shared/shadcn/ui/sonner";
+
+import { resolveRequiredPackageNames } from "./use-install-packages";
+
+const toSelectedIds = (names: string[]) =>
+    Object.fromEntries(names.map((name) => [name, true]));
+
+export const useSelectedPackages = (packages: ProcessedPackage[]) => {
+    const [requested, setRequested] = useState<string[]>([]);
+    const [selectedIds, setSelectedIds] = useState<{ [key: string]: boolean }>(
+        {},
+    );
+    const [resolvingId, setResolvingId] = useState<string>();
+
+    const selectedPackageNames = Object.entries(selectedIds)
+        .filter((pack) => pack[1])
+        .map(([name]) => name);
+
+    const applyRequested = async (nextRequested: string[]) => {
+        const unique = [...new Set(nextRequested)];
+        if (unique.length === 0) {
+            setRequested([]);
+            setSelectedIds({});
+            return;
+        }
+        const required = await resolveRequiredPackageNames(unique);
+        setRequested(unique);
+        setSelectedIds(toSelectedIds(required));
+    };
+
+    const onSelect = async (id: string) => {
+        setResolvingId(id);
+        try {
+            if (selectedIds[id]) {
+                const toDrop = new Set([
+                    id,
+                    ...transitiveDependants(id, requested, packages),
+                ]);
+                await applyRequested(requested.filter((name) => !toDrop.has(name)));
+            } else {
+                await applyRequested([...requested, id]);
+            }
+        } catch (error) {
+            toast.error("Failed resolving dependencies", {
+                description:
+                    error instanceof Error ? error.message : String(error),
+            });
+        } finally {
+            setResolvingId(undefined);
+        }
+    };
+
+    const clear = () => {
+        setRequested([]);
+        setSelectedIds({});
+    };
+
+    return {
+        selectedIds,
+        selectedPackageNames,
+        requestedPackageNames: requested,
+        onSelect,
+        clear,
+        resolvingId,
+    };
+};

--- a/packages/user/Config/ui/src/hooks/use-selected-packages.ts
+++ b/packages/user/Config/ui/src/hooks/use-selected-packages.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { transitiveDependants } from "@/lib/package-dependants";
+import { transitivePkgDependants } from "@/lib/package-dependants";
 import { ProcessedPackage } from "@/lib/zod/common-package";
 
 import { toast } from "@shared/shadcn/ui/sonner";
@@ -39,7 +39,7 @@ export const useSelectedPackages = (packages: ProcessedPackage[]) => {
             if (selectedIds[id]) {
                 const toDrop = new Set([
                     id,
-                    ...transitiveDependants(id, requested, packages),
+                    ...transitivePkgDependants(id, requested, packages),
                 ]);
                 await applyRequested(requested.filter((name) => !toDrop.has(name)));
             } else {

--- a/packages/user/Config/ui/src/lib/package-dependants.ts
+++ b/packages/user/Config/ui/src/lib/package-dependants.ts
@@ -1,0 +1,44 @@
+import { ProcessedPackage } from "@/lib/zod/common-package";
+
+export function dependsOf(pack: ProcessedPackage): string[] {
+    const meta =
+        pack.status === "UpdateAvailable"
+            ? pack.available
+            : pack.status === "RollBackAvailable"
+              ? pack.rollback
+              : pack;
+    return meta.depends.map((dep) => dep.name);
+}
+
+export function transitiveDependants(
+    name: string,
+    selected: string[],
+    packages: ProcessedPackage[],
+): string[] {
+    const byName = new Map(packages.map((pack) => [pack.id, pack]));
+    const reverse = new Map<string, string[]>();
+    for (const id of selected) {
+        const pack = byName.get(id);
+        if (!pack) {
+            continue;
+        }
+        for (const dep of dependsOf(pack)) {
+            const list = reverse.get(dep) ?? [];
+            list.push(id);
+            reverse.set(dep, list);
+        }
+    }
+
+    const dependants = new Set<string>();
+    const queue = [name];
+    while (queue.length > 0) {
+        const current = queue.shift()!;
+        for (const dependant of reverse.get(current) ?? []) {
+            if (dependant !== name && !dependants.has(dependant)) {
+                dependants.add(dependant);
+                queue.push(dependant);
+            }
+        }
+    }
+    return [...dependants];
+}

--- a/packages/user/Config/ui/src/lib/package-dependants.ts
+++ b/packages/user/Config/ui/src/lib/package-dependants.ts
@@ -1,5 +1,7 @@
 import { ProcessedPackage } from "@/lib/zod/common-package";
 
+import { transitivePkgDependants as walkPkgDependants } from "@shared/lib/transitive-pkg-dependants";
+
 export function dependsOf(pack: ProcessedPackage): string[] {
     const meta =
         pack.status === "UpdateAvailable"
@@ -10,35 +12,17 @@ export function dependsOf(pack: ProcessedPackage): string[] {
     return meta.depends.map((dep) => dep.name);
 }
 
-export function transitiveDependants(
+export function transitivePkgDependants(
     name: string,
     selected: string[],
     packages: ProcessedPackage[],
 ): string[] {
     const byName = new Map(packages.map((pack) => [pack.id, pack]));
-    const reverse = new Map<string, string[]>();
-    for (const id of selected) {
+    const items = selected.flatMap((id) => {
         const pack = byName.get(id);
-        if (!pack) {
-            continue;
-        }
-        for (const dep of dependsOf(pack)) {
-            const list = reverse.get(dep) ?? [];
-            list.push(id);
-            reverse.set(dep, list);
-        }
-    }
-
-    const dependants = new Set<string>();
-    const queue = [name];
-    while (queue.length > 0) {
-        const current = queue.shift()!;
-        for (const dependant of reverse.get(current) ?? []) {
-            if (dependant !== name && !dependants.has(dependant)) {
-                dependants.add(dependant);
-                queue.push(dependant);
-            }
-        }
-    }
-    return [...dependants];
+        return pack ? [pack] : [];
+    });
+    return walkPkgDependants(name, items, (pack) => pack.id, dependsOf).map(
+        (pack) => pack.id,
+    );
 }

--- a/packages/user/Config/ui/src/pages/packages.tsx
+++ b/packages/user/Config/ui/src/pages/packages.tsx
@@ -5,6 +5,7 @@ import { PackageItem } from "@/components/package-item";
 
 import { useInstallPackages } from "@/hooks/use-install-packages";
 import { usePackages } from "@/hooks/use-packages";
+import { useSelectedPackages } from "@/hooks/use-selected-packages";
 import { useSetAccountSources } from "@/hooks/use-set-sources";
 import { useSources } from "@/hooks/use-sources";
 
@@ -29,24 +30,18 @@ export const Packages = () => {
     const { data: sources } = useSources();
     const [showModal, setShowModal] = useState(false);
 
-    const [selectedIds, setSelectedIds] = useState<{ [key: string]: boolean }>(
-        {},
-    );
-
-    const selectedPackageNames = Object.entries(selectedIds)
-        .filter((pack) => pack[1])
-        .map(([name]) => name);
-
-    const onSelect = (id: string) => {
-        setSelectedIds((current) => ({
-            ...current,
-            [id]: !current[id],
-        }));
-    };
+    const {
+        selectedIds,
+        selectedPackageNames,
+        requestedPackageNames,
+        onSelect,
+        clear,
+        resolvingId,
+    } = useSelectedPackages(data);
 
     const onInstall = async () => {
-        await installPackages(selectedPackageNames);
-        setSelectedIds({});
+        await installPackages(requestedPackageNames);
+        clear();
     };
 
     const form = useAppForm({
@@ -58,7 +53,7 @@ export const Packages = () => {
             await setAccountSources([
                 zAccount.array().parse(data.value.accounts),
             ]);
-            setSelectedIds({});
+            clear();
         },
     });
 
@@ -93,6 +88,7 @@ export const Packages = () => {
                                     onClick={() => onInstall()}
                                     disabled={
                                         isPending ||
+                                        Boolean(resolvingId) ||
                                         selectedPackageNames.length == 0
                                     }
                                 >
@@ -200,12 +196,13 @@ export const Packages = () => {
                             <PackageItem
                                 pack={pack}
                                 isSelected={selectedIds[pack.id]}
-                                onClick={(id) => {
-                                    onSelect(id);
-                                }}
+                                onClick={onSelect}
                                 key={pack.id}
                                 isLoading={isLoading && selectedIds[pack.id]}
-                                isMutating={isPending && selectedIds[pack.id]}
+                                isMutating={
+                                    (isPending && selectedIds[pack.id]) ||
+                                    resolvingId === pack.id
+                                }
                             />
                         ))}
                     </div>


### PR DESCRIPTION
Fractaltester was failing to install, and then I realized it was because it was pulling in the fractalgen package, which needs to be installed at boot. The UI did not represent that the fractalgen package was also being installed. This fixes that and now selecting a package also selects any dependent packages. unselecting a dependent package also unselects the depender package.