### PR TITLE
Authdelegate getowner returns optional

### DIFF
--- a/packages/system/AuthDelegate/include/services/system/AuthDelegate.hpp
+++ b/packages/system/AuthDelegate/include/services/system/AuthDelegate.hpp
@@ -98,8 +98,8 @@ namespace SystemService
       /// already owned by the specified owner.
       bool newAccount(psibase::AccountNumber name, psibase::AccountNumber owner, bool requireMatch);
 
-      /// Gets the owner account of the specified account
-      psibase::AccountNumber getOwner(psibase::AccountNumber account);
+      /// Returns the owner of `account`, if any
+      std::optional<psibase::AccountNumber> getOwner(psibase::AccountNumber account);
 
      private:
       psibase::Actor<AuthInterface> authServiceOf(psibase::AccountNumber account);

--- a/packages/system/AuthDelegate/include/services/system/AuthDelegate.hpp
+++ b/packages/system/AuthDelegate/include/services/system/AuthDelegate.hpp
@@ -101,6 +101,11 @@ namespace SystemService
       /// Returns the owner of `account`, if any
       std::optional<psibase::AccountNumber> getOwner(psibase::AccountNumber account);
 
+      /// Returns the owner of `account`
+      ///
+      /// Aborts if the account has no owner.
+      psibase::AccountNumber checkOwner(psibase::AccountNumber account);
+
      private:
       psibase::Actor<AuthInterface> authServiceOf(psibase::AccountNumber account);
    };
@@ -112,7 +117,8 @@ namespace SystemService
                 method(isRejectSys, sender, rejecters),
                 method(setOwner, owner),
                 method(newAccount, name, owner, requireMatch),
-                method(getOwner, owner)
+                method(getOwner, owner),
+                method(checkOwner, owner)
                 //
    )
    PSIBASE_REFLECT_TABLES(AuthDelegate, AuthDelegate::Tables)

--- a/packages/system/AuthDelegate/src/AuthDelegate.cpp
+++ b/packages/system/AuthDelegate/src/AuthDelegate.cpp
@@ -18,36 +18,42 @@ namespace SystemService
                                    std::vector<Claim>         claims)
    {
       auto owner = getOwner(sender);
+      check(owner.has_value(), "account does not have an owning account");
 
-      if (requester == owner)
+      if (requester == *owner)
          flags = (flags & ~AuthInterface::requestMask) | AuthInterface::runAsRequesterReq;
 
       auto _ = recurse();
-      return authServiceOf(owner).checkAuthSys(flags, requester, owner, std::move(action),
-                                               std::move(allowedActions), std::move(claims));
+      return authServiceOf(*owner).checkAuthSys(flags, requester, *owner, std::move(action),
+                                                std::move(allowedActions), std::move(claims));
    }
 
    void AuthDelegate::canAuthUserSys(psibase::AccountNumber user)
    {
-      // Asserts if no owner is set for the user
-      getOwner(user);
+      check(getOwner(user).has_value(), "account does not have an owning account");
    }
 
    std::vector<AccountNumber> AuthDelegate::getDlgsSys(psibase::AccountNumber sender)
    {
-      return {getOwner(sender)};
+      auto owner = getOwner(sender);
+      check(owner.has_value(), "account does not have an owning account");
+      return {*owner};
    }
 
    bool AuthDelegate::isAuthSys(psibase::AccountNumber              sender,
                                 std::vector<psibase::AccountNumber> authorizers)
    {
-      return std::ranges::contains(authorizers, getOwner(sender));
+      auto owner = getOwner(sender);
+      check(owner.has_value(), "account does not have an owning account");
+      return std::ranges::contains(authorizers, *owner);
    }
 
    bool AuthDelegate::isRejectSys(psibase::AccountNumber              sender,
                                   std::vector<psibase::AccountNumber> rejecters)
    {
-      return std::ranges::contains(rejecters, getOwner(sender));
+      auto owner = getOwner(sender);
+      check(owner.has_value(), "account does not have an owning account");
+      return std::ranges::contains(rejecters, *owner);
    }
 
    void AuthDelegate::setOwner(psibase::AccountNumber owner)
@@ -65,11 +71,11 @@ namespace SystemService
       table.put(AuthDelegateRecord{.account = getSender(), .owner = owner});
    }
 
-   psibase::AccountNumber AuthDelegate::getOwner(psibase::AccountNumber account)
+   std::optional<AccountNumber> AuthDelegate::getOwner(psibase::AccountNumber account)
    {
-      auto row = open<AuthDelegateTable>(KvMode::read).getIndex<0>().get(account);
-      check(row.has_value(), "account does not have an owning account");
-      return row->owner;
+      if (auto row = open<AuthDelegateTable>(KvMode::read).getIndex<0>().get(account))
+         return row->owner;
+      return std::nullopt;
    }
 
    Actor<AuthInterface> AuthDelegate::authServiceOf(psibase::AccountNumber account)

