### PR TITLE
Remove Fracpack macro

### DIFF
--- a/doc/src/development/services/rust-service/graphql.md
+++ b/doc/src/development/services/rust-service/graphql.md
@@ -89,11 +89,11 @@ We need some data to query. Let's build on the example from the
 #[psibase::service_tables]
 mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{AccountNumber, Fracpack, ToKey};
+    use psibase::{AccountNumber, Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "MessageTable", index = 0)]
-    #[derive(Fracpack, Serialize, Deserialize, SimpleObject)]
+    #[derive(Pack, Unpack, ToSchema, Serialize, Deserialize, SimpleObject)]
     pub struct Message {
         #[primary_key]
         pub id: u64,
@@ -126,7 +126,7 @@ mod tables {
     }
 
     #[table(name = "LastUsedTable", index = 1)]
-    #[derive(Default, Fracpack, Serialize, Deserialize)]
+    #[derive(Default, Pack, Unpack, ToSchema, Serialize, Deserialize)]
     pub struct LastUsed {
         pub lastMessageId: u64,
     }

--- a/doc/src/development/services/rust-service/tables.md
+++ b/doc/src/development/services/rust-service/tables.md
@@ -16,12 +16,12 @@ cargo add -F derive serde
 ```rust
 #[psibase::service_tables]
 mod tables {
-    use psibase::{AccountNumber, Fracpack, ToSchema};
+    use psibase::{AccountNumber, Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     // Our first table (index 0) is MessageTable. It stores Message.
     #[table(name = "MessageTable", index = 0)]
-    #[derive(Fracpack, Serialize, Deserialize, ToSchema)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema)]
     pub struct Message {
         // Every table has a unique primary key. This doesn't have
         // to be a u64; many types may be keys, including String,
@@ -154,13 +154,13 @@ A singleton is a table that has at most 1 row. Let's add one to track the most-r
 ```rust
 #[psibase::service_tables]
 mod tables {
-    use psibase::{AccountNumber, Fracpack, ToKey, ToSchema};
+    use psibase::{AccountNumber, Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     // We can't renumber tables without corrupting
     // them. This table remains 0.
     #[table(name = "MessageTable", index = 0)]
-    #[derive(Fracpack, Serialize, Deserialize, ToKey, ToSchema)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema)]
     pub struct Message {
         #[primary_key]
         pub id: u64,
@@ -172,7 +172,7 @@ mod tables {
 
     // This table stores the last used message ID
     #[table(name = "LastUsedTable", index = 1)]
-    #[derive(Default, Fracpack, Serialize, Deserialize, ToKey, ToSchema)]
+    #[derive(Default, Pack, Unpack, Serialize, Deserialize, ToSchema)]
     pub struct LastUsed {
         pub lastMessageId: u64,
     }
@@ -263,12 +263,12 @@ So far we have a way to page through all messages, but don't have a good way to 
 ```rust
 #[psibase::service_tables]
 mod tables {
-    use psibase::{AccountNumber, Fracpack, ToKey, ToSchema};
+    use psibase::{AccountNumber, Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     // Same as before
     #[table(name = "MessageTable", index = 0)]
-    #[derive(Fracpack, Serialize, Deserialize, ToKey, ToSchema)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema)]
     pub struct Message {
         #[primary_key]
         pub id: u64,
@@ -299,7 +299,7 @@ mod tables {
 
     // Same as before
     #[table(name = "LastUsedTable", index = 1)]
-    #[derive(Default, Fracpack, Serialize, Deserialize, ToSchema)]
+    #[derive(Default, Pack, Unpack, Serialize, Deserialize, ToSchema)]
     pub struct LastUsed {
         pub lastMessageId: u64,
     }
@@ -429,7 +429,7 @@ Let's make the following adjustment to Message. `Debug, PartialEq, Eq` aid testa
 
 ```rust
 #[table(name = "MessageTable", index = 0)]
-#[derive(Debug, PartialEq, Eq, Fracpack, Serialize, Deserialize, ToKey, ToSchema)]
+#[derive(Debug, PartialEq, Eq, Pack, Unpack, Serialize, Deserialize, ToSchema)]
 pub struct Message {
     #[primary_key]
     pub id: u64,
@@ -512,7 +512,7 @@ Sometimes services need to define tables whose struct isn't defined within the s
 // This definition lives outside of the service_tables module. We can't use
 // `#[table]`, `#[primary_key]`, or `#[secondary_key]` here since
 // those attributes are part of the `#[service_tables]` macro.
-#[derive(psibase::Fracpack, serde::Serialize, serde::Deserialize)]
+#[derive(psibase::Pack, psibase::Unpack, psibase::ToSchema, serde::Serialize, serde::Deserialize)]
 pub struct Message {
     pub id: u64,
 
@@ -525,7 +525,7 @@ pub struct Message {
 ```rust
 // Inside the service_tables module (replacing both the `struct Message` and `impl Message`)
 #[table(name = "MessageTable", index = 0)]
-#[derive(Fracpack, Serialize, Deserialize, ToSchema)]
+#[derive(Pack, Unpack, Serialize, Deserialize, ToSchema)]
 pub struct WrapMessage(crate::Message);
 
 impl WrapMessage {

--- a/package-templates/basic-01/{{project-name | upper_camel_case}}/service/src/lib.rs
+++ b/package-templates/basic-01/{{project-name | upper_camel_case}}/service/src/lib.rs
@@ -1,11 +1,11 @@
 #[psibase::service_tables]
 pub mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{Fracpack, ToSchema};
+    use psibase::{Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug)]
     pub struct InitRow {}
     impl InitRow {
         #[primary_key]
@@ -13,7 +13,7 @@ pub mod tables {
     }
 
     #[table(name = "ExampleThingTable", index = 1)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct ExampleThing {
         pub thing: String,
     }

--- a/packages/system/AuthDyn/service/src/lib.rs
+++ b/packages/system/AuthDyn/service/src/lib.rs
@@ -4,13 +4,13 @@ pub mod tables {
     use psibase::services::auth_dyn::int_wrapper;
     use psibase::services::transact::ServiceMethod;
     use psibase::{
-        services::auth_dyn::policy::DynamicAuthPolicy, AccountNumber, Fracpack, ServiceWrapper,
-        Table, ToSchema,
+        services::auth_dyn::policy::DynamicAuthPolicy, AccountNumber, Pack, ServiceWrapper, Table,
+        ToSchema, Unpack,
     };
     use serde::{Deserialize, Serialize};
 
     #[table(name = "ManagementTable", index = 0)]
-    #[derive(Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct Management {
         #[primary_key]
         pub account: AccountNumber,
@@ -169,10 +169,9 @@ pub mod service {
         let policy = Management::get_assert(sender).dynamic_policy(method);
         assert_ne!(policy.threshold, 0, "multi auth threshold cannot be 0");
 
-        let total_possible_weight = policy
-            .authorizers
-            .iter()
-            .fold(0u8, |acc, authorizer| acc.checked_add(authorizer.weight).unwrap());
+        let total_possible_weight = policy.authorizers.iter().fold(0u8, |acc, authorizer| {
+            acc.checked_add(authorizer.weight).unwrap()
+        });
 
         if policy.threshold > total_possible_weight {
             return !is_approval;
@@ -188,7 +187,9 @@ pub mod service {
             .authorizers
             .into_iter()
             .filter(|authorizer| authorizers.contains(&authorizer.account))
-            .fold(0u8, |acc, authorizer| acc.checked_add(authorizer.weight).unwrap());
+            .fold(0u8, |acc, authorizer| {
+                acc.checked_add(authorizer.weight).unwrap()
+            });
 
         total_weight_approved >= required_weight
     }

--- a/packages/system/StagedTx/service/src/db.rs
+++ b/packages/system/StagedTx/service/src/db.rs
@@ -1,16 +1,16 @@
 #[psibase::service_tables]
 pub mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{AccountNumber, Action, Checksum256, Fracpack, TimePointUSec, ToSchema};
+    use psibase::{AccountNumber, Action, Checksum256, Pack, TimePointUSec, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
-    #[derive(Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema, SimpleObject)]
     pub struct ActionList {
         pub actions: Vec<Action>,
     }
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack)]
     pub struct InitRow {}
     impl InitRow {
         #[primary_key]
@@ -19,7 +19,7 @@ pub mod tables {
 
     /// A table that contains all of the transactions currently staged.
     #[table(name = "StagedTxTable", index = 1)]
-    #[derive(Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema, SimpleObject)]
     pub struct StagedTx {
         /// Unique ID for a staged transaction
         pub id: u32,
@@ -58,7 +58,7 @@ pub mod tables {
     }
 
     #[table(name = "LastUsedTable", index = 2)]
-    #[derive(Default, Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]
+    #[derive(Default, Pack, Unpack, Serialize, Deserialize, ToSchema, SimpleObject)]
     pub struct LastUsed {
         pub id: u32,
     }
@@ -69,7 +69,7 @@ pub mod tables {
 
     /// A table that contains all of the responses to staged transactions.
     #[table(name = "ResponseTable", index = 3)]
-    #[derive(Debug, Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]
+    #[derive(Debug, Pack, Unpack, Serialize, Deserialize, ToSchema, SimpleObject)]
     pub struct Response {
         /// The ID of the staged transaction
         pub id: u32,
@@ -102,7 +102,7 @@ pub mod tables {
     /// Table can be used to search for all parties in a staged transaction, or all
     /// staged transactions related to a given party.
     #[table(name = "StagedTxPartyTable", index = 4)]
-    #[derive(Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema, SimpleObject)]
     pub struct StagedTxParty {
         /// The ID of the staged transaction
         pub id: u32,

--- a/packages/system/StagedTx/service/src/event.rs
+++ b/packages/system/StagedTx/service/src/event.rs
@@ -1,6 +1,6 @@
-use psibase::{Fracpack, ToSchema};
+use psibase::{Pack, ToSchema, Unpack};
 
-#[derive(Debug, Copy, Clone, Fracpack, ToSchema)]
+#[derive(Debug, Copy, Clone, Pack, Unpack, ToSchema)]
 pub struct StagedTxEvent {
     pub ty: u8,
 }

--- a/packages/system/VirtualServer/service/src/tables.rs
+++ b/packages/system/VirtualServer/service/src/tables.rs
@@ -6,7 +6,7 @@ pub mod tables {
     use serde::{Deserialize, Serialize};
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, Default)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, Default)]
     pub struct InitRow {
         /// Bytes already in db at boot (`Native` + `Service`),
         pub used_bytes: u64,
@@ -40,7 +40,7 @@ pub mod tables {
     }
 
     #[table(name = "BillingConfigTable", index = 1)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject, Clone)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject, Clone)]
     #[serde(rename_all = "camelCase")]
     #[graphql(complex)]
     pub struct BillingConfig {
@@ -61,7 +61,7 @@ pub mod tables {
     /// The specs of the virtual server and the specs required by each node
     /// and are used to configure the network specs.
     #[table(name = "ServerSpecsTable", index = 2)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject, Clone)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject, Clone)]
     pub struct ServerSpecs {
         /// Amount of bandwidth capacity per second per server
         pub net_bps: u64,
@@ -83,7 +83,7 @@ pub mod tables {
     }
 
     #[table(name = "NetworkVariablesTable", index = 3)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject, Clone)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject, Clone)]
     /// Variables that are used to derive the specs of the network from the server specs.
     pub struct NetworkVariables {
         /// How much faster a node replays blocks compared to the live network
@@ -115,7 +115,9 @@ pub mod tables {
     /// or equal to) the server specs due to overhead in distributing server load
     /// across network peers.
     #[table(name = "NetworkSpecsTable", index = 4)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject, Clone, Default)]
+    #[derive(
+        Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject, Clone, Default,
+    )]
     pub struct NetworkSpecs {
         /// Amount of network bandwidth capacity per second in bits per second
         pub net_bps: u64,
@@ -135,7 +137,7 @@ pub mod tables {
     /// Settings related to the automatic management of an account resource buffer.
     /// If an account has not configured these settings, a default configuration will be used.
     #[table(name = "UserSettingsTable", index = 5)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject, Clone)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject, Clone)]
     pub struct UserSettings {
         #[primary_key]
         pub user: AccountNumber,
@@ -150,7 +152,7 @@ pub mod tables {
     }
 
     /// Parameters related to the automatic management of an account resource buffer.
-    #[derive(Fracpack, ToSchema, Serialize, Deserialize, Debug, Clone)]
+    #[derive(Pack, Unpack, ToSchema, Serialize, Deserialize, Debug, Clone)]
     pub struct BufferConfig {
         /// A threshold (specified in integer percentage values) at or below which the client should
         /// attempt to automatically refill the account's resource buffer. A threshold of 0 means
@@ -166,7 +168,7 @@ pub mod tables {
     /// A rate-limited resource is one that has a max capacity per unit time and uses
     /// a "difficulty adjustment" algorithm to adjust price based on congestion.
     #[table(name = "RateLimitPricingTable", index = 6)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject, Clone)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject, Clone)]
     #[graphql(complex)]
     pub struct RateLimitPricing {
         #[primary_key]
@@ -200,7 +202,9 @@ pub mod tables {
 
     /// Capacity-limited pricing state
     #[table(name = "CapacityPricingTable", index = 7)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject, Clone, Default)]
+    #[derive(
+        Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject, Clone, Default,
+    )]
     #[graphql(complex)]
     pub struct CapacityPricing {
         #[primary_key]

--- a/packages/user/Branding/service/src/lib.rs
+++ b/packages/user/Branding/service/src/lib.rs
@@ -1,10 +1,10 @@
 #[psibase::service_tables]
 mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{Fracpack, ToSchema};
+    use psibase::{Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
     #[table(name = "NetworkNameTable")]
-    #[derive(Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct NetworkName {
         pub name: String,
     }

--- a/packages/user/Chainmail/service/src/tables.rs
+++ b/packages/user/Chainmail/service/src/tables.rs
@@ -1,11 +1,11 @@
 #[psibase::service_tables]
 pub mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{AccountNumber, Fracpack, TimePointSec, ToSchema};
+    use psibase::{AccountNumber, Pack, TimePointSec, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack)]
     pub struct InitRow {}
 
     impl InitRow {
@@ -14,7 +14,7 @@ pub mod tables {
     }
 
     #[table(name = "SavedMessageTable", index = 1)]
-    #[derive(Debug, Serialize, Deserialize, ToSchema, Fracpack, SimpleObject)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema, Pack, Unpack, SimpleObject)]
     pub struct SavedMessage {
         #[primary_key]
         pub msg_id: u64,

--- a/packages/user/DiffAdjust/service/src/lib.rs
+++ b/packages/user/DiffAdjust/service/src/lib.rs
@@ -3,7 +3,7 @@ pub mod tables {
     use psibase::services::nft::Wrapper as Nft;
     use psibase::services::transact::Wrapper as TransactSvc;
     use psibase::{
-        get_sender, AccountNumber, Fracpack, ServiceWrapper, Table, TimePointSec, ToSchema,
+        get_sender, AccountNumber, Pack, ServiceWrapper, Table, TimePointSec, ToSchema, Unpack,
     };
 
     use async_graphql::{ComplexObject, SimpleObject};
@@ -13,7 +13,7 @@ pub mod tables {
     const ONE_MILLION: u32 = 1_000_000;
 
     #[table(name = "RateLimitTable", index = 0)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct RateLimit {
         #[primary_key]
         pub nft_id: u32,

--- a/packages/user/Evaluations/service/src/db.rs
+++ b/packages/user/Evaluations/service/src/db.rs
@@ -2,11 +2,11 @@
 pub mod tables {
     use async_graphql::SimpleObject;
 
-    use psibase::{AccountNumber, Fracpack, ToSchema};
+    use psibase::{AccountNumber, Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "ConfigTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack)]
     pub struct ConfigRow {
         pub owner: AccountNumber,
         pub last_used_id: u32,
@@ -20,7 +20,7 @@ pub mod tables {
     }
 
     #[table(name = "EvaluationTable", index = 1)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct Evaluation {
         pub id: u32,
         pub created_at: u32,
@@ -35,7 +35,9 @@ pub mod tables {
     }
 
     #[table(name = "UserTable", index = 2)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
+    #[derive(
+        Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone,
+    )]
     pub struct User {
         pub owner: AccountNumber,
         pub evaluation_id: u32,
@@ -47,7 +49,9 @@ pub mod tables {
     }
 
     #[table(name = "GroupTable", index = 3)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
+    #[derive(
+        Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone,
+    )]
     pub struct Group {
         pub owner: AccountNumber,
         pub evaluation_id: u32,
@@ -56,7 +60,9 @@ pub mod tables {
     }
 
     #[table(name = "UserSettingsTable", index = 4)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
+    #[derive(
+        Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone,
+    )]
     pub struct UserSettings {
         #[primary_key]
         pub user: AccountNumber,

--- a/packages/user/FaucetTok/service/src/lib.rs
+++ b/packages/user/FaucetTok/service/src/lib.rs
@@ -8,7 +8,7 @@ pub mod tables {
     use psibase::*;
 
     #[table(name = "ConfigTable", index = 0)]
-    #[derive(ToSchema, Fracpack)]
+    #[derive(ToSchema, Pack, Unpack)]
     pub struct ConfigRow {
         pub token_id: TID,
     }

--- a/packages/user/FractalGen/service/src/lib.rs
+++ b/packages/user/FractalGen/service/src/lib.rs
@@ -3,11 +3,11 @@
 
 #[psibase::service_tables]
 pub mod tables {
-    use psibase::{Fracpack, Table, ToSchema};
+    use psibase::{Pack, Table, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "ConfigTable", index = 0)]
-    #[derive(Default, Fracpack, ToSchema, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, Serialize, Deserialize, Debug)]
     pub struct ConfigRow {}
     impl ConfigRow {
         #[primary_key]

--- a/packages/user/FractalTester/service/src/lib.rs
+++ b/packages/user/FractalTester/service/src/lib.rs
@@ -11,11 +11,11 @@
 
 #[psibase::service_tables]
 pub mod tables {
-    use psibase::{Fracpack, Table, ToSchema};
+    use psibase::{Pack, Table, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "ConfigTable", index = 0)]
-    #[derive(Default, Fracpack, ToSchema, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, Serialize, Deserialize, Debug)]
     pub struct ConfigRow {}
     impl ConfigRow {
         #[primary_key]

--- a/packages/user/Fractals/service/src/tables/mod.rs
+++ b/packages/user/Fractals/service/src/tables/mod.rs
@@ -13,13 +13,13 @@ pub mod tables {
     use async_graphql::SimpleObject;
     use psibase::{
         services::tokens::{Quantity, TID},
-        AccountNumber, Fracpack, TimePointSec, ToSchema,
+        AccountNumber, Pack, TimePointSec, ToSchema, Unpack,
     };
 
     use serde::{Deserialize, Serialize};
 
     #[table(name = "ConfigTable", index = 0)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct Config {
         pub last_levy_id: u32,
     }
@@ -30,7 +30,7 @@ pub mod tables {
     }
 
     #[table(name = "FractalTable", index = 1)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct Fractal {
         #[primary_key]
@@ -45,7 +45,7 @@ pub mod tables {
     }
 
     #[table(name = "FractalMemberTable", index = 2)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct FractalMember {
         pub fractal: AccountNumber,
@@ -66,7 +66,7 @@ pub mod tables {
     }
 
     #[table(name = "FractalExileTable", index = 3)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct FractalExile {
         #[graphql(skip)]
@@ -87,7 +87,7 @@ pub mod tables {
     }
 
     #[table(name = "RewardStreamTable", index = 4)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct RewardStream {
         pub fractal: AccountNumber,
         pub owner: AccountNumber,
@@ -103,7 +103,7 @@ pub mod tables {
     }
 
     #[table(name = "RoleTable", index = 5)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct Role {
         pub fractal: AccountNumber,
         pub account: AccountNumber,
@@ -124,7 +124,7 @@ pub mod tables {
     }
 
     #[table(name = "OccupationTable", index = 6)]
-    #[derive(Default, Fracpack, ToSchema, Serialize, Deserialize, Debug, Clone)]
+    #[derive(Default, Pack, Unpack, ToSchema, Serialize, Deserialize, Debug, Clone)]
     pub struct Occupation {
         pub fractal: AccountNumber,
         pub index: u8,
@@ -139,7 +139,7 @@ pub mod tables {
     }
 
     #[table(name = "LevyTable", index = 7)]
-    #[derive(Default, Fracpack, ToSchema, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, Serialize, Deserialize, Debug)]
     pub struct Levy {
         pub id: u32,
         pub fractal: AccountNumber,

--- a/packages/user/Guilds/service/src/tables/mod.rs
+++ b/packages/user/Guilds/service/src/tables/mod.rs
@@ -11,11 +11,11 @@ mod role_map;
 #[psibase::service_tables]
 pub mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{define_flags, AccountNumber, Fracpack, Memo, ToSchema};
+    use psibase::{define_flags, AccountNumber, Memo, Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "GuildTable", index = 0)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct Guild {
         #[primary_key]
@@ -34,7 +34,7 @@ pub mod tables {
     }
 
     #[table(name = "RankingTable", index = 1)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct Ranking {
         pub fractal: AccountNumber,
         pub guild: AccountNumber,
@@ -70,7 +70,7 @@ pub mod tables {
     }
 
     #[table(name = "GuildMemberTable", index = 2)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct GuildMember {
         #[graphql(skip)]
@@ -103,7 +103,7 @@ pub mod tables {
     }
 
     #[table(name = "GuildApplicationTable", index = 3)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct GuildApplication {
         #[graphql(skip)]
@@ -127,7 +127,7 @@ pub mod tables {
     }
 
     #[table(name = "GuildInviteTable", index = 4)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct GuildInvite {
         #[primary_key]
@@ -147,7 +147,7 @@ pub mod tables {
     }
 
     #[table(name = "GuildAttestTable", index = 5)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct GuildAttest {
         #[graphql(skip)]
@@ -171,7 +171,7 @@ pub mod tables {
     }
 
     #[table(name = "EvaluationInstanceTable", index = 6)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct EvaluationInstance {
         #[primary_key]
@@ -188,7 +188,7 @@ pub mod tables {
     }
 
     #[table(name = "RoleMapTable", index = 7)]
-    #[derive(Default, Fracpack, SimpleObject, ToSchema, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, SimpleObject, ToSchema, Serialize, Deserialize, Debug)]
     pub struct RoleMap {
         pub fractal: AccountNumber,
         pub role_id: u8,
@@ -203,7 +203,7 @@ pub mod tables {
     }
 
     #[table(name = "FractalSettingsTable", index = 8)]
-    #[derive(Default, Fracpack, SimpleObject, ToSchema, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, SimpleObject, ToSchema, Serialize, Deserialize, Debug)]
     pub struct FractalSettings {
         #[primary_key]
         pub fractal: AccountNumber,

--- a/packages/user/Identity/service/src/lib.rs
+++ b/packages/user/Identity/service/src/lib.rs
@@ -12,7 +12,7 @@ mod tables {
     use serde::{Deserialize, Serialize};
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug)]
     pub struct InitRow {}
     impl InitRow {
         #[primary_key]
@@ -20,7 +20,7 @@ mod tables {
     }
 
     #[table(name = "AttestationTable", index = 1)]
-    #[derive(Debug, Fracpack, ToSchema, Serialize, Deserialize, SimpleObject)]
+    #[derive(Debug, Pack, Unpack, ToSchema, Serialize, Deserialize, SimpleObject)]
     pub struct Attestation {
         /// The attesting account / the issuer
         pub attester: AccountNumber,
@@ -57,7 +57,7 @@ mod tables {
     }
 
     #[table(name = "AttestationStatsTable", index = 2)]
-    #[derive(Debug, Fracpack, ToSchema, Serialize, Deserialize, SimpleObject)]
+    #[derive(Debug, Pack, Unpack, ToSchema, Serialize, Deserialize, SimpleObject)]
     pub struct AttestationStats {
         /// The credential subject, in this case, the subject/subject
         #[primary_key]

--- a/packages/user/NameMarket/service/src/lib.rs
+++ b/packages/user/NameMarket/service/src/lib.rs
@@ -13,11 +13,11 @@ pub mod tables {
     use async_graphql::SimpleObject;
     use psibase::services::tokens::Quantity;
     use psibase::AccountNumber;
-    use psibase::{Fracpack, ToSchema};
+    use psibase::{Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug)]
     pub struct InitRow {}
     impl InitRow {
         #[primary_key]
@@ -25,7 +25,7 @@ pub mod tables {
     }
 
     #[table(name = "AuctionsTable", index = 1)]
-    #[derive(Fracpack, ToSchema, Serialize, Deserialize, Debug)]
+    #[derive(Pack, Unpack, ToSchema, Serialize, Deserialize, Debug)]
     pub struct Auction {
         #[primary_key]
         pub length: u8,
@@ -35,7 +35,7 @@ pub mod tables {
     }
 
     #[table(name = "PurchasedAccountsTable", index = 2)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     pub struct PurchasedAccount {
         #[primary_key]
         pub account: AccountNumber,

--- a/packages/user/Nft/query-service/src/lib.rs
+++ b/packages/user/Nft/query-service/src/lib.rs
@@ -8,7 +8,7 @@ mod service {
     };
     use psibase::{services::accounts::Account, *};
 
-    #[derive(Fracpack, ToSchema, Debug, Clone, SimpleObject)]
+    #[derive(Pack, Unpack, ToSchema, Debug, Clone, SimpleObject)]
     struct UserDetail {
         account: AccountNumber,
         authService: AccountNumber,
@@ -23,7 +23,7 @@ mod service {
         }
     }
 
-    #[derive(Fracpack, ToSchema, Debug, Clone, SimpleObject)]
+    #[derive(Pack, Unpack, ToSchema, Debug, Clone, SimpleObject)]
     struct NftDetail {
         id: NID,
         owner: UserDetail,

--- a/packages/user/Nft/service/src/lib.rs
+++ b/packages/user/Nft/service/src/lib.rs
@@ -3,8 +3,8 @@
 pub mod tables {
     use async_graphql::SimpleObject;
     use psibase::{
-        abort_message, define_flags, get_sender, AccountNumber, FlagsType, Fracpack, Memo,
-        ServiceWrapper, Table, ToSchema,
+        abort_message, define_flags, get_sender, AccountNumber, FlagsType, Memo, Pack,
+        ServiceWrapper, Table, ToSchema, Unpack,
     };
     use serde::{Deserialize, Serialize};
 
@@ -17,7 +17,7 @@ pub mod tables {
     });
 
     #[table(name = "ConfigTable", index = 0)]
-    #[derive(Fracpack, ToSchema, Serialize, Deserialize, Debug)]
+    #[derive(Pack, Unpack, ToSchema, Serialize, Deserialize, Debug)]
     pub struct ConfigRow {
         pub next_id: NID,
     }
@@ -56,7 +56,7 @@ pub mod tables {
     }
 
     #[table(name = "NftTable", index = 1)]
-    #[derive(Fracpack, ToSchema, Serialize, Deserialize, Debug, Clone, SimpleObject)]
+    #[derive(Pack, Unpack, ToSchema, Serialize, Deserialize, Debug, Clone, SimpleObject)]
     pub struct Nft {
         #[primary_key]
         pub id: NID,
@@ -137,7 +137,7 @@ pub mod tables {
     }
 
     #[table(name = "NftHolderTable", index = 2)]
-    #[derive(Fracpack, ToSchema, Serialize, Deserialize, SimpleObject, Debug, Clone)]
+    #[derive(Pack, Unpack, ToSchema, Serialize, Deserialize, SimpleObject, Debug, Clone)]
     #[graphql(complex)]
     pub struct NftHolder {
         #[primary_key]
@@ -146,7 +146,7 @@ pub mod tables {
     }
 
     #[table(name = "CreditTable", index = 3)]
-    #[derive(Fracpack, ToSchema, Serialize, Deserialize, Debug, Clone, SimpleObject)]
+    #[derive(Pack, Unpack, ToSchema, Serialize, Deserialize, Debug, Clone, SimpleObject)]
     #[allow(non_snake_case)]
     pub struct CreditRecord {
         #[primary_key]

--- a/packages/user/Profiles/service/src/lib.rs
+++ b/packages/user/Profiles/service/src/lib.rs
@@ -44,13 +44,14 @@ pub fn content_type_mime(content_type: ImgContentType) -> Option<&'static str> {
 #[psibase::service_tables]
 pub mod tables {
     use psibase::AccountNumber;
-    use psibase::{Fracpack, ToSchema};
+    use psibase::{Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "ProfileTable", index = 0)]
     #[derive(
         Default,
-        Fracpack,
+        Pack,
+        Unpack,
         ToSchema,
         async_graphql::SimpleObject,
         Serialize,

--- a/packages/user/Registry/service/src/tables.rs
+++ b/packages/user/Registry/service/src/tables.rs
@@ -1,11 +1,13 @@
 #[psibase::service_tables]
 pub mod tables {
     use async_graphql::SimpleObject;
-    use psibase::{AccountNumber, Fracpack, ToSchema};
+    use psibase::{AccountNumber, Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "AppMetadataTable", index = 0)]
-    #[derive(Default, Debug, Clone, Fracpack, ToSchema, Serialize, SimpleObject, Deserialize)]
+    #[derive(
+        Default, Debug, Clone, Pack, Unpack, ToSchema, Serialize, SimpleObject, Deserialize,
+    )]
     #[serde(rename_all = "camelCase")]
     #[graphql(complex)]
     pub struct AppMetadata {
@@ -37,7 +39,7 @@ pub mod tables {
     }
 
     #[table(name = "NextIdTable", index = 1)]
-    #[derive(Default, Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]
+    #[derive(Default, Pack, Unpack, Serialize, Deserialize, ToSchema, SimpleObject)]
     pub struct NextId {
         pub id: u32,
     }
@@ -85,7 +87,9 @@ pub mod tables {
     /// This table holds all unique tags
     /// One TagRecord per unique tag
     #[table(name = "TagsTable", index = 2)]
-    #[derive(Debug, Clone, Fracpack, ToSchema, Serialize, Deserialize, SimpleObject, PartialEq)]
+    #[derive(
+        Debug, Clone, Pack, Unpack, ToSchema, Serialize, Deserialize, SimpleObject, PartialEq,
+    )]
     pub struct TagRecord {
         /// The unique identifier for the tag
         #[primary_key]
@@ -113,7 +117,7 @@ pub mod tables {
     /// This table maps apps to their tags
     /// One AppTag record per app-tag pair
     #[table(name = "AppTagsTable", index = 3)]
-    #[derive(Debug, Clone, Fracpack, ToSchema, Serialize, Deserialize, SimpleObject)]
+    #[derive(Debug, Clone, Pack, Unpack, ToSchema, Serialize, Deserialize, SimpleObject)]
     pub struct AppTag {
         /// The unique identifier for the app
         pub app_id: AccountNumber,

--- a/packages/user/Symbol/service/src/lib.rs
+++ b/packages/user/Symbol/service/src/lib.rs
@@ -7,14 +7,14 @@ pub mod tables {
     use psibase::services::tokens::Wrapper as Tokens;
     use psibase::services::tokens::{Decimal, Quantity, TokenRecord, TID};
     use psibase::{
-        get_sender, get_service, AccountNumber, Fracpack, ServiceWrapper, Table, ToSchema,
+        get_sender, get_service, AccountNumber, Pack, ServiceWrapper, Table, ToSchema, Unpack,
     };
     use serde::{Deserialize, Serialize};
 
     use crate::service::{CREATED, MAPPED};
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug)]
     pub struct InitRow {}
     impl InitRow {
         #[primary_key]
@@ -22,7 +22,7 @@ pub mod tables {
     }
 
     #[table(name = "SymbolLengthTable", index = 1)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject)]
     #[graphql(complex)]
     pub struct SymbolLength {
         #[primary_key]
@@ -131,7 +131,7 @@ pub mod tables {
     }
 
     #[table(name = "SymbolTable", index = 2)]
-    #[derive(Default, Fracpack, ToSchema, Serialize, Deserialize, Debug, SimpleObject)]
+    #[derive(Default, Pack, Unpack, ToSchema, Serialize, Deserialize, Debug, SimpleObject)]
     #[graphql(complex)]
     pub struct Symbol {
         #[primary_key]
@@ -228,7 +228,7 @@ pub mod tables {
     }
 
     #[table(name = "MappingTable", index = 3)]
-    #[derive(Default, Fracpack, ToSchema, Serialize, Deserialize, Debug, SimpleObject)]
+    #[derive(Default, Pack, Unpack, ToSchema, Serialize, Deserialize, Debug, SimpleObject)]
     #[graphql(complex)]
     pub struct Mapping {
         #[primary_key]

--- a/packages/user/TokenStream/service/src/lib.rs
+++ b/packages/user/TokenStream/service/src/lib.rs
@@ -2,14 +2,14 @@
 pub mod tables {
     use async_graphql::{ComplexObject, SimpleObject};
     use psibase::services::tokens::{Decimal, Precision, Quantity, TID};
-    use psibase::{AccountNumber, Fracpack, ServiceWrapper, Table, TimePointSec, ToSchema};
+    use psibase::{AccountNumber, Pack, ServiceWrapper, Table, TimePointSec, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     use psibase::services::nft::{Wrapper as Nfts, NID};
     use psibase::services::transact::Wrapper as TransactSvc;
 
     #[table(name = "StreamTable", index = 0)]
-    #[derive(Default, Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Default, Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct Stream {
         #[primary_key]

--- a/packages/user/TokenSwap/service/src/tables.rs
+++ b/packages/user/TokenSwap/service/src/tables.rs
@@ -3,17 +3,18 @@ pub mod tables {
 
     use async_graphql::{ComplexObject, SimpleObject};
     use psibase::services::nft::NID;
-    use psibase::services::token_swap::{PPM, Wrapper as TokenSwap, swap};
-    use psibase::services::tokens::{Decimal, Quantity, TID, TokenRecord, Wrapper as Tokens};
+    use psibase::services::token_swap::{swap, Wrapper as TokenSwap, PPM};
+    use psibase::services::tokens::{Decimal, Quantity, TokenRecord, Wrapper as Tokens, TID};
     use psibase::{
-        AccountNumber, Fracpack, Memo, ServiceWrapper, Table, ToSchema, abort_message, get_sender,
+        abort_message, get_sender, AccountNumber, Memo, Pack, ServiceWrapper, Table, ToSchema,
+        Unpack,
     };
 
     use crate::helpers::{mul_div, sqrt};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug)]
     pub struct InitRow {}
 
     impl InitRow {
@@ -39,7 +40,7 @@ pub mod tables {
     }
 
     #[table(name = "PoolTable", index = 1)]
-    #[derive(Serialize, Deserialize, SimpleObject, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, SimpleObject, ToSchema, Pack, Unpack, Debug)]
     #[graphql(complex)]
     pub struct Pool {
         #[primary_key]
@@ -48,7 +49,7 @@ pub mod tables {
     }
 
     #[table(name = "ReserveTable", index = 2)]
-    #[derive(Serialize, Deserialize, SimpleObject, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, SimpleObject, ToSchema, Pack, Unpack, Debug)]
     #[graphql(complex)]
     pub struct Reserve {
         pub pool_id: TID,

--- a/packages/user/Tokens/service/src/tables.rs
+++ b/packages/user/Tokens/service/src/tables.rs
@@ -1,17 +1,17 @@
 #[psibase::service_tables]
 pub mod tables {
-    use crate::service::{TID, fmt_amount};
+    use crate::service::{fmt_amount, TID};
     use async_graphql::{ComplexObject, SimpleObject};
     use psibase::services::accounts::Wrapper as Accounts;
-    use psibase::services::nft::{NID, Wrapper as Nfts};
+    use psibase::services::nft::{Wrapper as Nfts, NID};
     use psibase::services::tokens::{Decimal, Precision, Quantity};
-    use psibase::{AccountNumber, Memo, ServiceWrapper, TableRecord, abort_message, get_sender};
-    use psibase::{Flags, define_flags};
-    use psibase::{Fracpack, Table, ToSchema};
+    use psibase::{abort_message, get_sender, AccountNumber, Memo, ServiceWrapper, TableRecord};
+    use psibase::{define_flags, Flags};
+    use psibase::{Pack, Table, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug)]
     pub struct InitRow {
         pub last_used_id: TID,
         pub last_used_shared_bal_id: u64,
@@ -87,7 +87,7 @@ pub mod tables {
     }
 
     #[table(name = "TokenTable", index = 1)]
-    #[derive(Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
+    #[derive(Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug)]
     #[graphql(complex)]
     pub struct Token {
         #[primary_key]
@@ -284,7 +284,7 @@ pub mod tables {
     }
 
     #[table(name = "BalanceTable", index = 2)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject)]
     #[graphql(complex)]
     pub struct Balance {
         pub account: AccountNumber,
@@ -399,7 +399,7 @@ pub mod tables {
     }
 
     #[table(name = "SharedBalanceTable", index = 3)]
-    #[derive(Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
+    #[derive(Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
     #[graphql(complex)]
     pub struct SharedBalance {
         #[primary_key]
@@ -650,7 +650,7 @@ pub mod tables {
     });
 
     #[table(name = "BalanceConfigTable", index = 4)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject)]
     pub struct BalanceConfig {
         pub account: AccountNumber,
         pub token_id: TID,
@@ -716,7 +716,7 @@ pub mod tables {
     }
 
     #[table(name = "UserConfigTable", index = 5)]
-    #[derive(Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
+    #[derive(Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
     #[graphql(complex)]
     pub struct UserConfig {
         #[primary_key]
@@ -771,7 +771,7 @@ pub mod tables {
     }
 
     #[table(name = "ConfigTable", index = 6)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject)]
     #[graphql(complex)]
     pub struct ConfigRow {
         pub sys_tid: TID,
@@ -790,7 +790,7 @@ pub mod tables {
     }
 
     #[table(name = "UserPendingTable", index = 7)]
-    #[derive(Fracpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
+    #[derive(Pack, Unpack, ToSchema, SimpleObject, Serialize, Deserialize, Debug, Clone)]
     #[graphql(complex)]
     pub struct UserPendingRecord {
         #[graphql(skip)]
@@ -843,7 +843,7 @@ pub mod tables {
     }
 
     #[table(name = "SubAccountTable", index = 8)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject)]
     pub struct SubAccount {
         pub account: AccountNumber,
         pub sub_account: String,
@@ -971,7 +971,7 @@ pub mod tables {
     }
 
     #[table(name = "SubAccountBalanceTable", index = 9)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug, SimpleObject)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug, SimpleObject)]
     #[graphql(complex)]
     pub struct SubAccountBalance {
         #[graphql(skip)]

--- a/rust/psibase/src/services/staged_tx.rs
+++ b/rust/psibase/src/services/staged_tx.rs
@@ -1,18 +1,18 @@
 #[crate::service(name = "staged-tx", dispatch = false, psibase_mod = "crate")]
 #[allow(non_snake_case, unused_variables)]
 mod service {
-    use crate::{AccountNumber, Action, Checksum256, Fracpack, TimePointUSec};
+    use crate::{AccountNumber, Action, Checksum256, Pack, TimePointUSec, Unpack};
     use async_graphql::SimpleObject;
     use fracpack::ToSchema;
     use serde::{Deserialize, Serialize};
 
-    #[derive(Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema, SimpleObject)]
     #[fracpack(fracpack_mod = "fracpack")]
     pub struct ActionList {
         pub actions: Vec<Action>,
     }
 
-    #[derive(Fracpack, Serialize, Deserialize, ToSchema, SimpleObject)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema, SimpleObject)]
     #[fracpack(fracpack_mod = "fracpack")]
     pub struct StagedTx {
         pub id: u32,

--- a/rust/psibase/src/services/virtual_server.rs
+++ b/rust/psibase/src/services/virtual_server.rs
@@ -1,10 +1,10 @@
-use crate::{Fracpack, ToSchema};
+use crate::{Pack, ToSchema, Unpack};
 use async_graphql::SimpleObject;
 use serde::{Deserialize, Serialize};
 
 /// The specs of the virtual server and the specs required by each node
 /// and are used to configure the network specs.
-#[derive(Debug, Clone, Serialize, Deserialize, Fracpack, ToSchema, SimpleObject)]
+#[derive(Debug, Clone, Serialize, Deserialize, Pack, Unpack, ToSchema, SimpleObject)]
 #[fracpack(fracpack_mod = "fracpack")]
 pub struct ServerSpecs {
     /// Amount of bandwidth capacity per second per server
@@ -14,7 +14,7 @@ pub struct ServerSpecs {
 }
 
 /// Variables that are used to derive the specs of the network from the server specs.
-#[derive(Debug, Clone, Serialize, Deserialize, Fracpack, ToSchema, SimpleObject)]
+#[derive(Debug, Clone, Serialize, Deserialize, Pack, Unpack, ToSchema, SimpleObject)]
 #[fracpack(fracpack_mod = "fracpack")]
 pub struct NetworkVariables {
     /// How much faster a node replays blocks compared to the live network
@@ -29,7 +29,7 @@ pub struct NetworkVariables {
 }
 
 /// Parameters related to the automatic management of an account resource buffer.
-#[derive(Debug, Clone, Serialize, Deserialize, Fracpack, ToSchema, SimpleObject)]
+#[derive(Debug, Clone, Serialize, Deserialize, Pack, Unpack, ToSchema, SimpleObject)]
 #[fracpack(fracpack_mod = "fracpack")]
 pub struct BufferConfig {
     /// A threshold (specified in integer percentage values) at or below which the client should

--- a/rust/psibase_macros/psibase-macros-derive/src/lib.rs
+++ b/rust/psibase_macros/psibase-macros-derive/src/lib.rs
@@ -31,12 +31,6 @@ pub fn component_name(_item: TokenStream) -> TokenStream {
     component_name_macro_impl()
 }
 
-// TODO: remove
-#[proc_macro_derive(Fracpack, attributes(fracpack))]
-pub fn derive_fracpack(input: TokenStream) -> TokenStream {
-    fracpack_macro_impl(input, true, true)
-}
-
 #[proc_macro_derive(Pack, attributes(fracpack))]
 pub fn derive_pack(input: TokenStream) -> TokenStream {
     fracpack_macro_impl(input, true, false)

--- a/rust/test_contract_2/src/lib.rs
+++ b/rust/test_contract_2/src/lib.rs
@@ -13,7 +13,7 @@ mod service {
 
     /// Holds an answer to a calculation done by an account `id`
     #[table(name = "AnswerTable", index = 0)]
-    #[derive(Fracpack, Serialize, Deserialize, SimpleObject, ToSchema)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, SimpleObject, ToSchema)]
     pub struct Answer {
         /// The account responsible for the calculation
         #[primary_key]

--- a/rust/test_psibase_macros/services/add-check-init/src/lib.rs
+++ b/rust/test_psibase_macros/services/add-check-init/src/lib.rs
@@ -1,9 +1,9 @@
 #[psibase::service_tables]
 mod service_tables {
-    use psibase::{Fracpack, ToSchema};
+    use psibase::{Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
     #[table(name = "InitTable", index = 0)]
-    #[derive(Serialize, Deserialize, ToSchema, Fracpack, Debug)]
+    #[derive(Serialize, Deserialize, ToSchema, Pack, Unpack, Debug)]
     pub struct InitRow {}
     impl InitRow {
         #[primary_key]

--- a/rust/test_subjective/src/lib.rs
+++ b/rust/test_subjective/src/lib.rs
@@ -1,10 +1,10 @@
 #[psibase::service_tables]
 mod tables {
-    use psibase::{Fracpack, ToSchema};
+    use psibase::{Pack, ToSchema, Unpack};
     use serde::{Deserialize, Serialize};
 
     #[table(name = "SubjectiveTable", index = 0, db = "Subjective")]
-    #[derive(Fracpack, Serialize, Deserialize, ToSchema)]
+    #[derive(Pack, Unpack, Serialize, Deserialize, ToSchema)]
     pub struct SubjectiveRow {
         #[primary_key]
         pub id: i32,


### PR DESCRIPTION
Using macros names that are the same as the traits they define is the standard in rust. Bundling multiple traits in a single attribute doesn't seem to be the norm.