--- a/packages/system/AuthDelegate/src/AuthDelegate.cpp
+++ b/packages/system/AuthDelegate/src/AuthDelegate.cpp
@@ -17,43 +17,36 @@ namespace SystemService
                                    std::vector<ServiceMethod> allowedActions,
                                    std::vector<Claim>         claims)
    {
-      auto owner = getOwner(sender);
-      check(owner.has_value(), "account does not have an owning account");
+      auto owner = checkOwner(sender);
 
-      if (requester == *owner)
+      if (requester == owner)
          flags = (flags & ~AuthInterface::requestMask) | AuthInterface::runAsRequesterReq;
 
       auto _ = recurse();
-      return authServiceOf(*owner).checkAuthSys(flags, requester, *owner, std::move(action),
-                                                std::move(allowedActions), std::move(claims));
+      return authServiceOf(owner).checkAuthSys(flags, requester, owner, std::move(action),
+                                               std::move(allowedActions), std::move(claims));
    }
 
    void AuthDelegate::canAuthUserSys(psibase::AccountNumber user)
    {
-      check(getOwner(user).has_value(), "account does not have an owning account");
+      checkOwner(user);
    }
 
    std::vector<AccountNumber> AuthDelegate::getDlgsSys(psibase::AccountNumber sender)
    {
-      auto owner = getOwner(sender);
-      check(owner.has_value(), "account does not have an owning account");
-      return {*owner};
+      return {checkOwner(sender)};
    }
 
    bool AuthDelegate::isAuthSys(psibase::AccountNumber              sender,
                                 std::vector<psibase::AccountNumber> authorizers)
    {
-      auto owner = getOwner(sender);
-      check(owner.has_value(), "account does not have an owning account");
-      return std::ranges::contains(authorizers, *owner);
+      return std::ranges::contains(authorizers, checkOwner(sender));
    }
 
    bool AuthDelegate::isRejectSys(psibase::AccountNumber              sender,
                                   std::vector<psibase::AccountNumber> rejecters)
    {
-      auto owner = getOwner(sender);
-      check(owner.has_value(), "account does not have an owning account");
-      return std::ranges::contains(rejecters, *owner);
+      return std::ranges::contains(rejecters, checkOwner(sender));
    }
 
    void AuthDelegate::setOwner(psibase::AccountNumber owner)
@@ -76,6 +69,13 @@ namespace SystemService
       if (auto row = open<AuthDelegateTable>(KvMode::read).getIndex<0>().get(account))
          return row->owner;
       return std::nullopt;
+   }
+
+   AccountNumber AuthDelegate::checkOwner(psibase::AccountNumber account)
+   {
+      auto owner = getOwner(account);
+      check(owner.has_value(), "account does not have an owning account");
+      return *owner;
    }
 
    Actor<AuthInterface> AuthDelegate::authServiceOf(psibase::AccountNumber account)

--- a/packages/system/AuthDelegate/src/AuthDelegate.cpp
+++ b/packages/system/AuthDelegate/src/AuthDelegate.cpp
@@ -64,14 +64,14 @@ namespace SystemService
       table.put(AuthDelegateRecord{.account = getSender(), .owner = owner});
    }
 
-   std::optional<AccountNumber> AuthDelegate::getOwner(psibase::AccountNumber account)
+   std::optional<psibase::AccountNumber> AuthDelegate::getOwner(psibase::AccountNumber account)
    {
       if (auto row = open<AuthDelegateTable>(KvMode::read).getIndex<0>().get(account))
          return row->owner;
       return std::nullopt;
    }
 
-   AccountNumber AuthDelegate::checkOwner(psibase::AccountNumber account)
+   psibase::AccountNumber AuthDelegate::checkOwner(psibase::AccountNumber account)
    {
       auto owner = getOwner(account);
       check(owner.has_value(), "account does not have an owning account");

--- a/packages/system/AuthDelegate/test/src/AuthDelegate-test.cpp
+++ b/packages/system/AuthDelegate/test/src/AuthDelegate-test.cpp
@@ -66,28 +66,6 @@ namespace
 
 }  // namespace
 
-SCENARIO("AuthDelegate getOwner")
-{
-   GIVEN("Regular chain")
-   {
-      DefaultTestChain t;
-      auto alice = t.addAccount("alice"_a);
-      auto bob   = t.from(t.addAccount("bob"_a));
-
-      THEN("getOwner returns none for an account with no AuthDelegateTable row")
-      {
-         auto result = bob.to<AuthDelegate>().getOwner(alice);
-         REQUIRE(result.succeeded());
-         CHECK(!result.returnVal().has_value());
-      }
-      THEN("getDlgsSys aborts for an account with no AuthDelegateTable row")
-      {
-         REQUIRE(bob.to<AuthDelegate>().getDlgsSys(alice).failed(
-             "account does not have an owning account"));
-      }
-   }
-}
-
 // Tx can be staged on behalf of an account using auth-delegate
 // Tx is executed once the owner accepts it
 // Tx is deleted without execution if owner rejects it

--- a/packages/system/AuthDelegate/test/src/AuthDelegate-test.cpp
+++ b/packages/system/AuthDelegate/test/src/AuthDelegate-test.cpp
@@ -66,6 +66,28 @@ namespace
 
 }  // namespace
 
+SCENARIO("AuthDelegate getOwner")
+{
+   GIVEN("Regular chain")
+   {
+      DefaultTestChain t;
+      auto alice = t.addAccount("alice"_a);
+      auto bob   = t.from(t.addAccount("bob"_a));
+
+      THEN("getOwner returns none for an account with no AuthDelegateTable row")
+      {
+         auto result = bob.to<AuthDelegate>().getOwner(alice);
+         REQUIRE(result.succeeded());
+         CHECK(!result.returnVal().has_value());
+      }
+      THEN("getDlgsSys aborts for an account with no AuthDelegateTable row")
+      {
+         REQUIRE(bob.to<AuthDelegate>().getDlgsSys(alice).failed(
+             "account does not have an owning account"));
+      }
+   }
+}
+
 // Tx can be staged on behalf of an account using auth-delegate
 // Tx is executed once the owner accepts it
 // Tx is deleted without execution if owner rejects it

--- a/packages/user/Packages/src/Packages.cpp
+++ b/packages/user/Packages/src/Packages.cpp
@@ -85,7 +85,10 @@ namespace UserService
          }
          else
          {
-            if (to<AuthDelegate>().getOwner(account) != sender)
+            auto owner = to<AuthDelegate>().getOwner(account);
+            if (!owner)
+               abortMessage("account does not have an owning account");
+            if (*owner != sender)
                abortMessage("Account " + account.str() + " in " + package.name +
                             " is not owned by " + sender.str());
          }

--- a/packages/user/Packages/src/Packages.cpp
+++ b/packages/user/Packages/src/Packages.cpp
@@ -85,10 +85,8 @@ namespace UserService
          }
          else
          {
-            auto owner = to<AuthDelegate>().getOwner(account);
-            if (!owner)
-               abortMessage("account does not have an owning account");
-            if (*owner != sender)
+            auto owner = to<AuthDelegate>().checkOwner(account);
+            if (owner != sender)
                abortMessage("Account " + account.str() + " in " + package.name +
                             " is not owned by " + sender.str());
          }

--- a/packages/user/Packages/src/RPackages.cpp
+++ b/packages/user/Packages/src/RPackages.cpp
@@ -47,10 +47,14 @@ namespace UserService
                                            AuthDelegate::service.str() + " as its auth service");
                   }
                }
-               else if (psibase::to<AuthDelegate>().getOwner(account) != owner)
+               else
                {
-                  psibase::abortMessage("Account " + account.str() + " is not owned by " +
-                                        owner.str());
+                  auto accountOwner = psibase::to<AuthDelegate>().getOwner(account);
+                  if (!accountOwner)
+                     psibase::abortMessage("account does not have an owning account");
+                  else if (*accountOwner != owner)
+                     psibase::abortMessage("Account " + account.str() + " is not owned by " +
+                                           owner.str());
                }
             }
             else

--- a/rust/psibase/src/services/auth_delegate.rs
+++ b/rust/psibase/src/services/auth_delegate.rs
@@ -21,9 +21,9 @@ mod service {
         unimplemented!()
     }
 
-    /// Gets the owner account of the specified account
+    /// Returns the owner of `account`, if any
     #[action]
-    fn getOwner(account: AccountNumber) -> AccountNumber {
+    fn getOwner(account: AccountNumber) -> Option<AccountNumber> {
         unimplemented!()
     }
 

--- a/rust/psibase/src/services/auth_delegate.rs
+++ b/rust/psibase/src/services/auth_delegate.rs
@@ -27,6 +27,14 @@ mod service {
         unimplemented!()
     }
 
+    /// Returns the owner of `account`
+    ///
+    /// Aborts if the account has no owner.
+    #[action]
+    fn checkOwner(account: AccountNumber) -> AccountNumber {
+        unimplemented!()
+    }
+
     /// This is an implementation of the standard auth service interface defined in [SystemService::AuthInterface]
     ///
     /// This action is automatically called by `accounts` when an account is configured to use this auth service.


### PR DESCRIPTION
This doesn't actually change any behavior for now. But eventually we want rpc services to return more idiomatic errors (http or gql errors) instead of server aborts. So I figure first step is trying to eliminate transitive aborts where the query is calling an inline action which itself aborts. We should prefer calling actions that don't abort internally, even if for now we still abort in the rpc service.